### PR TITLE
Updating url for az private repo

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -56,7 +56,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' 
     {qase_id: 6, provider: 'GitLab',  repoUrl: 'https://gitlab.com/fleetqa/fleet-qa-examples.git'},
     {qase_id: 7, provider: 'Gh',  repoUrl: 'https://github.com/fleetqa/fleet-qa-examples.git'},
     {qase_id: 8, provider: 'Bitbucket', repoUrl: 'https://bitbucket.org/fleetqa-bb/fleet-qa-examples.git'},
-    {qase_id: 98, provider: 'Azure',  repoUrl: 'https://fleetqateam@dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples'}
+    {qase_id: 98, provider: 'Azure',  repoUrl: 'https://dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples'}
   ]
 
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {


### PR DESCRIPTION
Fixes [failed](https://github.com/rancher/fleet-e2e/actions/runs/8732280556/job/23959047616#step:9:266) ci tests on 2.7 due to username present in Azure.

![2024-04-18_10-15](https://github.com/rancher/fleet-e2e/assets/37271841/6965a324-1ca7-495d-ae59-359d627e9582)


Changing: 
```
https://fleetqateam@dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples
```
to
```
https://dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples
```

CI on 2.7 [here](https://github.com/rancher/fleet-e2e/actions/runs/8735472306)