### PR TITLE
Bump actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -300,7 +300,7 @@ jobs:
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure() 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots-basics-${{ inputs.cluster_name }}
           path: tests/cypress/screenshots
@@ -309,7 +309,7 @@ jobs:
       - name: Upload Cypress videos (Basics)
         # Test run video is always captured, so this action uses "always()" condition
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos-basics-${{ inputs.cluster_name }}
           path: tests/cypress/videos


### PR DESCRIPTION
v3 reported as deprecated

For our use no other actions should be required but I'd like to see how it will handle several screenshots on failure.

Testrun:
* v2.9 https://github.com/rancher/fleet-e2e/actions/runs/8753431166 (there is only one failure in first_login - this is not enough for test)
* 2.9.0-alpha1 https://github.com/rancher/fleet-e2e/actions/runs/8754169025