### PR TITLE
Adding traefik test

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -23,7 +23,7 @@ export const path  = "nginx"
 beforeEach(() => {
   cy.login();
   cy.visit('/');
-  cy.deleteAllFleetRepos();
+  // cy.deleteAllFleetRepos();
 });
 
 
@@ -49,21 +49,24 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@p0' }, () => {
   );
 
   qase(115,
-    it('FLEET-115: Deploy "Traefik" application on "kube-system" namespace to local cluster', { tags: '@fleet-115' }, () => {
+    it.only('FLEET-115: Deploy "Traefik" application on "kube-system" namespace to local cluster', { tags: '@fleet-115' }, () => {
 
       const repoName = "local-cluster-fleet-115"
       const branch = "main"
-      const path = "traefik"
-      const repoUrl = "https://github.com/fleetqa/fleet-qa-examples"
+      let appName, path
+      appName = path = "traefik"
+      const repoUrl = "https://github.com/sbulage/test-fleet"
+      const namespace = "kube-system"
 
       cy.fleetNamespaceToggle('fleet-local');
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, keepResources: 'yes' });
       cy.clickButton('Create');
       cy.checkGitRepoStatus(repoName, '1 / 1', '7 / 7');
       cy.verifyTableRow(1, 'Service', 'traefik');
       cy.verifyTableRow(3, 'IngressRoute', 'traefik-dashboard');
       cy.verifyTableRow(5, 'ClusterRole', 'traefik-kube-system');
       cy.deleteAllFleetRepos();
+      cy.checkApplicationStatus(appName, namespace);
     })
   );
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -47,6 +47,26 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@p0' }, () => {
       cy.deleteAllFleetRepos();
     })
   );
+
+  qase(115,
+    it('FLEET-115: Deploy "Traefik" application on "kube-system" namespace to local cluster', { tags: '@fleet-115' }, () => {
+
+      const repoName = "local-cluster-fleet-115"
+      const branch = "main"
+      const path = "traefik"
+      const repoUrl = "https://github.com/fleetqa/fleet-qa-examples"
+
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '7 / 7');
+      cy.verifyTableRow(1, 'Service', 'traefik');
+      cy.verifyTableRow(3, 'IngressRoute', 'traefik-dashboard');
+      cy.verifyTableRow(5, 'ClusterRole', 'traefik-kube-system');
+      cy.deleteAllFleetRepos();
+    })
+  );
+
 });
 
 describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' }, () => {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -178,10 +178,11 @@ Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
 });
 
 // Check deployed application status (present or not)
-Cypress.Commands.add('checkApplicationStatus', (appName, clusterName='local') => {
+Cypress.Commands.add('checkApplicationStatus', (appName, namespace, clusterName='local') => {
   cypressLib.burgerMenuToggle();
   cypressLib.accesMenu(clusterName);
   cy.clickNavMenu(['Workloads', 'Pods']);
+  cy.nameSpaceMenuToggle(namespace);
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-0-row"]`)
     .children({ timeout: 60000 })

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -182,7 +182,12 @@ Cypress.Commands.add('checkApplicationStatus', (appName, namespace, clusterName=
   cypressLib.burgerMenuToggle();
   cypressLib.accesMenu(clusterName);
   cy.clickNavMenu(['Workloads', 'Pods']);
-  cy.nameSpaceMenuToggle(namespace);
+  if (namespace) {
+    cy.nameSpaceMenuToggle(namespace);
+  }
+  // Type application name in filter
+  let newAppName = new RegExp(appName + "(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9]+")
+  cy.get('.search.row').should('exist').type(newAppName);
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-0-row"]`)
     .children({ timeout: 60000 })

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -31,7 +31,7 @@ declare global {
       deleteAll(fleetCheck?: boolean): Chainable<Element>;
       deleteAllFleetRepos(): Chainable<Element>;
       checkGitRepoStatus(repoName: string, bundles?: string, resources?: string): Chainable<Element>;
-      checkApplicationStatus(appName: string, namespace?: string, clusterName?: string): Chainable<Element>;
+      checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;
     }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -31,7 +31,7 @@ declare global {
       deleteAll(fleetCheck?: boolean): Chainable<Element>;
       deleteAllFleetRepos(): Chainable<Element>;
       checkGitRepoStatus(repoName: string, bundles?: string, resources?: string): Chainable<Element>;
-      checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
+      checkApplicationStatus(appName: string, namespace?: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;
     }


### PR DESCRIPTION
Request
Automate Traefik install in a way does not collide with k8s versions + crds / k3d on ds cluster
Initial ref: https://github.com/rancher/fleet-e2e/issues/104