### PR TITLE
Adding check for local cluster to be ready after rancher login

### DIFF
--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -27,6 +27,7 @@ describe('First login on Rancher', () => {
         cypressLib.accesMenu('Continuous Delivery');
         cy.contains('Dashboard').should('be.visible')
         cypressLib.accesMenu('Clusters');
+        cy.fleetNamespaceToggle('fleet-local')
         cy.verifyTableRow(0, 'Active', ' ')
         cy.get("td[data-testid='sortable-cell-0-2']", { timeout: 300000 }).should('not.contain', '0')
     })

--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -19,4 +19,15 @@ describe('First login on Rancher', () => {
     it('Log in and accept terms and conditions', () => {
     cypressLib.firstLogin();
     })
+
+    it('Check ready state of local cluster after Rancher login', () => {
+        cy.login();
+        cy.visit('/');
+        cypressLib.burgerMenuToggle();
+        cypressLib.accesMenu('Continuous Delivery');
+        cy.contains('Dashboard').should('be.visible')
+        cypressLib.accesMenu('Clusters');
+        cy.verifyTableRow(0, 'Active', ' ')
+        cy.get("td[data-testid='sortable-cell-0-2']", { timeout: 300000 }).should('not.contain', '0')
+    })
 })


### PR DESCRIPTION
Implementing: https://github.com/rancher/fleet-e2e/issues/63

### Results:
- CI https://github.com/rancher/fleet-e2e/actions/runs/8267264159
In ci seemed ok after 40 seconds:
![image](https://github.com/rancher/fleet-e2e/assets/37271841/24795ccc-b904-404f-9c16-5167d9099bf5)


- Local:
It correctly waits up to 5 minutes for state to be active (in the screenshot it waited 2.8 minutes before giving ok to test)

![2024-03-13_16-23](https://github.com/rancher/fleet-e2e/assets/37271841/cdb98922-0126-4da7-a440-e88d3fb9e631)
![2024-03-13_16-25](https://github.com/rancher/fleet-e2e/assets/37271841/9d350897-9ae8-4167-bb90-4981a8e5e8df)

