### PR TITLE
Move CheckPod for fleet call after deploying rancher

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -156,13 +156,15 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 		By("Waiting for fleet", func() {
 			// This is performed after 2 min sleep from previous step
 			// Wait unit the command return something
+			count := 1
 			Eventually(func() error {
 				out, err := kubectl.Run("get", "pods",
 					"--namespace", "cattle-fleet-local-system",
 					"-l", "app=fleet-agent",
-					"-o", "yaml",
+					"-o", "jsonpath={.items[*].spec.containers[*].image}",
 				)
-				GinkgoWriter.Printf("Waiting for fleet-agent, stdout is: %s\n", out)
+				GinkgoWriter.Printf("Waiting for fleet-agent loop %d:\n%s\n", count, out)
+				count++
 				return err
 			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
 

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -148,9 +148,6 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			Eventually(func() error {
 				return rancher.CheckPod(k, checkList)
 			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
-
-			// A bit dirty be better to wait a little here for all to be correctly started
-			// time.Sleep(2 * time.Minute)
 		})
 
 		By("Waiting for fleet", func() {
@@ -168,8 +165,6 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 			checkList := [][]string{
 				{"cattle-fleet-system", "app=fleet-controller"},
-				{"cattle-fleet-system", "app=gitjob"},
-				{"cattle-fleet-local-system", "app=fleet-agent"},
 			}
 			Eventually(func() error {
 				return rancher.CheckPod(k, checkList)

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -154,14 +154,14 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 		})
 
 		By("Waiting for fleet", func() {
-			// Wait unit the command return something on stdout or repeat if there is something on stderr
+			// Wait unit the kubectl command return exit code 0
 			count := 1
 			Eventually(func() error {
-				out, err := kubectl.Run("get", "pods",
-					"--namespace", "cattle-fleet-local-system",
-					"-l", "app=fleet-agent",
+				out, err := kubectl.Run("rollout", "status",
+					"--namespace", "cattle-fleet-system",
+					"deployment", "fleet-controller",
 				)
-				GinkgoWriter.Printf("Waiting for fleet-agent pod, loop %d:\n%s\n", count, out)
+				GinkgoWriter.Printf("Waiting for fleet-controller deployment, loop %d:\n%s\n", count, out)
 				count++
 				return err
 			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -150,12 +150,11 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 
 			// A bit dirty be better to wait a little here for all to be correctly started
-			time.Sleep(2 * time.Minute)
+			// time.Sleep(2 * time.Minute)
 		})
 
 		By("Waiting for fleet", func() {
-			// This is performed after 2 min sleep from previous step
-			// Wait unit the command return something
+			// Wait unit the command return something on stdout or repeat if there is something on stderr
 			count := 1
 			Eventually(func() error {
 				out, err := kubectl.Run("get", "pods",
@@ -163,7 +162,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 					"-l", "app=fleet-agent",
 					"-o", "jsonpath={.items[*].spec.containers[*].image}",
 				)
-				GinkgoWriter.Printf("Waiting for fleet-agent loop %d:\n%s\n", count, out)
+				GinkgoWriter.Printf("Waiting for fleet-agent image name, loop %d:\n%s\n", count, out)
 				count++
 				return err
 			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -160,9 +160,8 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				out, err := kubectl.Run("get", "pods",
 					"--namespace", "cattle-fleet-local-system",
 					"-l", "app=fleet-agent",
-					"-o", "jsonpath={.items[*].spec.containers[*].image}",
 				)
-				GinkgoWriter.Printf("Waiting for fleet-agent image name, loop %d:\n%s\n", count, out)
+				GinkgoWriter.Printf("Waiting for fleet-agent pod, loop %d:\n%s\n", count, out)
 				count++
 				return err
 			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))


### PR DESCRIPTION
At install time of rancher the fleet resources are not even present and the original check is false positive so I removed it together with the implicit 2 min wait after installing Rancher.

The initial fleet check is now done in a new step waiting for `feet-controller` deployment which is only Fleet resource installed even without login to Rancher webUI.

Other Fleet related resources as `gitjob` and `fleet-agent` are installed only after initial login to Rancher over WebUI.

This PR saves ~2minutes of the jobs execution time.

Runs with related output: 
* 2.8-head https://github.com/rancher/fleet-e2e/actions/runs/8046053378/job/21972551727#step:7:93
* 2.7-head https://github.com/rancher/fleet-e2e/actions/runs/8046058140/job/21972563760#step:7:91