### PR TITLE
Bump github.com/rancher-sandbox/ele-testhelpers with support

### DIFF
--- a/.github/workflows/ui-pr_rm_head_2.8.yaml
+++ b/.github/workflows/ui-pr_rm_head_2.8.yaml
@@ -36,7 +36,7 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY PULL_REQUEST EVENT
       destroy_runner: true
       upstream_cluster_version: 'v1.27.10+k3s2'
-      rancher_version: 'devel/2.8'
+      rancher_version: 'latest/devel/2.8'
       # If qase_run_id is none the run is getting deleted in QASE
       qase_run_id: 'none'
       grep_test_by_tag: '@login @p0 @p1'

--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -13,7 +13,7 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version - latest/latest, latest/2.7.10[-rc2], prime/latest/2.7.12
+        description: Rancher version channel/version/head_version latest/latest, latest/2.7.10[-rc2], prime/2.7.12, prime/devel/2.7
         default: latest/devel/2.7
         type: string
         required: true

--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -13,8 +13,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version as 'devel/2.7' or '2.8.2[-rc3]'
-        default: devel/2.7
+        description: Rancher version channel/version/head_version - latest/latest, latest/2.7.10[-rc2], prime/latest/2.7.12
+        default: latest/devel/2.7
         type: string
         required: true
       upstream_cluster_version:

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -13,8 +13,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version as 'devel/2.8' or '2.8.2[-rc3]'
-        default: devel/2.8
+        description: Rancher version channel/version/head_version - latest/latest, latest/2.8.3[-rc8], prime/latest/2.8.2
+        default: latest/devel/2.8
         type: string
         required: true
       upstream_cluster_version:

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -13,7 +13,7 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version - latest/latest, latest/2.8.3[-rc8], prime/latest/2.8.2
+        description: Rancher version channel/version/head_version latest/latest, latest/2.8.3[-rc8], prime/2.8.2, prime/devel/2.8
         default: latest/devel/2.8
         type: string
         required: true

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -13,7 +13,7 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version - latest/latest, latest/2.9.x[-rc1], prime/latest/2.9.x
+        description: Rancher version channel/version/head_version latest/latest, latest/2.9.x[-rc1], prime/2.9.x, prime/devel/2.9
         default: latest/devel/2.9
         type: string
         required: true

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -13,8 +13,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version as 'devel/2.9' or '2.8.2[-rc3]'
-        default: devel/2.9
+        description: Rancher version channel/version/head_version - latest/latest, latest/2.9.x[-rc1], prime/latest/2.9.x
+        default: latest/devel/2.9
         type: string
         required: true
       upstream_cluster_version:

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -78,13 +78,17 @@ var _ = BeforeSuite(func() {
 
 	// Extract Rancher Manager channel/version to install
 	if rancherVersion != "" {
+		// Split rancherVersion and reset it
 		s := strings.Split(rancherVersion, "/")
-		// Always use "rancher-latest" as other values make no sense here
-		rancherChannel = "latest"
-		rancherVersion = s[0]
-		rancherHeadVersion = ""
+		rancherVersion = ""
+
+		// Get needed informations
+		rancherChannel = s[0]
 		if len(s) > 1 {
-			rancherHeadVersion = s[1]
+			rancherVersion = s[1]
+		}
+		if len(s) > 2 {
+			rancherHeadVersion = s[2]
 		}
 	}
 })

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240408122439-64e37f816d30
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -131,8 +131,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736 h1:xWNdHJ63vkdVUDjotF4nuGff+KSl3vQzqvgwOTFnmaw=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240408122439-64e37f816d30 h1:Lvjm6A5QgF06C+HcQyP/gjt2hQWyD9PobFmeffkt4ag=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240408122439-64e37f816d30/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Ref: https://github.com/rancher/fleet-e2e/issues/91

* New `prime` channel introduced via https://github.com/rancher-sandbox/ele-testhelpers/pull/45
* When running CI against `latest/devel/2.7` new staging registries `stgregistry.suse.com/rancher` are used for pulling `rancher:v2.7-head` and `rancher-agent:v2.7-head` images

Also we had to switch back to original way of rancher version selection as there is not only `latest` channel present anymore but also `prime` in addition.

The bumped module now permits to use for example `prime/2.7.12` for released versions. The pre-release testing procedure for prime is not yet clear.

Accepted values for rancher version are:
```
latest/latest
latest/devel/2.x
latest/2.8.3[-rc3]
prime/devel/2.8 (untested)
```

Testruns (FAILURES are releated to different cy selectors for SSH in 2.7):
* **FAILED** latest/devel/2.7  https://github.com/rancher/fleet-e2e/actions/runs/8601097760
![image](https://github.com/rancher/fleet-e2e/assets/12828077/f2ef36d8-bb39-4d02-844d-086f95e0221a)
* **PASSED** latest/devel/2.8  https://github.com/rancher/fleet-e2e/actions/runs/8601089538
![image](https://github.com/rancher/fleet-e2e/assets/12828077/06d8c91a-d8dd-463c-88ec-7c4dbb520601)
* **FAILED** prime/2.7.12 https://github.com/rancher/fleet-e2e/actions/runs/8601431753
![image](https://github.com/rancher/fleet-e2e/assets/12828077/471e7180-1e9e-4ab8-9b33-469654865ca5)