### PR TITLE
Runner dependencies and tweaks

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -141,8 +141,10 @@ jobs:
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
       - name: Install latest helm-3 on runner
         run: |
+          echo "::group::Install git and helm-3"
           sudo zypper -n install --no-recommends git
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          echo "::endgroup::"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -141,7 +141,6 @@ jobs:
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
       - name: Install latest helm-3 on runner
         run: |
-          # helm needs git for plugins
           sudo zypper -n install --no-recommends git
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Checkout
@@ -150,6 +149,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: tests/go.mod
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
       - name: Install preriquisite components
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -140,7 +140,10 @@ jobs:
       - name: Adding /usr/local/bin into PATH
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
       - name: Install latest helm-3 on runner
-        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        run: |
+          # helm needs git for plugins
+          sudo zypper -n install --no-recommends git
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -137,6 +137,10 @@ jobs:
       RANCHER_VERSION: ${{ inputs.rancher_version }}
       TIMEOUT_SCALE: 3
     steps:
+      - name: Adding /usr/local/bin into PATH
+        run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
+      - name: Install latest helm-3 on runner
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go


### PR DESCRIPTION
Testrun: https://github.com/rancher/fleet-e2e/actions/runs/7724603509/job/21057106620

This PR basically:
* adds /usr/local/bin to PATH
* installs helm-3 (cutting-edge) and git as its dependency
* installs node/npm over action (even tho cypress running in container it needs to install cy plugins which are then mounted into container)

There is still a problem with cypress which is trying to access rancher by using domain concatenated from IP in reverse order but the install part seems to be ok now.