### PR TITLE
Update rancher_version values for scheduled jobs

### DIFF
--- a/.github/workflows/ui-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rm_head_2.7.yaml
@@ -55,6 +55,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.26.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel/2.7' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1' }}

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -55,6 +55,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ contains(fromJSON('["pull_request", "schedule"]'), github.event_name) && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel/2.8' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -55,6 +55,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel/2.9' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1' }}


### PR DESCRIPTION
I did not update `rancher_version` values for scheduled jobs in our workflow files - it was still using `devel/2.x` instead of `latest/devel/2.x` so all scheduled jobs failed tonight.