### PR TITLE
Implementing Bitbucket private repo test

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -26,6 +26,12 @@ on:
       gitlab_private_pwd:
         description: Gitlab password for private repo tests
         required: false
+      bitbucket_private_user:
+        description: Bitbucket username for private repo tests
+        required: false
+      bitbucket_private_pwd:
+        description: Bitbucket password for private repo tests
+        required: false
       qase_api_token:
         description: Qase API token to use for Qase reporting
         required: true
@@ -237,6 +243,8 @@ jobs:
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}
           GITLAB_PRIVATE_USER: ${{ secrets.gitlab_private_user }}
           GITLAB_PRIVATE_PWD: ${{ secrets.gitlab_private_pwd }}
+          BITBUCKET_PRIVATE_USER: ${{ secrets.bitbucket_private_user }}
+          BITBUCKET_PRIVATE_PWD: ${{ secrets.bitbucket_private_pwd }}
           # Add /workdir/e2e/unit_tests/user.spec.ts again when implementing RBAC tests.
           SPEC: |
             /workdir/e2e/unit_tests/first_login_rancher.spec.ts

--- a/.github/workflows/ui-pr_rm_head_2.8.yaml
+++ b/.github/workflows/ui-pr_rm_head_2.8.yaml
@@ -21,6 +21,8 @@ jobs:
       rancher_password: ${{ secrets.RANCHER_PASSWORD }}
       gitlab_private_user: ${{ secrets.GITLAB_PRIVATE_USER }}
       gitlab_private_pwd: ${{ secrets.GITLAB_PRIVATE_PWD }}
