### PR TITLE
Hardcoded values for runs scheduled by cron

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -21,9 +21,6 @@ on:
         description: PAT token used to add runner
         required: true
     inputs:
-      cert-manager_version:
-        description: Version of cert-manager to use
-        type: string
       cluster_name:
         description: Name of the provisioned cluster
         type: string
@@ -45,7 +42,7 @@ on:
         type: string
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.9+k3s1
+        default: v1.27.10+k3s2
         type: string
         required: true
       zone:
@@ -111,7 +108,6 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     env:
       ARCH: amd64
-      CERT_MANAGER_VERSION: ${{ inputs.cert-manager_version }}
       INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
       K3S_KUBECONFIG_MODE: 0644
       # For Rancher Manager
@@ -170,7 +166,6 @@ jobs:
             /workdir/e2e/unit_tests/user.spec.ts
             /workdir/e2e/unit_tests/menu.spec.ts
             /workdir/e2e/unit_tests/p0_fleet.spec.ts
-          UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
         run: cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure() 

--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
+      # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.26.10+k3s2' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}

--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -4,10 +4,9 @@ name: UI-RM_head_2.7
 on:
   push:
     branches: 
-      -main 
+      - main
     paths-ignore:
       - 'README.md'
-  
   workflow_dispatch:
     inputs:
       destroy_runner:
@@ -24,8 +23,8 @@ on:
         default: v1.26.10+k3s2
         type: string
         required: true
-  # schedule:
-    # - cron: '0 4 * * *'
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   ui:
@@ -37,6 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
+      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
-      rancher_version: ${{ inputs.rancher_version }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.26.10+k3s2' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -4,10 +4,9 @@ name: UI-RM_head_2.8
 on:
   push:
     branches: 
-      -main 
+      - main
     paths-ignore:
       - 'README.md'
-      
   workflow_dispatch:
     inputs:
       destroy_runner:
@@ -21,11 +20,11 @@ on:
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.9+k3s1
+        default: v1.27.10+k3s2
         type: string
         required: true
-  # schedule:
-    # - cron: '0 4 * * *'
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   ui:
@@ -37,6 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
+      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
-      rancher_version: ${{ inputs.rancher_version }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
+      # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
+      # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -4,10 +4,9 @@ name: UI-RM_head_2.9
 on:
   push:
     branches: 
-      -main 
+      - main
     paths-ignore:
       - 'README.md'
-  
   workflow_dispatch:
     inputs:
       destroy_runner:
@@ -21,11 +20,11 @@ on:
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.9+k3s1
+        default: v1.27.10+k3s2
         type: string
         required: true
-  # schedule:
-    # - cron: '0 4 * * *'
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   ui:
@@ -37,6 +36,7 @@ jobs:
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
+      # WARNING, BELOW ARE HARDCODED VALUES FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
-      rancher_version: ${{ inputs.rancher_version }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -35,13 +35,10 @@ const (
 )
 
 var (
-	arch               string
-	CertManagerVersion string
-	clusterName        string
-	clusterNS          string
+	arch string
+	clusterName string
 	rancherHostname    string
 	k8sUpstreamVersion string
-	k8sVersion         string
 	rancherChannel     string
 	rancherHeadVersion string
 	rancherVersion     string
@@ -70,12 +67,9 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	arch = os.Getenv("ARCH")
-	CertManagerVersion = os.Getenv("CERT_MANAGER_VERSION")
 	clusterName = os.Getenv("CLUSTER_NAME")
-	clusterNS = os.Getenv("CLUSTER_NS")
 	rancherHostname = os.Getenv("PUBLIC_DNS")
 	k8sUpstreamVersion = os.Getenv("K8S_UPSTREAM_VERSION")
-	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
 
 	// Extract Rancher Manager channel/version to install

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -10,8 +10,6 @@ npm install
 # Start Cypress tests with docker
 docker run -v $PWD:/workdir -w /workdir                     \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
-    -e K8S_UPSTREAM_VERSION=$K8S_UPSTREAM_VERSION           \
-    -e K8S_VERSION_TO_PROVISION=$K8S_VERSION_TO_PROVISION   \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \


### PR DESCRIPTION
For scheduled jobs we are unable to use `input.<value>` from dispatch block so I extended the `with:` block by hardcoded values.

Initially I used `env:` block but it is also not supported by `uses:` so I used this hardcoded approach for simplicity. We won't know if scheduled runs are using the values until we merge.

More changes:
* cleanup of unneeded values
* bump to latest k8s

Testrun (2.7 manual): https://github.com/rancher/fleet-e2e/actions/runs/7873742581/job/21481808429
