### PR TITLE
Adding exception to skip test for rancher 2.7

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -270,7 +270,6 @@ jobs:
         env:
           BROWSER: chrome
           CYPRESS_DOCKER: 'cypress/included:13.6.4'
-          RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -233,14 +233,15 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
   )
 });
 
-if (Cypress.env('rancher_version') != '2.7') {
-describe('Test local cluster behavior with New workspace', { tags: '@p1'}, () => {
-  qase(107,
-    it("Fleet-107: Test LOCAL CLUSTER cannot be moved to another workspace as no 'Change workspace' option available..", { tags: '@fleet-107' }, () => {
-      cy.accesMenuSelection('Continuous Deliver', 'Clusters');
-      cy.fleetNamespaceToggle('fleet-local');
-      cy.open3dotsMenu('local', 'Change workspace', true);
-    })
-  )
-});
+// Perform this test only if rancher_version does not contain "/2.7"
+if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
+  describe('Test local cluster behavior with New workspace', { tags: '@p1'}, () => {
+    qase(107,
+      it("Fleet-107: Test LOCAL CLUSTER cannot be moved to another workspace as no 'Change workspace' option available..", { tags: '@fleet-107' }, () => {
+        cy.accesMenuSelection('Continuous Deliver', 'Clusters');
+        cy.fleetNamespaceToggle('fleet-local');
+        cy.open3dotsMenu('local', 'Change workspace', true);
+      })
+    )
+  });
 }

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -233,6 +233,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
   )
 });
 
+if (Cypress.env('rancher_version') != '2.7') {
 describe('Test local cluster behavior with New workspace', { tags: '@p1'}, () => {
   qase(107,
     it("Fleet-107: Test LOCAL CLUSTER cannot be moved to another workspace as no 'Change workspace' option available..", { tags: '@fleet-107' }, () => {
@@ -242,3 +243,4 @@ describe('Test local cluster behavior with New workspace', { tags: '@p1'}, () =>
     })
   )
 });
+}


### PR DESCRIPTION
Skipping test 107 on Rancher 2.7 due to backport not implemented for it, making ci fail:

https://github.com/rancher/fleet-e2e/actions/runs/8748283153/job/24008094144#step:9:333 

CI in 2.7: https://github.com/rancher/fleet-e2e/actions/runs/8754736455
