### PR TITLE
Adapt ssh locator for rancher 2.7

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -130,7 +130,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(2,
     it('FLEET-2: Test GITLAB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-2' }, () => {
-      const repoName = "default-cluster-fleet-2"
+      const repoName = "local-cluster-fleet-2"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@gitlab.com:fleetqa/fleet-qa-examples.git"
@@ -138,7 +138,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-default')
+      cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -149,7 +149,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(3,
     it('FLEET-3: Test BITBUCKET Private Repository to install NGINX app using SSH auth', { tags: '@fleet-3' }, () => {
-      const repoName = "default-cluster-fleet-3"
+      const repoName = "local-cluster-fleet-3"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@bitbucket.org:fleetqa-bb/fleet-qa-examples.git"
@@ -157,7 +157,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-default')
+      cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -168,7 +168,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(4,
     it('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
-      const repoName = "default-cluster-fleet-4"
+      const repoName = "local-cluster-fleet-4"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@github.com:fleetqa/fleet-qa-examples.git"
@@ -176,7 +176,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-default')
+      cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -187,7 +187,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(97,
     it('FLEET-97: Test AZURE Private Repository to install NGINX app using SSH auth', { tags: '@fleet-97' }, () => {
-      const repoName = "default-cluster-fleet-97"
+      const repoName = "local-cluster-fleet-97"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@ssh.dev.azure.com:v3/fleetqateam/fleet-qa-examples/fleet-qa-examples"
@@ -195,7 +195,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-default')
+      cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -130,7 +130,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(2,
     it('FLEET-2: Test GITLAB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-2' }, () => {
-      const repoName = "local-cluster-fleet-2"
+      const repoName = "default-cluster-fleet-2"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@gitlab.com:fleetqa/fleet-qa-examples.git"
@@ -138,7 +138,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -149,7 +149,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(3,
     it('FLEET-3: Test BITBUCKET Private Repository to install NGINX app using SSH auth', { tags: '@fleet-3' }, () => {
-      const repoName = "local-cluster-fleet-3"
+      const repoName = "default-cluster-fleet-3"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@bitbucket.org:fleetqa-bb/fleet-qa-examples.git"
@@ -157,7 +157,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -168,7 +168,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(4,
     it('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
-      const repoName = "local-cluster-fleet-4"
+      const repoName = "default-cluster-fleet-4"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@github.com:fleetqa/fleet-qa-examples.git"
@@ -176,7 +176,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');
@@ -187,7 +187,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
 
   qase(97,
     it('FLEET-97: Test AZURE Private Repository to install NGINX app using SSH auth', { tags: '@fleet-97' }, () => {
-      const repoName = "local-cluster-fleet-97"
+      const repoName = "default-cluster-fleet-97"
       const branch = "main"
       const path = "nginx"
       const repoUrl = "git@ssh.dev.azure.com:v3/fleetqateam/fleet-qa-examples/fleet-qa-examples"
@@ -195,7 +195,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("rsa_private_key_qa")
       const pwdOrPrivateKey = Cypress.env("rsa_public_key_qa")
       
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-default')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
       cy.clickButton('Create');
       cy.open3dotsMenu(repoName, 'Force Update');

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -167,7 +167,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
   );
 
   qase(4,
-    it('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
+    it.only('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
       const repoName = "default-cluster-fleet-4"
       const branch = "main"
       const path = "nginx"

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -167,7 +167,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
   );
 
   qase(4,
-    it.only('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
+    it('FLEET-4: Test GITHUB Private Repository to install NGINX app using SSH auth', { tags: '@fleet-4' }, () => {
       const repoName = "default-cluster-fleet-4"
       const branch = "main"
       const path = "nginx"

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -38,8 +38,8 @@ Cypress.Commands.add('gitRepoAuth', (gitAuthType, userOrPublicKey, pwdOrPrivateK
   }
   else if (gitAuthType === 'ssh') {
     // Ugly implementation needed because 'typeValue' does not work here
-    cy.get('textarea[data-testid="auth-secret-ssh-public-key"]').focus().clear().type(userOrPublicKey, {log: false}).blur();
-    cy.get('textarea[data-testid="auth-secret-ssh-private-key"]').focus().clear().type(userOrPublicKey, {log: false}).blur();
+    cy.get('textarea.no-resize.no-ease').eq(0).focus().clear().type(userOrPublicKey, {log: false}).blur();
+    cy.get('textarea.no-resize.no-ease').eq(1).focus().clear().type(userOrPublicKey, {log: false}).blur();
   }
 });
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -154,10 +154,10 @@ Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
   cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
   cy.log(`Checking ${bundles} Bundles and ${resources} Resources`)
   if (bundles) {
-    cy.get('div.fleet-status', { timeout: 45000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 45000 }).should('be.visible')
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 30000 }).should('be.visible')
   }
   if (resources) {
-    cy.get('div.fleet-status', { timeout: 45000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 45000 }).should('be.visible')
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 30000 }).should('be.visible')
   }
 });
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -154,10 +154,10 @@ Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
   cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
   cy.log(`Checking ${bundles} Bundles and ${resources} Resources`)
   if (bundles) {
-    cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 30000 }).should('be.visible')
+    cy.get('div.fleet-status', { timeout: 45000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 45000 }).should('be.visible')
   }
   if (resources) {
-    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 30000 }).should('be.visible')
+    cy.get('div.fleet-status', { timeout: 45000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 45000 }).should('be.visible')
   }
 });
 


### PR DESCRIPTION
Adapt ssh keys locator for 2.7 to make ci green (current [failure](https://github.com/rancher/fleet-e2e/actions/runs/8601757348/job/23569757892#step:9:262))
It should be compatible as well with 2.8 and 2.9
