### PR TITLE
Get rid of cy zombies processes in docker

### DIFF
--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -8,7 +8,7 @@ pushd cypress
 npm install
 
 # Start Cypress tests with docker
-docker run -v $PWD:/workdir -w /workdir                     \
+docker run --init -v $PWD:/workdir -w /workdir              \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
     -e QASE_API_TOKEN=$QASE_API_TOKEN                       \
     -e QASE_REPORT=$QASE_REPORT                             \


### PR DESCRIPTION
This solves problem with abandoned Cypress processes inside its docker container. It is probably harmless but it might prevent docker container to spawn new processes in more complex scenarios.

Basically `docker run --init` will spawn special PID 1 inside docker which is able to handle terminated process correctly.

Before fix on runner.
![image](https://github.com/rancher/fleet-e2e/assets/12828077/d0b7b572-a02f-492b-8796-b14a17ede5bf)

There is no sign of defunct processes while using this PR.