### PR TITLE
Temporarily disabling crons until correcct k8s version is passed on a…

### DIFF
--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -18,8 +18,8 @@ on:
         default: v1.26.10+k3s2
         type: string
         required: true
-  schedule:
-    - cron: '0 4 * * *'
+  # schedule:
+    # - cron: '0 4 * * *'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -18,8 +18,8 @@ on:
         default: v1.27.9+k3s1
         type: string
         required: true
-  schedule:
-    - cron: '0 4 * * *'
+  # schedule:
+    # - cron: '0 4 * * *'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -18,8 +18,8 @@ on:
         default: v1.27.9+k3s1
         type: string
         required: true
-  schedule:
-    - cron: '0 4 * * *'
+  # schedule:
+    # - cron: '0 4 * * *'
 
 jobs:
   ui:


### PR DESCRIPTION
Disabling dalily runs at night until correct k8s versions are passed and we do not have [these errors](https://github.com/rancher/fleet-e2e/actions/runs/7809881872/job/21302428259):


CI on 2.8: https://github.com/rancher/fleet-e2e/actions/runs/7814293292

Error log:
```
[FAILED] Unexpected error:
      <*kubectl.CustomError | 0xc0001a82d0>: 
      helm repo add rancher- https://releases.rancher.com/server-charts/:[helm repo add rancher- https://releases.rancher.com/server-charts/] cmd, failed with the following error: WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/gh-runner/.kube/config
      WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/gh-runner/.kube/config
      Error: looks like "https://releases.rancher.com/server-charts/" is not a valid chart repository or cannot be reached: failed to fetch https://releases.rancher.com/server-charts/index.yaml : 404 Not Found
      : exit status 1:WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/gh-runner/.kube/config
      WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/gh-runner/.kube/config
      Error: looks like "https://releases.rancher.com/server-charts/" is not a valid chart repository or cannot be reached: failed to fetch https://releases.rancher.com/server-charts/index.yaml : 404 Not Found
      
      {
          Msg: "helm repo add rancher- https://releases.rancher.com/server-charts/",
make: *** [Makefile:7: e2e-install-rancher] Error 1
          StdOut: "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/gh-runner/.kube/config\nWARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/gh-runner/.kube/config\nError: looks like \"https://releases.rancher.com/server-charts/\" is not a valid chart repository or cannot be reached: failed to fetch https://releases.rancher.com/server-charts/index.yaml : 404 Not Found\n",
          Err: <*errors.withStack | 0xc000013800>{
              error: <*errors.withMessage | 0xc00007e280>{
                  cause: <*exec.ExitError | 0xc00007e220>{
                      ProcessState: {
                          pid: 22856,
                          status: 256,
                          rusage: {
                              Utime: {Sec: 0, Usec: 50075},
                              Stime: {Sec: 0, Usec: 11782},
                              Maxrss: 461[96](https://github.com/rancher/fleet-e2e/actions/runs/7809881872/job/21302428259#step:7:97),
                              Ixrss: 0,
                              Idrss: 0,
                              Isrss: 0,
                              Minflt: 1561,
                              Majflt: 0,
                              Nswap: 0,
                              Inblock: 0,
                              Oublock: 0,
                              Msgsnd: 0,
                              Msgrcv: 0,
                              Nsignals: 0,
                              Nvcsw: 363,
                              Nivcsw: 14,
                          },
                      },
                      Stderr: nil,
                  },
                  msg: "[helm repo add rancher- https://releases.rancher.com/server-charts/] cmd, failed with the following error: WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/gh-runner/.kube/config\nWARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/gh-runner/.kube/config\nError: looks like \"[https://releases.rancher.com/server-charts/\](https://releases.rancher.com/server-charts//)" is not a valid chart repository or cannot be reached: failed to fetch https://releases.rancher.com/server-charts/index.yaml : 404 Not Found\n",
              },
              stack: [0x77b2ad, 0x77afd5, 0x77ffe5, 0x78184e, 0x74bbb5, 0x758bdc, 0x780be5, 0x74187b, 0x753bd8, 0x46e341],
          },
      }
  occurred
```