### PR TITLE
Adding more Rbac standard user tests (43 and 44) with specifc verbs

### DIFF
--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -38,7 +38,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.createRoleTemplate({
         roleType: "Global",
         roleName: "fleetAllVerbsRole",
-        resources: [
+        rules: [
           { resource: "fleetworkspaces", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
           { resource: "gitrepos", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
           { resource: "bundles", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
@@ -47,7 +47,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
 
       // Assign role to the created user
       cy.assignRoleToUser(baseUser, "fleetAllVerbsRole");
-      
+
       // Logout as admin and login as other user
       cypressLib.logout();
       cy.login(baseUser, uiPassword);
@@ -78,7 +78,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.createRoleTemplate({
         roleType: "Global",
         roleName: customRoleName,
-        resources: [
+        rules: [
           { resource: "fleetworkspaces", verbs: ["list", "create"]},
           { resource: "gitrepos", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
           { resource: "bundles", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
@@ -108,7 +108,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
   )
 
   qase(44,
-    it('Test "Std-Base" user with custom roles to "fleetworkspaces" all verbs except "Delete can "edit" but not "delete" them', { tags: '@fleet-44' }, () => {
+    it('Test "Std-Base" user with custom role to "fleetworkspaces" all verbs except "delete can "edit" but not "delete" them', { tags: '@fleet-44' }, () => {
       
       const stduser = "std-user-44"
       const customRoleName = "fleetAllExceptDeleteFleetWorkspaces"
@@ -120,16 +120,16 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.createRoleTemplate({
         roleType: "Global",
         roleName: customRoleName,
-        resources: [
+        rules: [
           { resource: "fleetworkspaces", verbs: ["create", "get", "list", "patch", "update", "watch"]},
           { resource: "gitrepos", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
           { resource: "bundles", verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]},
         ]
       });
 
-      // // Assign role to the created user
+      // Assign role to the created user
       cy.assignRoleToUser(stduser, customRoleName)
-      
+
       // Logout as admin and login as other user
       cypressLib.logout();
       cy.login(stduser, uiPassword);
@@ -143,6 +143,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.verifyTableRow(0, 'Active', 'fleet-default');
       cy.verifyTableRow(1, 'Active', 'fleet-local');
       cy.open3dotsMenu('fleet-default', 'Edit Config');
+      cy.contains('allowedTargetNamespaces').should('be.visible');
       
       // What the user should NOT be able to access (once in Fleet Workspace menu)
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'Workspace');

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -28,7 +28,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
   const uiPassword    = "rancherpassword"
 
   qase(5,
-    it('Test "User-Base" user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access can access "Workspaces", "Bundles" and "Git Repos" but not to "Clusters" and "Clusters Groups"', { tags: '@fleet-5' }, () => {
+    it('Test "User-Base" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Clusters" NOR "Clusters Groups"', { tags: '@fleet-5' }, () => {
 
       // Create User "User-Base"
       cypressLib.burgerMenuToggle();
@@ -52,7 +52,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cypressLib.logout();
       cy.login(baseUser, uiPassword);
 
-      // What the user should be able to access
+      // What the user should be able to access / do
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.wait(500)
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'Workspaces');
@@ -66,10 +66,10 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
   )
 
   qase(43,
-    it('Test "Std-Base" user with custom role "list" and "create" to "fleetworkspaces" can list and create workspaces but NOT  "edit" nor "delete" them', { tags: '@fleet-43' }, () => {
+    it('Test "Standard Base" role user with "list" and "create" verbs for "fleetworkspaces" resource. User can NOT "edit" nor "delete" them', { tags: '@fleet-43' }, () => {
       
       const stduser = "std-user-43"
-      const customRoleName = "fleetListAndCreateRole"
+      const customRoleName = "fleetListAndCreateRoleOnFleetworkspaces"
 
       //  Create "Standard User"
       cypressLib.burgerMenuToggle();
@@ -92,7 +92,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cypressLib.logout();
       cy.login(stduser, uiPassword);
 
-      // What the user should be able to access
+      // What the user should be able to access / do
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.wait(500)
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'Bundles');
@@ -101,17 +101,17 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.verifyTableRow(1, 'Active', 'fleet-local');
       cy.get('a.btn.role-primary').contains('Create').should('be.visible');
       
-      // What the user should NOT be able to access
+      // Ensuring the user is not able to "edit" or "delete" workspaces.
       cy.open3dotsMenu('fleet-default', 'Delete', true);
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
     })
   )
 
   qase(44,
-    it('Test "Std-Base" user with custom role to "fleetworkspaces" all verbs except "delete can "edit" but not "delete" them', { tags: '@fleet-44' }, () => {
+    it('Test "Standard Base" role with custom role to "fleetworkspaces" with all verbs except "delete" can "edit" but can NOT "delete" them', { tags: '@fleet-44' }, () => {
       
       const stduser = "std-user-44"
-      const customRoleName = "fleetAllExceptDeleteFleetWorkspaces"
+      const customRoleName = "fleetAllExceptDeleteFleetOnFleetWorkspacesRole"
 
       // Create "Standard User"
       cypressLib.burgerMenuToggle();
@@ -134,7 +134,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cypressLib.logout();
       cy.login(stduser, uiPassword);
 
-      // What the user should be able to access
+      // What the user should be able to access / do
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.wait(1000)
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'Bundles');
@@ -145,7 +145,7 @@ describe('Test Fleet access with RBAC with custom roles', { tags: '@rbac' }, () 
       cy.open3dotsMenu('fleet-default', 'Edit Config');
       cy.contains('allowedTargetNamespaces').should('be.visible');
       
-      // What the user should NOT be able to access (once in Fleet Workspace menu)
+      // Ensuring the user is not able to "delete" workspaces. 
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'Workspace');
       cy.open3dotsMenu('fleet-default', 'Delete', true);
     })

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -247,7 +247,7 @@ Cypress.Commands.add('modifyDeployedApplication', (appName, clusterName='local')
 });
 
 // Create Role Template (User & Authentication)
-Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='No', verbs, rules, apiGroups, nonResourcesURLs}) => {
+Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='no', rules, apiGroups, nonResourcesURLs}) => {
 
   // // Access to user & authentication menu and create desired role template
   cy.accesMenuSelection('Users & Authentication', 'Role Templates');
@@ -258,19 +258,19 @@ Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUse
   cy.typeValue('Name', roleName);
 
   // Add new user default
-  if (newUserDefault === 'Yes') {
+  if (newUserDefault === 'yes') {
     cy.get('span[aria-label="Yes: Default role for new users"]').click();
   }
   
     // Addition of resources and verbs linked to resources
     // Each resource is an object with 2 keys: resource and verbs
-    rules.forEach((resource: { resource: string, verbs: string[] }, i) => {
+    rules.forEach((rule: { resource: string, verbs: string[] }, i) => {
       // Iterate over Resource cells and add 1 resource
       cy.get(`input.vs__search`).eq(2 * i + 1).click();
-      cy.contains(resource.resource, { matchCase: false }).should("exist").click();
+      cy.contains(rule.resource, { matchCase: false }).should("exist").click();
       cy.clickButton("Add Resource");
 
-        resource.verbs.forEach((verb) => {
+        rule.verbs.forEach((verb) => {
           cy.get(`input.vs__search`).eq(2 * i).click();
           cy.get(`ul.vs__dropdown-menu > li`).contains(verb).should("exist").click();
         });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -263,7 +263,7 @@ Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUse
   }
   
     // Addition of resources and verbs linked to resources
-    // Each resource is an object with 2 keys: resource and verbs
+    // Each rule is an object with 2 keys: resource and verbs
     rules.forEach((rule: { resource: string, verbs: string[] }, i) => {
       // Iterate over Resource cells and add 1 resource
       cy.get(`input.vs__search`).eq(2 * i + 1).click();

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -247,7 +247,7 @@ Cypress.Commands.add('modifyDeployedApplication', (appName, clusterName='local')
 });
 
 // Create Role Template (User & Authentication)
-Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='no', rules, apiGroups, nonResourcesURLs}) => {
+Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='no', rules}) => {
 
   // // Access to user & authentication menu and create desired role template
   cy.accesMenuSelection('Users & Authentication', 'Role Templates');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -153,16 +153,16 @@ Cypress.Commands.add('filterInSearchBox', (filterText) => {
 
 // Go to specific Sub Menu from Access Menu
 Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery',secondAccessMenu, clickOption) => {
-      cypressLib.burgerMenuToggle( {animationDistanceThreshold: 10} );
-      cy.contains(firstAccessMenu).should('be.visible')
-      cypressLib.accesMenu(firstAccessMenu);
-      if (secondAccessMenu) {
-        cy.contains(secondAccessMenu).should('be.visible')
-        cypressLib.accesMenu(secondAccessMenu);
-      };
-      if (clickOption) {
-        cy.get('nav.side-nav').contains(clickOption).should('be.visible').click();
-      };
+  cypressLib.burgerMenuToggle( {animationDistanceThreshold: 10} );
+  cy.contains(firstAccessMenu).should('be.visible')
+  cypressLib.accesMenu(firstAccessMenu);
+  if (secondAccessMenu) {
+    cy.contains(secondAccessMenu).should('be.visible')
+    cypressLib.accesMenu(secondAccessMenu);
+  };
+  if (clickOption) {
+    cy.get('nav.side-nav').contains(clickOption).should('be.visible').click();
+  };
 });
 
 // Fleet namespace toggle
@@ -247,7 +247,7 @@ Cypress.Commands.add('modifyDeployedApplication', (appName, clusterName='local')
 });
 
 // Create Role Template (User & Authentication)
-Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='No', verbs, resources, apiGroups, nonResourcesURLs}) => {
+Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUserDefault='No', verbs, rules, apiGroups, nonResourcesURLs}) => {
 
   // // Access to user & authentication menu and create desired role template
   cy.accesMenuSelection('Users & Authentication', 'Role Templates');
@@ -264,21 +264,17 @@ Cypress.Commands.add('createRoleTemplate', ({roleType='Global', roleName, newUse
   
     // Addition of resources and verbs linked to resources
     // Each resource is an object with 2 keys: resource and verbs
-    if (resources) {
-      resources.forEach((resource: { resource: string, verbs: string[] }, i) => {
-        // Iterate over Resource cells and add 1 resource
-        cy.get(`input.vs__search`).eq(2 * i + 1).click();
-        cy.contains(resource.resource, { matchCase: false }).should("exist").click();
-        cy.clickButton("Add Resource");
-  
-        if (resource.verbs) {
-          resource.verbs.forEach((verb) => {
-            cy.get(`input.vs__search`).eq(2 * i).click();
-            cy.get(`ul.vs__dropdown-menu > li`).contains(verb).should("exist").click();
-          });
-        }
-      });
-    }
+    rules.forEach((resource: { resource: string, verbs: string[] }, i) => {
+      // Iterate over Resource cells and add 1 resource
+      cy.get(`input.vs__search`).eq(2 * i + 1).click();
+      cy.contains(resource.resource, { matchCase: false }).should("exist").click();
+      cy.clickButton("Add Resource");
+
+        resource.verbs.forEach((verb) => {
+          cy.get(`input.vs__search`).eq(2 * i).click();
+          cy.get(`ul.vs__dropdown-menu > li`).contains(verb).should("exist").click();
+        });
+    });
 
   // "Hack" to get the button to be clickable
   cy.get('button.role-link').last().click()

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -35,7 +35,7 @@ declare global {
       checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;
-      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], verbs?: string[], resources?: string[], apiGroups?: string[], nonResourcesURLs?: string[] ): Chainable<Element>;
+      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], verbs?: string[], rules?: string[], apiGroups?: string[], nonResourcesURLs?: string[] ): Chainable<Element>;
       assignRoleToUser(userName: string, roleName: string): Chainable<Element>;
     }
   }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -35,7 +35,7 @@ declare global {
       checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;
-      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], rules?: string[], apiGroups?: string[], nonResourcesURLs?: string[] ): Chainable<Element>;
+      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], rules?: string[]): Chainable<Element>;
       assignRoleToUser(userName: string, roleName: string): Chainable<Element>;
     }
   }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -35,7 +35,7 @@ declare global {
       checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;
-      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], verbs?: string[], rules?: string[], apiGroups?: string[], nonResourcesURLs?: string[] ): Chainable<Element>;
+      createRoleTemplate(roleType: string, roleName: string, newUserDefault?: string['yes'|'no'], rules?: string[], apiGroups?: string[], nonResourcesURLs?: string[] ): Chainable<Element>;
       assignRoleToUser(userName: string, roleName: string): Chainable<Element>;
     }
   }


### PR DESCRIPTION
Implementation of [FLEET-43](https://app.qase.io/project/FLEET?previewMode=modal&suite=13&tab=&case=43) and [FLEET-44](https://app.qase.io/project/FLEET?previewMode=side&suite=13&tab=&case=44)

#### Additional implementations:
- Refactor of `createRoleTemplate` to add specific verbs per resource
- Further refactor of Fleet-5 to be compliant with previous refactor
- Other refactors to ensure test reliability