### PR TITLE
Fleet qa/78 refactor tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_a_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_a_fleet.spec.ts
@@ -1,0 +1,75 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '~/support/commands';
+import '~/support/test_details';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+beforeEach(() => {
+  cy.login();
+  cy.visit('/');
+  cy.deleteAllFleetRepos();
+});
+
+
+Cypress.config();
+
+describe('Test Fleet deployment on PUBLIC repos', { tags: '@p3' }, () => {
+  qase(62,
+    it.skip('FLEET-62: Deploy application to local cluster', { tags: '@fleet-62' }, () => {
+      const repoName = "local-cluster-fleet-62"
+      const branch = "master"
+      const path = "simple"
+      const repoUrl = "https://github.com/rancher/fleet-examples"
+
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6')
+      cy.verifyTableRow(1, 'Service', 'frontend');
+      cy.verifyTableRow(3, 'Service', 'redis-master');
+      cy.verifyTableRow(5, 'Service', 'redis-slave');
+      cy.deleteAllFleetRepos();
+    })
+  );
+})
+
+describe('Fleet Deployment Test Cases on PRIVATE repos',  { tags: '@p0' }, () => {
+
+  qase(6,
+    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 , tags: '@fleet-6' }, () => {
+      cy.runPrivateRepoTests(6);
+    })
+  );
+
+  qase(7,
+    it('FLEET-7: Test BITBUCKET Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-7' }, () => {
+      cy.runPrivateRepoTests(7);
+    })
+  );
+
+  qase(8,
+    it('FLEET-8: Test GITHUB Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-8' }, () => {
+      cy.runPrivateRepoTests(8);
+    })
+  );
+
+  qase(98,
+    it('FLEET-98: Test AZURE DEVOPS Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-98' }, () => {
+      cy.runPrivateRepoTests(98);
+    })
+  );
+
+});
+

