### PR TITLE
Use inputs in run-name for dispatched runs

### DIFF
--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-RM_head_2.7
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}` - `{2}` destroy={3}', inputs.rancher_version, inputs.upstream_cluster_version, inputs.grep_test_by_tag, inputs.destroy_runner) || github.workflow }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-RM_head_2.8
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}` - `{2}` destroy={3}', inputs.rancher_version, inputs.upstream_cluster_version, inputs.grep_test_by_tag, inputs.destroy_runner) || github.workflow }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-RM_head_2.9
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}` - `{2}` destroy={3}', inputs.rancher_version, inputs.upstream_cluster_version, inputs.grep_test_by_tag, inputs.destroy_runner) || github.workflow }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Adding more details into run-name for dispatched runs only

![image](https://github.com/rancher/fleet-e2e/assets/12828077/d45d34ca-e46f-4abd-8230-66857a8b57d6)
