### PR TITLE
Fleet qa/review implicit waits and other mechanism

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -55,8 +55,6 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
       const userOrPublicKey = Cypress.env("gitlab_private_user");
       const pwdOrPrivateKey = Cypress.env("gitlab_private_pwd");
 
-      // Looping 2 times due to error on 2.8-head
-      for (let i = 0; i < 2; i++) {
         cy.fleetNamespaceToggle('fleet-default')
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
@@ -64,7 +62,7 @@ describe('Fleet Deployment Test Cases',  { tags: '@p0' }, () => {
         cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1')
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();
-      }
+
     })
   );
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -92,7 +92,7 @@ Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2)
   // Ensure table is loaded and visible
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
-    .children({ timeout: 300000 })
+    .children({ timeout: 60000 })
     .should('contain', expectedText1 )
     .should('contain', expectedText2 ); // TODO: refactor this so it is not mandatory value
 });
@@ -168,7 +168,7 @@ Cypress.Commands.add('checkApplicationStatus', (appName, clusterName='local') =>
   cy.clickNavMenu(['Workloads', 'Pods']);
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-0-row"]`)
-    .children({ timeout: 300000 })
+    .children({ timeout: 60000 })
     .should('contain.text', appName);
 });
 


### PR DESCRIPTION
Testing if we can speed up test failures a bit by reducing max timeouts
Removing loop on tests Fleet-6 since it is no longer needed.