### PR TITLE
Bumping gha to avoid annotation warnings

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -112,11 +112,11 @@ jobs:
           echo "uuid=${UUID//-}" >> ${GITHUB_OUTPUT}
           echo "runner=${GH_REPO//\//-}-ci-${UUID//-}" >> ${GITHUB_OUTPUT}
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.credentials }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Create runner
         run: |
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
@@ -233,7 +233,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: tests/go.mod
       - name: Install Node
@@ -346,11 +346,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.credentials }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Delete PAT token secrets
         run: |
           gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }} || true

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -235,6 +235,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
+          cache: false
           go-version-file: tests/go.mod
       - name: Install Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Bumping these Github actions...

`google-github-actions/auth@v1` -> `v2`
`google-github-actions/setup-gcloud@v1` -> `v2`
`actions/setup-go@v3` -> `v5`

... to avoid these warning on ci

![image](https://github.com/rancher/fleet-e2e/assets/37271841/60a8c274-3da7-4e7b-857c-ca579367fedb)
