### PR TITLE
Fleet qa/65 improve deletion and more

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -44,8 +44,8 @@ describe('Fleet Deployment Test Cases', () => {
   );
 
   qase(6,
-    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', () => {
-      const repoName = "local-cluster-fleet-6"
+    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 }, () => {
+      const repoName = "default-cluster-fleet-6"
       const branch = "main"
       const path = "test-fleet-main/nginx"
       const repoUrl = "https://gitlab.com/qa1613907/gitlab-test-fleet.git"
@@ -64,7 +64,7 @@ describe('Fleet Deployment Test Cases', () => {
 
   qase(7,
     it('FLEET-7: Test BITBUCKET Private Repository to install NGINX app using HTTP auth', () => {
-      const repoName = "local-cluster-fleet-7"
+      const repoName = "default-cluster-fleet-7"
       const branch = "main"
       const path = "test-fleet-main/nginx"
       const repoUrl = "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test"
@@ -83,7 +83,7 @@ describe('Fleet Deployment Test Cases', () => {
 
   qase(8,
     it('FLEET-8: Test GITHUB Private Repository to install NGINX app using HTTP auth', () => {
-      const repoName = "local-cluster-fleet-8"
+      const repoName = "default-cluster-fleet-8"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "https://github.com/mmartinsuse/test-fleet"

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -44,7 +44,7 @@ describe('Fleet Deployment Test Cases', () => {
   );
 
   qase(6,
-    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 }, () => {
+    it.only('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 }, () => {
       const repoName = "default-cluster-fleet-6"
       const branch = "main"
       const path = "test-fleet-main/nginx"
@@ -53,12 +53,15 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("gitlab_private_user");
       const pwdOrPrivateKey = Cypress.env("gitlab_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-default')
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
-      cy.clickButton('Create');
-      cy.open3dotsMenu(repoName, 'Force Update');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-      cy.deleteAllFleetRepos();
+      // Looping 2 times due to error on 2.8-head
+      for (let i = 0; i < 2; i++) {
+        cy.fleetNamespaceToggle('fleet-default')
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
+        cy.clickButton('Create');
+        cy.open3dotsMenu(repoName, 'Force Update');
+        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+        cy.deleteAllFleetRepos();
+      }
     })
   );
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
   cy.visit('/');
   cypressLib.burgerMenuToggle();
   cypressLib.checkNavIcon('cluster-management').should('exist');
+  cy.deleteAllFleetRepos();
 });
 
 
@@ -37,13 +38,9 @@ describe('Fleet Deployment Test Cases', () => {
       // use repoUrl = 'https://github.com/rancher/fleet-examples', path = 'simple-chart'
       // and check in Deployments that resources 'frontend', 'redis-master', 'redis-slave' are ok
 
-      // Click on the Continuous Delivery's icon
-      cypressLib.accesMenu('Continuous Delivery');
-      cypressLib.accesMenu('Git Repos');
-
       // Change namespace to fleet-local
-      cy.contains('fleet-').click();
-      cy.contains('fleet-local').should('be.visible').click();
+      cy.fleetNamespaceToggle('fleet-local')
+
 
       // Add Fleet repository and create it
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
@@ -63,7 +60,6 @@ describe('Fleet Deployment Test Cases', () => {
 
       // Delete all git repos
       cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
     })
   );
 
@@ -77,10 +73,6 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("gitlab_private_user");
       const pwdOrPrivateKey = Cypress.env("gitlab_private_pwd");
   
-      // // Click on the Continuous Delivery's icon
-      cypressLib.accesMenu('Continuous Delivery');
-      cypressLib.accesMenu('Git Repos');
-
       // Change namespace to fleet-local  
       cy.fleetNamespaceToggle('fleet-local')
 
@@ -124,7 +116,6 @@ describe('Fleet Deployment Test Cases', () => {
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.verifyTableRow(0, repoName, ' ')
       cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
 
     })
   );
@@ -139,9 +130,7 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("bitbucket_private_user");
       const pwdOrPrivateKey = Cypress.env("bitbucket_private_pwd");
   
-      // // Click on the Continuous Delivery's icon
-      cypressLib.accesMenu('Continuous Delivery');
-      cypressLib.accesMenu('Git Repos');
+      // Click on the Continuous Delivery's icon
       cy.fleetNamespaceToggle('fleet-local')
 
       // Add Fleet repository and create it
@@ -160,7 +149,7 @@ describe('Fleet Deployment Test Cases', () => {
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.verifyTableRow(0, repoName, ' ')
       cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
+
     })
   );
 
@@ -175,8 +164,6 @@ describe('Fleet Deployment Test Cases', () => {
       const pwdOrPrivateKey = Cypress.env("gh_private_pwd");
   
       // Click on the Continuous Delivery's icon
-      cypressLib.accesMenu('Continuous Delivery');
-      cypressLib.accesMenu('Git Repos');
       cy.fleetNamespaceToggle('fleet-local')
 
       // Add Fleet repository and create it
@@ -195,7 +182,6 @@ describe('Fleet Deployment Test Cases', () => {
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.verifyTableRow(0, repoName, ' ')
       cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
     })
   );
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -44,7 +44,7 @@ describe('Fleet Deployment Test Cases', () => {
   );
 
   qase(6,
-    it.only('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 }, () => {
+    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 }, () => {
       const repoName = "default-cluster-fleet-6"
       const branch = "main"
       const path = "test-fleet-main/nginx"

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -19,8 +19,6 @@ import { qase } from 'cypress-qase-reporter/dist/mocha';
 beforeEach(() => {
   cy.login();
   cy.visit('/');
-  cypressLib.burgerMenuToggle();
-  cypressLib.checkNavIcon('cluster-management').should('exist');
   cy.deleteAllFleetRepos();
 });
 
@@ -41,25 +39,15 @@ describe('Fleet Deployment Test Cases', () => {
       // Change namespace to fleet-local
       cy.fleetNamespaceToggle('fleet-local')
 
-
       // Add Fleet repository and create it
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
 
       // Assert repoName exists and its state is 1/1
-      cy.verifyTableRow(0, repoName, ' ');
-      cy.open3dotsMenu( repoName, 'Force Update');
-      cy.verifyTableRow(0, '1/1', ' ');
-      cy.contains("already exists").should('not.exist');
-
-      // Delete created repo
-      cypressLib.burgerMenuToggle();
-      cypressLib.accesMenu('Continuous Delivery');
-      cypressLib.accesMenu('Git Repos');
-      cy.verifyTableRow(0, repoName, ' ');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
 
       // Delete all git repos
-      cy.deleteAll();
+      cy.deleteAllFleetRepos();
     })
   );
 
@@ -79,21 +67,11 @@ describe('Fleet Deployment Test Cases', () => {
       // Add Fleet repository and create it
       cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
       cy.clickButton('Create');
-
       cy.open3dotsMenu( repoName, 'Force Update');
             
       // Ugly thing. Meanwhile Fleet state is not guaranteed. We will delete repo and recreate it
       // Delete once this is ok.
-      
-      // Delete created repo
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.verifyTableRow(0, repoName, ' ')
-      cy.deleteAll();
-      cy.contains('No repositories have been added').should('be.visible')
-
-
-      // Click on the Continuous Delivery's icon
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+      cy.deleteAllFleetRepos();
 
       // Change namespace to fleet-local
       cy.fleetNamespaceToggle('fleet-local')
@@ -106,16 +84,10 @@ describe('Fleet Deployment Test Cases', () => {
       cy.open3dotsMenu( repoName, 'Force Update');
             
       // Assert repoName exists and its state is 1/1
-      cy.verifyTableRow(0, 'Active', repoName);
-      cy.contains(repoName).click()
-      cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(' 1 / 1 Resources ready ', { timeout: 30000 }).should('be.visible')
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
 
-      // Delete created repo
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.verifyTableRow(0, repoName, ' ')
-      cy.deleteAll();
+      // Delete all git repos
+      cy.deleteAllFleetRepos();
 
     })
   );
@@ -139,16 +111,9 @@ describe('Fleet Deployment Test Cases', () => {
       cy.open3dotsMenu( repoName, 'Force Update');
 
       // Assert repoName exists and its state is 1/1
-      cy.verifyTableRow(0, 'Active', repoName);     
-      cy.contains(repoName).click()
-      cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(' 1 / 1 Resources ready ', { timeout: 30000 }).should('be.visible')
-
-      // Delete created repo
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.verifyTableRow(0, repoName, ' ')
-      cy.deleteAll();
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+      // Delete all git repos
+      cy.deleteAllFleetRepos();
 
     })
   );
@@ -172,16 +137,10 @@ describe('Fleet Deployment Test Cases', () => {
       cy.open3dotsMenu( repoName, 'Force Update');
 
       // Assert repoName exists and its state is 1/1
-      cy.verifyTableRow(0, 'Active', repoName);     
-      cy.contains(repoName).click()
-      cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(' 1 / 1 Bundles ready ', { timeout: 30000 }).should('be.visible')
-      cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(' 1 / 1 Resources ready ', { timeout: 30000 }).should('be.visible')
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
 
-      // Delete created repo
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.verifyTableRow(0, repoName, ' ')
-      cy.deleteAll();
+      // Delete all git repos
+      cy.deleteAllFleetRepos();
     })
   );
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -13,7 +13,6 @@ limitations under the License.
 */
 
 import '~/support/commands';
-import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 beforeEach(() => {
@@ -31,22 +30,15 @@ describe('Fleet Deployment Test Cases', () => {
       const branch = "master"
       const path = "simple-chart"
       const repoUrl = "https://github.com/rancher/fleet-test-data/"
-      
+
       // TODO: When this issue is resolved https://github.com/rancher/fleet/issues/2128
       // use repoUrl = 'https://github.com/rancher/fleet-examples', path = 'simple-chart'
       // and check in Deployments that resources 'frontend', 'redis-master', 'redis-slave' are ok
 
-      // Change namespace to fleet-local
       cy.fleetNamespaceToggle('fleet-local')
-
-      // Add Fleet repository and create it
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
-
-      // Assert repoName exists and its state is 1/1
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-
-      // Delete all git repos
       cy.deleteAllFleetRepos();
     })
   );
@@ -60,35 +52,13 @@ describe('Fleet Deployment Test Cases', () => {
       const gitAuthType = "http"
       const userOrPublicKey = Cypress.env("gitlab_private_user");
       const pwdOrPrivateKey = Cypress.env("gitlab_private_pwd");
-  
-      // Change namespace to fleet-local  
+
       cy.fleetNamespaceToggle('fleet-local')
-
-      // Add Fleet repository and create it
-      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
-      cy.open3dotsMenu( repoName, 'Force Update');
-            
-      // Ugly thing. Meanwhile Fleet state is not guaranteed. We will delete repo and recreate it
-      // Delete once this is ok.
-      cy.deleteAllFleetRepos();
-
-      // Change namespace to fleet-local
-      cy.fleetNamespaceToggle('fleet-local')
-
-      // // Add Fleet repository and create it
-      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
-      cy.clickButton('Create');
-
-      // Force update to better ensure it creates
-      cy.open3dotsMenu( repoName, 'Force Update');
-            
-      // Assert repoName exists and its state is 1/1
+      cy.open3dotsMenu(repoName, 'Force Update');
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-
-      // Delete all git repos
       cy.deleteAllFleetRepos();
-
     })
   );
 
@@ -101,20 +71,13 @@ describe('Fleet Deployment Test Cases', () => {
       const gitAuthType = "http"
       const userOrPublicKey = Cypress.env("bitbucket_private_user");
       const pwdOrPrivateKey = Cypress.env("bitbucket_private_pwd");
-  
-      // Click on the Continuous Delivery's icon
+
       cy.fleetNamespaceToggle('fleet-local')
-
-      // Add Fleet repository and create it
-      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
-      cy.open3dotsMenu( repoName, 'Force Update');
-
-      // Assert repoName exists and its state is 1/1
+      cy.open3dotsMenu(repoName, 'Force Update');
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-      // Delete all git repos
       cy.deleteAllFleetRepos();
-
     })
   );
 
@@ -127,24 +90,16 @@ describe('Fleet Deployment Test Cases', () => {
       const gitAuthType = "http"
       const userOrPublicKey = Cypress.env("gh_private_user");
       const pwdOrPrivateKey = Cypress.env("gh_private_pwd");
-  
-      // Click on the Continuous Delivery's icon
+
       cy.fleetNamespaceToggle('fleet-local')
-
-      // Add Fleet repository and create it
-      cy.addFleetGitRepo( {repoName, repoUrl, branch, path,  gitAuthType, userOrPublicKey, pwdOrPrivateKey} );
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
-      cy.open3dotsMenu( repoName, 'Force Update');
-
-      // Assert repoName exists and its state is 1/1
+      cy.open3dotsMenu(repoName, 'Force Update');
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-
-      // Delete all git repos
       cy.deleteAllFleetRepos();
     })
   );
 
 
-  
 });
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -53,7 +53,7 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("gitlab_private_user");
       const pwdOrPrivateKey = Cypress.env("gitlab_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -72,7 +72,7 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("bitbucket_private_user");
       const pwdOrPrivateKey = Cypress.env("bitbucket_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -91,7 +91,7 @@ describe('Fleet Deployment Test Cases', () => {
       const userOrPublicKey = Cypress.env("gh_private_user");
       const pwdOrPrivateKey = Cypress.env("gh_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -35,9 +35,8 @@ Cypress.Commands.add('gitRepoAuth', (gitAuthType, userOrPublicKey, pwdOrPrivateK
   if (gitAuthType === 'http') {
     // Not using cyLib.typeValue because values are visible in runner 
     // Currently { log: false } not set there, so needed to adapt function here.
-    // cy.get('input[data-testid="auth-secret-basic-public-key"]').focus().clear().type(userOrPublicKey, { log: false });
-    cy.get('input[data-testid="auth-secret-basic-private-key"]').focus().clear().type(pwdOrPrivateKey, { log: false });
-    cy.get('input[data-testid="auth-secret-basic-public-key"]').focus().clear().type(userOrPublicKey, { log: false });
+    cy.get('.labeled-input.create').contains('label', 'Username').siblings().clear().type(userOrPublicKey, { log: false });
+    cy.get('.labeled-input.create').contains('label', 'Password').siblings().clear().type(pwdOrPrivateKey, { log: false });
   }
   else if (gitAuthType === 'ssh') {
     // Ugly implementation needed because 'typeValue' does not work here

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -33,10 +33,8 @@ Cypress.Commands.add('gitRepoAuth', (gitAuthType, userOrPublicKey, pwdOrPrivateK
   cy.get('div.option-kind-highlighted', { timeout: 15000 }).contains(gitAuthType, { matchCase: false }).should('be.visible').click();
 
   if (gitAuthType === 'http') {
-    // Not using cyLib.typeValue because values are visible in runner 
-    // Currently { log: false } not set there, so needed to adapt function here.
-    cy.get('.labeled-input.create').contains('label', 'Username').siblings().clear().type(userOrPublicKey, { log: false });
-    cy.get('.labeled-input.create').contains('label', 'Password').siblings().clear().type(pwdOrPrivateKey, { log: false });
+    cy.typeValue('Username', userOrPublicKey, false,  false );
+    cy.typeValue('Password', pwdOrPrivateKey, false,  false );
   }
   else if (gitAuthType === 'ssh') {
     // Ugly implementation needed because 'typeValue' does not work here

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -33,13 +33,16 @@ Cypress.Commands.add('gitRepoAuth', (gitAuthType, userOrPublicKey, pwdOrPrivateK
   cy.get('div.option-kind-highlighted', { timeout: 15000 }).contains(gitAuthType, { matchCase: false }).should('be.visible').click();
 
   if (gitAuthType === 'http') {
-    cy.typeValue('Username', userOrPublicKey);
-    cy.typeValue('Password', pwdOrPrivateKey);
+    // Not using cyLib.typeValue because values are visible in runner 
+    // Currently { log: false } not set there, so needed to adapt function here.
+    // cy.get('input[data-testid="auth-secret-basic-public-key"]').focus().clear().type(userOrPublicKey, { log: false });
+    cy.get('input[data-testid="auth-secret-basic-private-key"]').focus().clear().type(pwdOrPrivateKey, { log: false });
+    cy.get('input[data-testid="auth-secret-basic-public-key"]').focus().clear().type(userOrPublicKey, { log: false });
   }
   else if (gitAuthType === 'ssh') {
     // Ugly implementation needed because 'typeValue' does not work here
-    cy.get('textarea.no-resize.no-ease').eq(0).focus().clear().type(userOrPublicKey);
-    cy.get('textarea.no-resize.no-ease').eq(1).focus().clear().type(pwdOrPrivateKey);
+    cy.get('textarea.no-resize.no-ease').eq(0).focus().clear().type(userOrPublicKey, { log: false });
+    cy.get('textarea.no-resize.no-ease').eq(1).focus().clear().type(pwdOrPrivateKey, { log: false });
   }
 });
 
@@ -59,6 +62,7 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, gitA
     cy.gitRepoAuth(gitAuthType, userOrPublicKey, pwdOrPrivateKey);
   }
   cy.clickButton('Next');
+  cy.get('button.btn').contains('Previous').should('be.visible');
 })
 
 // 3 dots menu selection

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -125,7 +125,18 @@ Cypress.Commands.add('deleteAll', () => {
     if ($body.text().includes('Delete')) {
       cy.get('[width="30"] > .checkbox-outer-container.check').click();
       cy.get('.btn').contains('Delete').click({ctrlKey: true});
-      cy.get('.btn').contains('Delete').should('not.exist');
+      cy.get('.btn', { timeout: 20000 }).contains('Delete').should('not.exist');
+      cy.contains('No repositories have been added', { timeout: 20000 }).should('be.visible')
     };
   });
+});
+
+// Command to delete all repos pressent in Fleet local and default
+Cypress.Commands.add('deleteAllFleetRepos', () => {
+  cypressLib.accesMenu('Continuous Delivery');
+  cypressLib.accesMenu('Git Repos');
+  cy.fleetNamespaceToggle('fleet-local')
+  cy.deleteAll();
+  cy.fleetNamespaceToggle('fleet-default')
+  cy.deleteAll();
 });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -130,10 +130,23 @@ Cypress.Commands.add('deleteAll', () => {
 
 // Command to delete all repos pressent in Fleet local and default
 Cypress.Commands.add('deleteAllFleetRepos', () => {
-  cypressLib.accesMenu('Continuous Delivery');
-  cypressLib.accesMenu('Git Repos');
+  cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
   cy.fleetNamespaceToggle('fleet-local')
   cy.deleteAll();
   cy.fleetNamespaceToggle('fleet-default')
   cy.deleteAll();
+});
+
+// Check Git repo deployment status
+Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
+  cy.verifyTableRow(0, 'Active', repoName);
+  cy.contains(repoName).click()
+  cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
+  cy.log(`Checking ${bundles} Bundles and ${resources} Resources`)
+  if (bundles) {
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 30000 }).should('be.visible')
+  }
+  if (resources) {
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 30000 }).should('be.visible')
+  }
 });

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -30,6 +30,7 @@ declare global {
       accesMenuSelection(firstAccessMenu: string, secondAccessMenu?: string): Chainable<Element>;
       deleteAll(): Chainable<Element>;
       deleteAllFleetRepos(): Chainable<Element>;
+      checkGitRepoStatus(repoName: string, bundles?: string, resources?: string): Chainable<Element>;
     }
   }
 }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -29,6 +29,7 @@ declare global {
       nameSpaceMenuToggle(namespaceName: string): Chainable<Element>;
       accesMenuSelection(firstAccessMenu: string, secondAccessMenu?: string): Chainable<Element>;
       deleteAll(): Chainable<Element>;
+      deleteAllFleetRepos(): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
Implementation of https://github.com/rancher/fleet-e2e/issues/65

# Done:
- Created delete function for leftovers of Gitrepos either in default or local
- Corrected function that left logs of unwanted info on runners
- Added extra check of the element in the creating repo process to help minimize duplication of repos after clicking `Create` button
- Refactor delete function to include locator of check deleted repo page
- Others refactors
- Added resource check function
- Major refactor on tests for better reading

# Test done
https://github.com/rancher/fleet-e2e/actions/runs/8328879488/job/22789937537