### PR TITLE
Support for multiple downstream cluster provisioning

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -204,6 +204,7 @@ jobs:
     needs: [create-runner, pre-qase]
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     env:
+      DS_CLUSTER_COUNT: 2
       ARCH: amd64
       INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
       K3S_KUBECONFIG_MODE: 0644

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -204,7 +204,7 @@ jobs:
     needs: [create-runner, pre-qase]
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     env:
-      DS_CLUSTER_COUNT: 2
+      DS_CLUSTER_COUNT: 3
       ARCH: amd64
       INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
       K3S_KUBECONFIG_MODE: 0644

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -16,7 +16,7 @@ import 'cypress/support/commands';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const appName = "nginx-keep";
-export const clusterName = "k3d-imported";
+export const clusterName = "imported-0";
 export const branch = "main";
 export const path  = "nginx"
 

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -281,8 +281,8 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
         cy.fleetNamespaceToggle('fleet-default');
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
         cy.clickButton('Create');
-        cy.verifyTableRow(0, 'Active', '1/1');
-        cy.accesMenuSelection('k3d-imported', 'Storage', 'ConfigMaps');
+        cy.verifyTableRow(0, 'Active', /([1-9]\d*)\/\1/);
+        cy.accesMenuSelection('imported-0', 'Storage', 'ConfigMaps');
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
@@ -305,8 +305,8 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
         cy.fleetNamespaceToggle('fleet-default');
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey});
         cy.clickButton('Create');
-        cy.verifyTableRow(0, 'Active', '1/1');
-        cy.accesMenuSelection('k3d-imported', 'Storage', 'ConfigMaps');
+        cy.verifyTableRow(0, 'Active', /([1-9]\d*)\/\1/);
+        cy.accesMenuSelection('imported-0', 'Storage', 'ConfigMaps');
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -122,7 +122,19 @@ Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2)
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
     .children({ timeout: 60000 })
     .should('contain', expectedText1 )
-    .should('contain', expectedText2 ); // TODO: refactor this so it is not mandatory value
+    // Check if expectedText2 is a RegExp or a string
+    .then(() => {
+      if (expectedText2 instanceof RegExp) {
+        cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+          .children({ timeout: 60000 })
+          .invoke('text')
+          .should('match', expectedText2);
+      } else {
+        cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+          .children({ timeout: 60000 })
+          .should('contain', expectedText2);
+      }
+    });
 });
 
 // Namespace Toggle

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -25,7 +25,7 @@ declare global {
       gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string): Chainable<Element>;
       addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string, fleetNamespace?: string): Chainable<Element>;
       fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
-      verifyTableRow(rowNumber: number, expectedText1?: string, expectedText2?: string): Chainable<Element>;
+      verifyTableRow(rowNumber: number, expectedText1?: string, expectedText2?: string|RegExp): Chainable<Element>;
       nameSpaceMenuToggle(namespaceName: string): Chainable<Element>;
       accesMenuSelection(firstAccessMenu: string, secondAccessMenu?: string, clickOption?: string): Chainable<Element>;
       filterInSearchBox(filterText: string): Chainable<Element>;

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -42,6 +42,7 @@ var (
 	rancherChannel       string
 	rancherHeadVersion   string
 	rancherVersion       string
+	dsClusterCountStr    string
 )
 
 /**
@@ -72,6 +73,7 @@ var _ = BeforeSuite(func() {
 	// We will use the same version for downstream and upstream clusters
 	k8sDownstreamVersion = os.Getenv("INSTALL_K3S_VERSION")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
+	dsClusterCountStr = os.Getenv("DS_CLUSTER_COUNT")
 
 	// Convert k3s version to a tag usable by k3d
 	k8sDownstreamVersion = strings.Replace(k8sDownstreamVersion, "+", "-", 1)


### PR DESCRIPTION
Ref. https://github.com/rancher/fleet-e2e/issues/101

This PR is adding support for provisioning multiple k3d downstream clusters. For simplicity the PR has been split to 2 commits, one for infra and another for cypress.

For now deployment of ~two~ three clusters is hardcoded by setting the env variable `DS_CLUSTER_COUNT=3`, but once needed input for setting the number of clusters can be easily added to workflows.

I also had to modify cypress part as the clusters are named differently, changed from `k3d-imported` to `imported-0` ... `imported-X`.

There was a need to modify also `verifyTableRow` command (and their calls) which now accepts for `expectedText2` either string or regexp like `/([1-9]\d*)\/\1/` for matching a string where a sequence of digits (that starts with a non-zero digit) is followed by a / and then the same sequence of digits. For example, it would match 2/2 or 1/1, but not 1/2 or 1/0.