### PR TITLE
Always expose k3d on the same port 64430

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -312,7 +312,16 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 			// TODO: Wait for K3d resources instead od delay
 			// Delay few seconds before checking
-			time.Sleep(tools.SetTimeout(20 * time.Second))
+			// time.Sleep(tools.SetTimeout(20 * time.Second))
+
+			count := 1
+			Eventually(func() string {
+				k3dApiCheckCmd := exec.Command("curl", "-v", "-k", "https://127.0.0.1:64430")
+				out, _ := k3dApiCheckCmd.CombinedOutput()
+				GinkgoWriter.Printf("K3d API response %d:\n%s\n", count, out)
+				count++
+				return string(out)
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(ContainSubstring("\"message\": \"Unauthorized\""))
 
 			// Run the registration insecure command on downstream cluster
 			regCmd := exec.Command("bash", "-c", insecureRegistrationCommand)

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -299,6 +299,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				"--agents", "0",
 				"--servers", "1",
 				"--image", "rancher/k3s:" + k8sDownstreamVersion,
+				"--api-port", "0.0.0.0:64430",
 			}
 
 			createCmd := exec.Command("k3d", "cluster", "create", "downstream"+"1")


### PR DESCRIPTION
Attempt to to resolve following CI issue by using higher port for downstream k3d cluster and its k8s API endpoint exposed over docker.  I see the problem pretty often like in 1 of 10 CI runs.

It should be safe to merge as it shouldn't have any side effect until we implement support in CI for more downstream clusters.

![pasted_image](https://github.com/rancher/fleet-e2e/assets/12828077/a9fcfcdc-3615-4e3b-9499-3dfb7a80de95)


UPDATE:
* k3d k8s API endpoint always exposed on port 64430
* added curl check by reaching this endpoint and expecting 'Unauthorized' string
* waiting for Ready state of k3d nodes and all CRDs