+      bitbucket_private_user: ${{ secrets.BITBUCKET_PRIVATE_USER }}
+      bitbucket_private_pwd: ${{ secrets.BITBUCKET_PRIVATE_PWD }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       test_description: "CI test for PR#${{ github.event.pull_request.number }} with K3s"

--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -34,6 +34,8 @@ jobs:
       rancher_password: ${{ secrets.RANCHER_PASSWORD }}
       gitlab_private_user: ${{ secrets.GITLAB_PRIVATE_USER }}
       gitlab_private_pwd: ${{ secrets.GITLAB_PRIVATE_PWD }}
+      bitbucket_private_user: ${{ secrets.BITBUCKET_PRIVATE_USER }}
+      bitbucket_private_pwd: ${{ secrets.BITBUCKET_PRIVATE_PWD }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -34,6 +34,8 @@ jobs:
       rancher_password: ${{ secrets.RANCHER_PASSWORD }}
       gitlab_private_user: ${{ secrets.GITLAB_PRIVATE_USER }}
       gitlab_private_pwd: ${{ secrets.GITLAB_PRIVATE_PWD }}
+      bitbucket_private_user: ${{ secrets.BITBUCKET_PRIVATE_USER }}
+      bitbucket_private_pwd: ${{ secrets.BITBUCKET_PRIVATE_PWD }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -34,6 +34,8 @@ jobs:
       rancher_password: ${{ secrets.RANCHER_PASSWORD }}
       gitlab_private_user: ${{ secrets.GITLAB_PRIVATE_USER }}
       gitlab_private_pwd: ${{ secrets.GITLAB_PRIVATE_PWD }}
+      bitbucket_private_user: ${{ secrets.BITBUCKET_PRIVATE_USER }}
+      bitbucket_private_pwd: ${{ secrets.BITBUCKET_PRIVATE_PWD }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -81,7 +81,7 @@ describe('Fleet Deployment Test Cases', () => {
       cypressLib.accesMenu('Continuous Delivery');
       cypressLib.accesMenu('Git Repos');
 
-      // Change namespace to fleet-local
+      // Change namespace to fleet-local  
       cy.fleetNamespaceToggle('fleet-local')
 
       // Add Fleet repository and create it
@@ -115,6 +115,70 @@ describe('Fleet Deployment Test Cases', () => {
             
       // Assert repoName exists and its state is 1/1
       cy.verifyTableRow(0, 'Active', repoName);
+      cy.contains(repoName).click()
+      cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
+      cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')
+      cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(' 1 / 1 Resources ready ', { timeout: 30000 }).should('be.visible')
+
+      // Delete created repo
+      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+      cy.verifyTableRow(0, repoName, ' ')
+      cy.deleteAll();
+      cy.contains('No repositories have been added').should('be.visible')
+
+    })
+  );
+
+  qase(7,
+    it('FLEET-7: Test BITBUCKET Private Repository to install NGINX app using HTTP auth', () => {
+      const repoName = "local-cluster-fleet-7"
+      const branch = "main"
+      const path = "test-fleet-main/nginx"
+      const repoUrl = "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test"
+      const gitAuthType = "http"
+      const userOrPublicKey = Cypress.env("bitbucket_private_user");
+      const pwdOrPrivateKey = Cypress.env("bitbucket_private_pwd");
+  
+      // // Click on the Continuous Delivery's icon
+      cypressLib.accesMenu('Continuous Delivery');
+      cypressLib.accesMenu('Git Repos');
+      cy.fleetNamespaceToggle('fleet-local')
+
+      // Add Fleet repository and create it
+      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
+      cy.clickButton('Create');
+      cy.open3dotsMenu( repoName, 'Force Update');
+         
+      ////////////////////////////////////////////////////////////////////////////////
+      // Ugly thing. Meanwhile Fleet state is not guaranteed. We will delete repo and recreate it
+      // Delete once this is ok.
+      
+      // Delete created repo
+      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+      cy.verifyTableRow(0, repoName, ' ')
+      cy.deleteAll();
+      cy.contains('No repositories have been added').should('be.visible')
+
+
+      // Click on the Continuous Delivery's icon
+      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+
+      // Change namespace to fleet-local
+      cy.fleetNamespaceToggle('fleet-local')
+
+      // // Add Fleet repository and create it
+      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
+      cy.clickButton('Create');
+
+      // Force update to better ensure it creates
+      cy.open3dotsMenu( repoName, 'Force Update');
+      
+      //////////////////////////////////////////////////////////////////
+
+      // Assert repoName exists and its state is 1/1
+      cy.verifyTableRow(0, 'Active', repoName);
+      cy.verifyTableRow(0, '1/1', ' ');
+      
       cy.contains(repoName).click()
       cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
       cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -148,37 +148,9 @@ describe('Fleet Deployment Test Cases', () => {
       cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
       cy.clickButton('Create');
       cy.open3dotsMenu( repoName, 'Force Update');
-         
-      ////////////////////////////////////////////////////////////////////////////////
-      // Ugly thing. Meanwhile Fleet state is not guaranteed. We will delete repo and recreate it
-      // Delete once this is ok.
-      
-      // Delete created repo
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.verifyTableRow(0, repoName, ' ')
-      cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
-
-
-      // Click on the Continuous Delivery's icon
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-
-      // Change namespace to fleet-local
-      cy.fleetNamespaceToggle('fleet-local')
-
-      // // Add Fleet repository and create it
-      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
-      cy.clickButton('Create');
-
-      // Force update to better ensure it creates
-      cy.open3dotsMenu( repoName, 'Force Update');
-      
-      //////////////////////////////////////////////////////////////////
 
       // Assert repoName exists and its state is 1/1
-      cy.verifyTableRow(0, 'Active', repoName);
-      cy.verifyTableRow(0, '1/1', ' ');
-      
+      cy.verifyTableRow(0, 'Active', repoName);     
       cy.contains(repoName).click()
       cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
       cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')
@@ -189,7 +161,6 @@ describe('Fleet Deployment Test Cases', () => {
       cy.verifyTableRow(0, repoName, ' ')
       cy.deleteAll();
       cy.contains('No repositories have been added').should('be.visible')
-
     })
   );
 

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -37,6 +37,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.username             = process.env.RANCHER_USER;
   config.env.gitlab_private_user  = process.env.GITLAB_PRIVATE_USER;
   config.env.gitlab_private_pwd   = process.env.GITLAB_PRIVATE_PWD;
-
+  config.env.bitbucket_private_user  = process.env.BITBUCKET_PRIVATE_USER;
+  config.env.bitbucket_private_pwd   = process.env.BITBUCKET_PRIVATE_PWD;
   return config;
 };

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -19,6 +19,8 @@ docker run -v $PWD:/workdir -w /workdir                     \
     -e RANCHER_USER=$RANCHER_USER                           \
     -e GITLAB_PRIVATE_USER=$GITLAB_PRIVATE_USER             \
     -e GITLAB_PRIVATE_PWD=$GITLAB_PRIVATE_PWD               \
+    -e BITBUCKET_PRIVATE_USER=$BITBUCKET_PRIVATE_USER       \
+    -e BITBUCKET_PRIVATE_PWD=$BITBUCKET_PRIVATE_PWD         \
     --add-host host.docker.internal:host-gateway            \
     --ipc=host                                              \
     $CYPRESS_DOCKER                                         \


### PR DESCRIPTION
### Done: 
Implementing part 2 from this task (https://github.com/rancher/fleet-e2e/issues/51) of private repo tests via `http` with Bitbucket.

### Notes:
Successful test with step including repo deletion and reinstalling [here](https://github.com/rancher/fleet-e2e/actions/runs/8068457472/job/22041308858). 
After removing this part, I was expecting the test to fail but it [passed](https://github.com/rancher/fleet-e2e/actions/runs/8068592234) also, so even better.

### Tests 
Passed test as well in 2.7 and 2.9 lanes
[UI-RM_head_2.7 #73](https://github.com/rancher/fleet-e2e/actions/runs/8092662730/job/22113808246#step:9:201)
[UI-RM_head_2.9 #92](https://github.com/rancher/fleet-e2e/actions/runs/8092666963)