### PR TITLE
Use full rancher version in QASE_RUN_NAME

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -166,6 +166,8 @@ jobs:
 
       - name: Create/Export Qase Run
         id: qase
+        env:
+          QASE_RUN_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.rancher_version || github.workflow }}
         run: |
           case ${{ inputs.qase_run_id }} in
             'auto')
@@ -174,14 +176,17 @@ jobs:
               QASE_DESC="${{ inputs.test_description }} (${GH_RUN_URL})"
               export QASE_RUN_DESCRIPTION="${QASE_DESC}"
 
-              # Define and export the Qase run name, as it cannot be done
-              # in 'env:' because GITHUB_WORKFLOW is a shell variable
-              # Export them also to be used locally
-              export QASE_RUN_NAME="${GITHUB_WORKFLOW}"
+              # Use full rancher version
+              QASE_RUN_NAME=$(echo $QASE_RUN_NAME | awk -F'/' '{print $NF}' | \
+                grep -P -o '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?' || true)
+              # Or workflow name if the full rancher version is not found
+              if [ -z "$QASE_RUN_NAME" ]; then
+                QASE_RUN_NAME="${{ github.workflow }}"
+              fi
 
               # Create a Qase run, get its ID
               ID=$(cd tests && make create-qase-run)
-            
+
               # Export outputs for future use
               echo "qase_run_description=${QASE_DESC}" >> ${GITHUB_OUTPUT}
               echo "qase_run_id=${ID}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -177,8 +177,7 @@ jobs:
               export QASE_RUN_DESCRIPTION="${QASE_DESC}"
 
               # Use full rancher version
-              QASE_RUN_NAME=$(echo $QASE_RUN_NAME | awk -F'/' '{print $NF}' | \
-                grep -P -o '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?' || true)
+              QASE_RUN_NAME=$(echo $QASE_RUN_NAME | grep -P '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?' || true)
               # Or workflow name if the full rancher version is not found
               if [ -z "$QASE_RUN_NAME" ]; then
                 QASE_RUN_NAME="${{ github.workflow }}"


### PR DESCRIPTION
This PR will make CI to create a QASE test run containing full rancher version from `rancher_version` variable.

* By default it will keep the test run name as it was before like `UI-RM_head_2.7`.
* when you trigger CI manually by using `rancher_version` input containing full rancher version (not just `2.7-head`) like `latest/2.7.13-rc5` the QASE run will be named `2.7.13-rc5`, the rc/alpha suffix with dash is optional.

Run with the version:
https://github.com/rancher/fleet-e2e/actions/runs/9124386519
https://app.qase.io/run/FLEET/dashboard/493

Run without the version (failed but later):
https://github.com/rancher/fleet-e2e/actions/runs/9124497648
https://app.qase.io/run/FLEET/dashboard/494