--- a/tests/cypress/e2e/unit_tests/p0_b_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_b_fleet.spec.ts
@@ -1,0 +1,108 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '~/support/commands';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+beforeEach(() => {
+  cy.login();
+  cy.visit('/');
+  cy.deleteAllFleetRepos();
+});
+
+
+Cypress.config();
+
+describe('Test Fleet deployment on PUBLIC repos', { tags: '@p3' }, () => {
+  qase(62,
+    it.skip('FLEET-62: Deploy application to local cluster', { tags: '@fleet-62' }, () => {
+      const repoName = "local-cluster-fleet-62"
+      const branch = "master"
+      const path = "simple"
+      const repoUrl = "https://github.com/rancher/fleet-examples"
+
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6')
+      cy.verifyTableRow(1, 'Service', 'frontend');
+      cy.verifyTableRow(3, 'Service', 'redis-master');
+      cy.verifyTableRow(5, 'Service', 'redis-slave');
+      cy.deleteAllFleetRepos();
+    })
+  );
+})
+
+describe('Fleet Deployment Test Cases on PRIVATE repos',  { tags: '@p0' }, () => {
+  const branch = "main"
+  const gitAuthType = "http"
+  const repoUrlGitlab = "https://gitlab.com/qa1613907/gitlab-test-fleet.git"
+  const repoUrlBitbucket = "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test"
+  const repoUrlGithub = "https://github.com/mmartinsuse/test-fleet"
+  const repoUrlAzure = "https://dev.azure.com/mamartin0216/_git/mamartin"
+  const pathGitlab = "test-fleet-main/nginx"
+  const pathBitbucket = "test-fleet-main/nginx"
+  const pathGithub = "nginx"
+  const pathAzure = "nginx-helm"
+  const userOrPublicKeyGitlab = Cypress.env("gitlab_private_user")
+  const pwdOrPrivateKeyGitlab = Cypress.env("gitlab_private_pwd")
+  const userOrPublicKeyBitbucket = Cypress.env("bitbucket_private_user")
+  const pwdOrPrivateKeyBitbucket = Cypress.env("bitbucket_private_pwd")
+  const userOrPublicKeyGithub = Cypress.env("gh_private_user")
+  const pwdOrPrivateKeyGithub = Cypress.env("gh_private_pwd")
+  const userOrPublicKeyAzure = Cypress.env("azure_private_user")
+  const pwdOrPrivateKeyAzure = Cypress.env("azure_private_pwd")
+  
+  const repoTestData: testData[] = [
+  { qase_id: 6,
+    testname: 'Test "local-cluster-fleet-6" PRIVATE repository to install "NGINX" app using "GITLAB" auth'},
+  { qase_id: 7,
+    testname: 'Test "local-cluster-fleet-7" PRIVATE repository to install "NGINX" app using "BITBUCKET" auth'},
+  { qase_id: 8,
+    testname: 'Test "local-cluster-fleet-8" PRIVATE repository to install "NGINX" app using "GITHUB" auth'},
+  { qase_id: 98,
+    testname: 'Test "local-cluster-fleet-98" PRIVATE repository to install "NGINX" app using "AZURE" auth'}, 
+  ]
+  repoTestData.forEach(({ qase_id, testname,  repoName }) => {
+
+    qase(qase_id,
+      it(`FLEET-${qase_id}: ${testname}`, { retries: 3, tags: `@fleet-${qase_id}` }, () => {
+        cy.fleetNamespaceToggle('fleet-local')
+        switch (qase_id){
+          case 6:
+            cy.addFleetGitRepo({ repoName: `local-cluster-fleet-${qase_id}`, repoUrl: repoUrlGitlab, branch, path: pathGitlab, gitAuthType, userOrPublicKey: userOrPublicKeyGitlab, pwdOrPrivateKey: pwdOrPrivateKeyGitlab });
+            break;
+          case 7:
+            cy.addFleetGitRepo({ repoName: `local-cluster-fleet-${qase_id}`, repoUrl: repoUrlBitbucket, branch, path: pathBitbucket, gitAuthType, userOrPublicKey: userOrPublicKeyBitbucket, pwdOrPrivateKey: pwdOrPrivateKeyBitbucket });
+            break;
+          case 8:
+            cy.addFleetGitRepo({ repoName: `local-cluster-fleet-${qase_id}`, repoUrl: repoUrlGithub, branch, path: pathGithub, gitAuthType, userOrPublicKey: userOrPublicKeyGithub, pwdOrPrivateKey: pwdOrPrivateKeyGithub });
+            break;
+          case 98:
+            cy.addFleetGitRepo({ repoName: `local-cluster-fleet-${qase_id}`, repoUrl: repoUrlAzure, branch, path: pathAzure, gitAuthType, userOrPublicKey: userOrPublicKeyAzure, pwdOrPrivateKey: pwdOrPrivateKeyAzure });
+            break;
+        }
+        cy.clickButton('Create');
+        cy.open3dotsMenu(repoName, 'Force Update');
+        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+        cy.deleteAllFleetRepos();
+      })
+    );
+  })
+
+
+
+});
+
+

