### PR TITLE
Fleet qa/update cypress

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -156,8 +156,7 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          # CYPRESS_DOCKER: 'cypress/included:10.9.0'
-          CYPRESS_DOCKER: 'cypress/included:cypress-13.6.4-node-20.11.0-chrome-121.0.6167.85-1-ff-120.0-edge-121.0.2277.83-1'
+          CYPRESS_DOCKER: 'cypress/included:cypress-13.6.4'
           RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:cypress-13.6.4'
+          CYPRESS_DOCKER: 'cypress/included:13.6.4'
           RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -156,7 +156,8 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          # CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          CYPRESS_DOCKER: 'cypress/included:cypress-13.6.4-node-20.11.0-chrome-121.0.6167.85-1-ff-120.0-edge-121.0.2277.83-1'
           RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin

--- a/tests/cypress/cypress.config.ts
+++ b/tests/cypress/cypress.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   viewportWidth: 1314,
   viewportHeight: 954,
   defaultCommandTimeout: 10000,
+  video: true,
+  videoCompression: true,
   reporter: 'cypress-qase-reporter',
   reporterOptions: {
     'apiToken': qaseAPIToken,

--- a/tests/cypress/cypress.config.ts
+++ b/tests/cypress/cypress.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       return require('./plugins/index.ts')(on, config)
     },
-    experimentalSessionAndOrigin: true,
     supportFile: './support/e2e.ts',
     fixturesFolder: './fixtures',
     screenshotsFolder: './screenshots',

--- a/tests/cypress/package.json
+++ b/tests/cypress/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.0.9",
     "cy-verify-downloads": "^0.1.8",
+    "cypress": "^13.6.4",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
@@ -33,7 +34,6 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
-    "cypress": "^13.6.4",
     "eslint-plugin-cypress": "^2.13.0"
   }
 }

--- a/tests/cypress/package.json
+++ b/tests/cypress/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.0.9",
     "cy-verify-downloads": "^0.1.8",
-    "cypress": "^10.0.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
@@ -34,6 +33,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
+    "cypress": "^13.6.4",
     "eslint-plugin-cypress": "^2.13.0"
   }
 }

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -17,28 +17,6 @@ limitations under the License.
 import 'cypress-file-upload';
 
 // Generic commands
-// ////////////////
-
-Cypress.Commands.overwrite('type', (originalFn, subject, text, options = {}) => {
-  options.delay = 100;
-  return originalFn(subject, text, options);
-});
-
-// Add a delay between command without using cy.wait()
-// https://github.com/cypress-io/cypress/issues/249#issuecomment-443021084
-const COMMAND_DELAY = 1000;
-
-for (const command of ['visit', 'click', 'trigger', 'type', 'clear', 'reload', 'contains']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, COMMAND_DELAY);
-    });
-  });
-};
 
 // Fleet commands
 

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -26,9 +26,15 @@ declare global {
 
 // TODO handle redirection errors better?
 // we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here
-Cypress.on('uncaught:exception', (err) => {
+Cypress.on('uncaught:exception', (err, runnable, promise) => {
   // returning false here prevents Cypress from failing the test
   if (err.message.includes('navigation guard')) {
+    return false;
+  }
+  if (err.message.includes('on cross-origin object')) {
+    return false;
+  }
+  if (promise) {
     return false;
   }
 });


### PR DESCRIPTION
# Done
Implements: https://github.com/rancher/fleet-e2e/issues/44

- Updated Cypress to the latest version as of today: `13.6.4`
- Updated Cypress Docker images to: `cypress/included:cypress-13.6.4-node-20.11.0-chrome-121.0.6167.85-1-ff-120.0-edge-121.0.2277.83-1`
- Added uncaught exceptions to avoid crashes
- Added video flags as by default videos are not passed in this version.
- Removed command `overwrite` which is incompatible with cy 13. This has turned into a significant speed increase (see screenshot)
![image (2)](https://github.com/rancher/fleet-e2e/assets/37271841/efa07ce0-5b87-42db-a116-00e8923a505a)

# Tests passing:

- [UI-RM_head_2.7 #37](https://github.com/rancher/fleet-e2e/actions/runs/7927306819)
- [UI-RM_head_2.8 #73](https://github.com/rancher/fleet-e2e/actions/runs/7927130411)
- [UI-RM_head_2.9 #66](https://github.com/rancher/fleet-e2e/actions/runs/7927309676)
- 
![image (3)](https://github.com/rancher/fleet-e2e/assets/37271841/364c931c-d99b-4650-a4b8-fb1132b579c6)

