### PR TITLE
Switch geo zone to US

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -47,8 +47,7 @@ on:
         required: true
       zone:
         description: GCP zone to host the runner
-        # TODO: Modify zone for fleet-e2e
-        default: asia-south2-c
+        default: us-east4-a
         type: string
 
 jobs:


### PR DESCRIPTION
To switch GCP region/zone geographically closer to dockerhub.com, github.com and gitlab.com services, seems they run on US east coast so I picked `us-east4-a`  where no other GCP instances are running.

Testrun: https://github.com/rancher/fleet-e2e/actions/runs/8003631031

It seems it saved 2 minutes in comparison with initial Indian zone. (12.5 min vs 10.5 min)