### PR TITLE
Fleet qa/bump k3s versions and add retries

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -84,7 +84,7 @@ on:
         type: string
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.10+k3s2
+        default: v1.28.8+k3s1
         type: string
         required: true
       zone:

--- a/.github/workflows/ui-pr_rm_head_2.8.yaml
+++ b/.github/workflows/ui-pr_rm_head_2.8.yaml
@@ -35,7 +35,7 @@ jobs:
       cluster_name: cluster-k3s
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY PULL_REQUEST EVENT
       destroy_runner: true
-      upstream_cluster_version: 'v1.27.10+k3s2'
+      upstream_cluster_version: 'v1.28.8+k3s1'
       rancher_version: 'latest/devel/2.8'
       # If qase_run_id is none the run is getting deleted in QASE
       qase_run_id: 'none'

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -20,7 +20,7 @@ on:
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.10+k3s2
+        default: v1.28.8+k3s1
         type: string
         required: true
       grep_test_by_tag:
@@ -54,7 +54,7 @@ jobs:
       cluster_name: cluster-k3s
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ contains(fromJSON('["pull_request", "schedule"]'), github.event_name) && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.28.8+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -20,7 +20,7 @@ on:
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.27.10+k3s2
+        default: v1.28.8+k3s1
         type: string
         required: true
       grep_test_by_tag:
@@ -54,7 +54,7 @@ jobs:
       cluster_name: cluster-k3s
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.27.10+k3s2' }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.28.8+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1' }}

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -61,7 +61,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' 
 
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {
     qase(qase_id,
-      it(`FLEET-${qase_id}: Test to install "NGINX" app using "HTTP" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}` }, () => {
+      it(`FLEET-${qase_id}: Test to install "NGINX" app using "HTTP" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
 
         const repoName = `default-cluster-fleet-${qase_id}`
         const userOrPublicKey = Cypress.env(`${provider.toLowerCase()}_private_user`)
@@ -93,7 +93,7 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
   
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {
     qase(qase_id,
-      it(`FLEET-${qase_id}: Test to install "NGINX" app using "SSH" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}` }, () => {
+      it(`FLEET-${qase_id}: Test to install "NGINX" app using "SSH" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
         
         const repoName = `default-cluster-fleet-${qase_id}`
 

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -174,7 +174,7 @@ describe('Test Self-Healing of resource modification when correctDrift option us
 
 describe('Test Self-Healing of resource modification when correctDrift option used for exisiting GitRepo', { tags: '@p1'}, () => {
   qase(77,
-    it("Fleet-77: Test MODIFICATION to resources will be self-healed when correctDrift is set to true in existing GitRepo.", { tags: '@fleet-77' }, () => {
+    it("Fleet-77: Test MODIFICATION to resources will be self-healed when correctDrift is set to true in existing GitRepo.", { tags: '@fleet-77', retries: 1 }, () => {
       const repoName = "local-cluster-correct-77"
       cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });


### PR DESCRIPTION
### Done:
- Added retried on flaky tests (examples: [Fleet-77](https://github.com/rancher/fleet-e2e/actions/runs/8716195109/job/23912577022#step:9:360) or [Fleet-98](https://github.com/rancher/fleet-e2e/actions/runs/8716195109/job/23912577022#step:9:276))

- Bumped kubernetes versions for 2.8-head and 2.9-head lanes to `v1.28.8+k3s1`
CI seem to work: [2.8 ](https://github.com/rancher/fleet-e2e/actions/runs/8720713510/job/23922895601#step:9:308), [2.9](https://github.com/rancher/fleet-e2e/actions/runs/8720904626/job/23924465957#step:9:203)

Errors in those lanes are due to flaky tests. 