--- a/tests/cypress/e2e/unit_tests/p0_c_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_c_fleet.spec.ts
@@ -1,0 +1,87 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '~/support/commands';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+beforeEach(() => {
+  cy.login();
+  cy.visit('/');
+  cy.deleteAllFleetRepos();
+});
+
+
+Cypress.config();
+describe('Test Fleet deployment on PUBLIC repos', { tags: '@p3' }, () => {
+  qase(62,
+    it('FLEET-62: Deploy application to local cluster', { tags: '@fleet-62' }, () => {
+      const repoName = "local-cluster-fleet-62"
+      const branch = "master"
+      const path = "simple"
+      const repoUrl = "https://github.com/rancher/fleet-examples"
+
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6')
+      cy.verifyTableRow(1, 'Service', 'frontend');
+      cy.verifyTableRow(3, 'Service', 'redis-master');
+      cy.verifyTableRow(5, 'Service', 'redis-slave');
+      cy.deleteAllFleetRepos();
+    })
+  );
+})
+
+describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p3' }, () => {
+  const branch = "main"
+  const gitAuthType = "http"
+  const repoTestData: testData[] = [
+    { qase_id: 6, test: "GITLAB", repoName: "local-cluster-fleet-6", repoUrl: "https://gitlab.com/qa1613907/gitlab-test-fleet.git",
+      path: "test-fleet-main/nginx", userOrPublicKey: Cypress.env("gitlab_private_user"), pwdOrPrivateKey: Cypress.env("gitlab_private_pwd") },
+    { qase_id: 7, test: "BITBUCKET", repoName: "local-cluster-fleet-7", repoUrl: "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test",
+      path: "test-fleet-main/nginx", userOrPublicKey: Cypress.env("bitbucket_private_user"), pwdOrPrivateKey: Cypress.env("bitbucket_private_pwd") },
+    { qase_id: 8, test: "GITHUB", repoName: "local-cluster-fleet-8", repoUrl: "https://github.com/mmartinsuse/test-fleet",
+      path: "nginx", userOrPublicKey: Cypress.env("gh_private_user"), pwdOrPrivateKey: Cypress.env("gh_private_pwd") },
+    { qase_id: 98, test: "AZURE", repoName: "local-cluster-fleet-98", repoUrl: "https://dev.azure.com/mamartin0216/_git/mamartin",
+      path: "nginx-helm", userOrPublicKey: Cypress.env("azure_private_user"), pwdOrPrivateKey: Cypress.env("azure_private_pwd") },
+  ]
+
+  repoTestData.forEach(({ qase_id, test, path, repoName, repoUrl, userOrPublicKey, pwdOrPrivateKey }) => {
+    qase(qase_id,
+      it(`FLEET-${qase_id}: Test "${test}" PRIVATE repository to install "NGINX" app using "HTTP" auth`, { retries: 3, tags: `@fleet-${qase_id}` }, () => {
+        if (test === "GITLAB") {
+          // Running 2 times due to error on 2.8-head
+          for (let i = 0; i < 2; i++) {
+            cy.fleetNamespaceToggle('fleet-local')
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
+            cy.clickButton('Create');
+            cy.open3dotsMenu(repoName, 'Force Update');
+            cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+            cy.deleteAllFleetRepos();
+          }
+        }
+        // Just run test once
+        else {
+          cy.fleetNamespaceToggle('fleet-local')
+          cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
+          cy.clickButton('Create');
+          cy.open3dotsMenu(repoName, 'Force Update');
+          cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+          cy.deleteAllFleetRepos();
+        }
+      })
+    );
+  })
+});
+

