### PR TITLE
Allow rancher version as `2.8.2[-rc3]` or `devel/2.7`

### DIFF
--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.7
+        description: Rancher version as 'devel/2.7' or '2.8.2[-rc3]'
+        default: devel/2.7
         type: string
         required: true
       upstream_cluster_version:
@@ -34,4 +34,4 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.26.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel/2.7' }}

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -18,8 +18,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.8
+        description: Rancher version as 'devel/2.8' or '2.8.2[-rc3]'
+        default: devel/2.8
         type: string
         required: true
       upstream_cluster_version:
@@ -43,4 +43,4 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ contains(fromJSON('["pull_request", "schedule"]'), github.event_name) && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel/2.8' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.9
+        description: Rancher version as 'devel/2.9' or '2.8.2[-rc3]'
+        default: devel/2.9
         type: string
         required: true
       upstream_cluster_version:
@@ -34,4 +34,4 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel/2.9' }}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -35,8 +35,8 @@ const (
 )
 
 var (
-	arch string
-	clusterName string
+	arch               string
+	clusterName        string
 	rancherHostname    string
 	k8sUpstreamVersion string
 	rancherChannel     string
@@ -75,8 +75,12 @@ var _ = BeforeSuite(func() {
 	// Extract Rancher Manager channel/version to install
 	if rancherVersion != "" {
 		s := strings.Split(rancherVersion, "/")
-		rancherChannel = s[0]
-		rancherVersion = s[1]
-		rancherHeadVersion = s[2]
+		// Always use "rancher-latest" as other values make no sense here
+		rancherChannel = "latest"
+		rancherVersion = s[0]
+		rancherHeadVersion = ""
+		if len(s) > 1 {
+			rancherHeadVersion = s[1]
+		}
 	}
 })


### PR DESCRIPTION
When triggering existing head_2.x workflow manually you can specify exact rancher version by:
* `2.8.2`
* `2.8.2-rc3` ... this will append `--version 2.8.2-rc3` and `--devel` to the helm command
* `devel/2.8` ... this will use `--set rancherImageTag=v2.8-head` and `--devel` (the latest helm chart present)

Note: It always use `rancher-latest` https://releases.rancher.com/server-charts/latest helm repo

Note: unfortunately prime is not supported as it uses different URL for the helm repo:
```
https://charts.rancher.com/server-charts/prime
vs
https://releases.rancher.com/server-charts/latest 
```