--- a/tests/cypress/e2e/unit_tests/p0_d_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_d_fleet.spec.ts
@@ -1,0 +1,120 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '~/support/commands';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+beforeEach(() => {
+  cy.login();
+  cy.visit('/');
+  cy.deleteAllFleetRepos();
+});
+
+Cypress.config();
+
+describe('Test Fleet deployment on PUBLIC repos', { tags: '@p3' }, () => {
+  qase(62,
+    it.skip('FLEET-62: Deploy application to local cluster', { tags: '@fleet-62' }, () => {
+      const repoName = "local-cluster-fleet-62"
+      const branch = "master"
+      const path = "simple"
+      const repoUrl = "https://github.com/rancher/fleet-examples"
+
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6')
+      cy.verifyTableRow(1, 'Service', 'frontend');
+      cy.verifyTableRow(3, 'Service', 'redis-master');
+      cy.verifyTableRow(5, 'Service', 'redis-slave');
+      cy.deleteAllFleetRepos();
+    })
+  );
+})
+
+describe('Fleet Deployment Test Cases on PRIVATE repos',  { tags: '@p0' }, () => {
+ 
+  const branch = "main"
+  const gitAuthType = "http"
+  const repoNameGitlab = `default-cluster-fleet-6`
+  const repoNameBitbucket = `default-cluster-fleet-7`
+  const repoNameGithub = `default-cluster-fleet-8`
+  const repoNameAzure = `default-cluster-fleet-98` 
+  const repoUrlGitlab = "https://gitlab.com/qa1613907/gitlab-test-fleet.git"
+  const repoUrlBitbucket = "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test"
+  const repoUrlGithub = "https://github.com/mmartinsuse/test-fleet"
+  const repoUrlAzure = "https://dev.azure.com/mamartin0216/_git/mamartin"
+  const pathGitlab = "test-fleet-main/nginx"
+  const pathBitbucket = "test-fleet-main/nginx"
+  const pathGithub = "nginx"
+  const pathAzure = "nginx-helm"
+  const userOrPublicKeyGitlab = Cypress.env("gitlab_private_user")
+  const pwdOrPrivateKeyGitlab = Cypress.env("gitlab_private_pwd")
+  const userOrPublicKeyBitbucket = Cypress.env("bitbucket_private_user")
+  const pwdOrPrivateKeyBitbucket = Cypress.env("bitbucket_private_pwd")
+  const userOrPublicKeyGithub = Cypress.env("gh_private_user")
+  const pwdOrPrivateKeyGithub = Cypress.env("gh_private_pwd")
+  const userOrPublicKeyAzure = Cypress.env("azure_private_user")
+  const pwdOrPrivateKeyAzure = Cypress.env("azure_private_pwd")
+
+  
+  qase(6,
+    it('FLEET-6: Test GITLAB Private Repository to install NGINX app using HTTP auth', { retries: 1 , tags: '@fleet-6' }, () => {
+      // Looping 2 times due to error on 2.8-head
+      for (let i = 0; i < 2; i++) {
+        cy.fleetNamespaceToggle('fleet-local')
+        cy.addFleetGitRepo({ repoName: repoNameGitlab, repoUrl: repoUrlGitlab, branch, path: pathGitlab, gitAuthType, userOrPublicKey: userOrPublicKeyGitlab, pwdOrPrivateKey: pwdOrPrivateKeyGitlab });
+        cy.clickButton('Create');
+        cy.open3dotsMenu({repoName: repoNameGitlab} , 'Force Update');
+        cy.checkGitRepoStatus({repoName: repoNameGitlab}, '1 / 1', '1 / 1')
+        cy.deleteAllFleetRepos();
+      }
+    })
+  );
+
+  qase(7,
+    it('FLEET-7: Test BITBUCKET Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-7' }, () => {
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName: repoNameBitbucket, repoUrl: repoUrlBitbucket , branch, path: pathBitbucket , gitAuthType, userOrPublicKey: userOrPublicKeyBitbucket, pwdOrPrivateKey: pwdOrPrivateKeyBitbucket });
+      cy.clickButton('Create');
+      cy.open3dotsMenu({repoName: repoNameBitbucket}, 'Force Update');
+      cy.checkGitRepoStatus({repoName: repoNameBitbucket}, '1 / 1', '1 / 1')
+      cy.deleteAllFleetRepos();
+    })
+  );
+
+  qase(8,
+    it('FLEET-8: Test GITHUB Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-8' }, () => {
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName: repoNameGithub, repoUrl: repoUrlGithub , branch, path: pathGithub , gitAuthType, userOrPublicKey: userOrPublicKeyGithub , pwdOrPrivateKey: pwdOrPrivateKeyGithub });;
+      cy.clickButton('Create');
+      cy.open3dotsMenu({repoName: repoNameGithub}, 'Force Update');
+      cy.checkGitRepoStatus({repoName: repoNameGithub}, '1 / 1', '1 / 1')
+      cy.deleteAllFleetRepos();
+    })
+  );
+
+  qase(98,
+    it('FLEET-98: Test AZURE DEVOPS Private Repository to install NGINX app using HTTP auth', { tags: '@fleet-98' }, () => {
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.addFleetGitRepo({ repoName: repoNameAzure, repoUrl: repoUrlAzure , branch, path: pathAzure , gitAuthType, userOrPublicKey: userOrPublicKeyAzure, pwdOrPrivateKey: pwdOrPrivateKeyAzure });
+      cy.clickButton('Create');
+      cy.open3dotsMenu({repoName: repoNameAzure}, 'Force Update');
+      cy.checkGitRepoStatus({repoName: repoNameAzure}, '1 / 1', '1 / 1')
+      cy.deleteAllFleetRepos();
+    })
+  );
+});
+
+

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -1,4 +1,4 @@
-/*
+0/*
 Copyright © 2023 - 2024 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,10 @@ beforeEach(() => {
   cy.deleteAllFleetRepos();
 });
 
+afterEach(() => {
+  cy.deleteAllFleetRepos();
+});
+
 
 Cypress.config();
 describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
@@ -32,13 +36,10 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const repoUrl = "https://github.com/rancher/fleet-examples"
 
       cy.fleetNamespaceToggle('fleet-local')
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
-      cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6')
+      cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, bundles: '1 / 1', resources: '6 / 6' });      
       cy.verifyTableRow(1, 'Service', 'frontend');
       cy.verifyTableRow(3, 'Service', 'redis-master');
       cy.verifyTableRow(5, 'Service', 'redis-slave');
-      cy.deleteAllFleetRepos();
     })
   );
 
@@ -54,11 +55,8 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
       // Looping 2 times due to error on 2.8-head
       for (let i = 0; i < 2; i++) {
-        cy.fleetNamespaceToggle('fleet-default')
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
-        cy.clickButton('Create');
-        cy.open3dotsMenu(repoName, 'Force Update');
-        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
+        cy.fleetNamespaceToggle('fleet-local')
+        cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles: '1 / 1', resources: '1 / 1' });
         cy.deleteAllFleetRepos();
       }
     })
@@ -74,12 +72,8 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("bitbucket_private_user");
       const pwdOrPrivateKey = Cypress.env("bitbucket_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-default')
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
-      cy.clickButton('Create');
-      cy.open3dotsMenu(repoName, 'Force Update');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-      cy.deleteAllFleetRepos();
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles: '1 / 1', resources: '1 / 1' });
     })
   );
 
@@ -93,12 +87,8 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("gh_private_user");
       const pwdOrPrivateKey = Cypress.env("gh_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-default')
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
-      cy.clickButton('Create');
-      cy.open3dotsMenu(repoName, 'Force Update');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-      cy.deleteAllFleetRepos();
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles: '1 / 1', resources: '1 / 1' });
     })
   );
 
@@ -112,12 +102,8 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("azure_private_user");
       const pwdOrPrivateKey = Cypress.env("azure_private_pwd");
 
-      cy.fleetNamespaceToggle('fleet-default')
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
-      cy.clickButton('Create');
-      cy.open3dotsMenu(repoName, 'Force Update');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
-      cy.deleteAllFleetRepos();
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles: '1 / 1', resources: '1 / 1' });
     })
   );
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -69,9 +69,9 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, gitA
 })
 
 // 3 dots menu selection
-Cypress.Commands.add('open3dotsMenu', (name, selection) => {
+Cypress.Commands.add('open3dotsMenu', ({repoName, selection}) => {
   // Open 3 dots button
-  cy.contains('tr.main-row', name).within(() => {
+  cy.contains('tr.main-row', repoName).within(() => {
     cy.get('.icon.icon-actions', { timeout: 5000 }).click();
   });
   if (selection) {
@@ -148,9 +148,9 @@ Cypress.Commands.add('deleteAllFleetRepos', () => {
 });
 
 // Check Git repo deployment status
-Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
+Cypress.Commands.add('checkGitRepoStatus', ({repoName, bundles, resources}) => {
   cy.verifyTableRow(0, 'Active', repoName);
-  cy.contains(repoName).click()
+  cy.contains(repoName).click({ force: true });
   cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
   cy.log(`Checking ${bundles} Bundles and ${resources} Resources`)
   if (bundles) {
@@ -181,4 +181,17 @@ Cypress.Commands.add('deleteApplicationDeployment', (appNamespace, clusterName='
   cy.nameSpaceMenuToggle(appNamespace);
   cy.clickNavMenu(['Workloads', 'Deployments']);
   cy.deleteAll({fleetCheck: false});
+});
+
+// Create command
+Cypress.Commands.add('createAndCheckFleetGitRepo', ( repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles, resources, forceUpdate='yes') => {
+  cy.log(repoName)
+  console.log(repoName)
+  cy.addFleetGitRepo( repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey );
+  cy.clickButton('Create');
+  // Force update command
+  if (forceUpdate === 'yes') {
+    cy.open3dotsMenu(repoName, 'Force Update')
+  };
+  cy.checkGitRepoStatus(repoName, bundles, resources); 
 });

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -20,7 +20,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       // Functions declared in commands.ts
-      open3dotsMenu(name: string, selection?: string): Chainable<Element>;
+      open3dotsMenu(repoName: string, selection?: string): Chainable<Element>;
       addPathOnGitRepoCreate(path: string): Chainable<Element>;
       gitRepoAuth(authType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string): Chainable<Element>;
       addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string): Chainable<Element>;
@@ -33,6 +33,7 @@ declare global {
       checkGitRepoStatus(repoName: string, bundles?: string, resources?: string): Chainable<Element>;
       checkApplicationStatus(appNamespace: string, appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(appNamespace: string, clusterName?: string): Chainable<Element>;
+      createAndCheckFleetGitRepo(repoName: string, repoUrl: string, branch?: string, path?: string, gitAuthType?: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, bundles?: string, resources?: string, forceUpdate?: string): Chainable<Element>;
     }
   }
 }

--- a/tests/cypress/support/test_details.ts
+++ b/tests/cypress/support/test_details.ts
@@ -1,0 +1,48 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// In this file you can write your custom commands and overwrite existing commands.
+
+import 'cypress-file-upload';
+import '~/support/commands';
+
+// PO tests cases
+Cypress.Commands.add('runPrivateRepoTests', (qase_id, testName) => {
+    const repoName = `default-cluster-fleet-${qase_id}`
+    const branch = "main"
+    const gitAuthType = "http"
+
+    cy.fleetNamespaceToggle('fleet-local')
+    
+    switch (qase_id) {
+        case 6:
+            cy.addFleetGitRepo({ repoName, repoUrl: "https://gitlab.com/qa1613907/gitlab-test-fleet.git", branch, path: "test-fleet-main/nginx", gitAuthType, userOrPublicKey: Cypress.env("gitlab_private_user"), pwdOrPrivateKey: Cypress.env("gitlab_private_pwd") });
+            break;
+        case 7:
+            cy.addFleetGitRepo({ repoName, repoUrl: "https://bitbucket.org/fleet-test-bitbucket/bitbucket-fleet-test", branch, path: "test-fleet-main/nginx", gitAuthType, userOrPublicKey: Cypress.env("bitbucket_private_user"), pwdOrPrivateKey: Cypress.env("bitbucket_private_pwd") });
+            break;
+        case 8:
+            cy.addFleetGitRepo({ repoName, repoUrl: "https://github.com/mmartinsuse/test-fleet" , branch, path: "nginx", gitAuthType, userOrPublicKey: Cypress.env("gh_private_user"), pwdOrPrivateKey: Cypress.env("gh_private_pwd") });
+            break;
+        case 9:
+            cy.addFleetGitRepo({ repoName, repoUrl: "https://dev.azure.com/mamartin0216/_git/mamartin", branch, path: "nginx-helm", gitAuthType, userOrPublicKey: Cypress.env("azure_private_user") , pwdOrPrivateKey: Cypress.env("azure_private_pwd") });
+    }
+    
+    cy.clickButton("Create");
+    cy.open3dotsMenu(repoName, "Force Update");
+    cy.checkGitRepoStatus(repoName, "1 / 1", "1 / 1");
+    cy.deleteAllFleetRepos();
+
+});
+


### PR DESCRIPTION
Implementation of: https://github.com/rancher/fleet-e2e/issues/78

# Initial task
Proposed 4 options for refactoring. All of them are present in this pr to be checked:

- **Option a** (`p0_a_fleet.spec.ts`). Similar model to Epinio. There is one spec with one line function that calls a second file (test_details.ts) containing the functions to be called. 
- **Option b** (`p0_b_fleet.spec.ts`). All constants are held under `describe`. There is one `const repoTestData` containing `qase_id` and `testname` which are to be used dynamically over test base
- **Option c** (`p0_c_fleet.spec.ts`). Similar to b, but here `const repoTestData` contains all specific values per test.
- **Option d** (`p0_d_fleet.spec.ts`). All constants to be used in different `it` within a `describe` are declared ahead right after the `describe`. Not a big refactor, but makes it easier to go over each `it`.

After checking all of these options and, personally, I don't like any of them. They either add more complexity, over-encapsulate things or are more difficult to read. Perhaps some may be more efficient in terms of execution or can be written with less lines of code, but personally I think it adds a complexity over the current model, which is quite easier to read and maintain. 

---

# Task done after initial discussion
After discussing the previous part with @sbulage, it was agreed to try 2 things:
- Try using reusable constants. After thinking a bit; I am not so sure about this one. If the constant could be exported within the `describe` I'd agree. We could do for instance a `const gitAuthType = "http"` for all private repos using http auth. But since the export needs to be done either globally or before the `describe`, I think it is confusing and prone to error to declare it for all test cases in the p0 spec to be overridden later if needed. I think is best to scope it within each `it`and solely the very rare ones which are truly repeatable for all the tests in the spec, to export it aside.
- To implement any of the above for the time being and try to work on further encapsulation of commonly used functions as to go from these 4 functions:
```
cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
cy.clickButton('Create');
cy.open3dotsMenu(repoName, 'Force Update');
cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
```
to only one as this one 
```
cy.createAndCheckFleetGitRepo({ repoName, branch, path, repoUrl, gitAuthType, userOrPublicKey, pwdOrPrivateKey, bundles: '1 / 1', resources: '1 / 1' });
```
I did this as well as using a hook `afterEach` for common functions as `deleteAllrepos`.

While the later one is ok, the overencapsulation is more complex to maintain and more difficult to read. By more difficult to read I mean it requires too much back and forth jumping over 2-3 functions to get to know what the initial one actually does. By more difficult to maintain I mean:
- Long functions
- Many ifs to make it selectable
- String constants are passed as objects as the travel from one function to another while they may be intended to remain as strings, which makes some changes on current working functions needed as [this](https://github.com/rancher/fleet-e2e/pull/89/files#diff-75965941f29be613c2bab5bdb432b711b86c52a2567d7f08dcf8aaeef907eb0cR72) one on the `open3dotsMenu` function .
- Troubleshooting currently working things. For instance, [this](https://github.com/rancher/fleet-e2e/pull/89/files#diff-75965941f29be613c2bab5bdb432b711b86c52a2567d7f08dcf8aaeef907eb0cR80) click on `Force Update` is not occurring after this encapsulation. It would require time to troubleshoot something that it was working.
 
**Conclusion**:
After all this I implemented the changes over p0 test cases and they [passed](https://github.com/rancher/fleet-e2e/actions/runs/8550197248/job/23426806208#step:9:274) on ci (there are some failures on 2 `p1`, which if we want to continue I will revise, but that is minor thing). However, I am not so sure this over-encapsulation, even when reduces a bit of code on the test set up, makes it more manageable overall. I am ok with avoiding some repetition by using hooks as but I am not so sure in the current set up we gain much more. If in the end we want to merge this encapsulated function and take it as base case, just let me know and I will correct the p1 cases. Otherwise, I'd leave things as they are. 
