### PR TITLE
Bumping cypress-qase-reporter to 1.4.3

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -29,7 +29,7 @@
     "cypress-mochawesome-reporter": "^3.8.2",
     "cypress-multi-reporters": "^1.6.4",
     "cypress-plugin-tab": "^1.0.5",
-    "cypress-qase-reporter": "1.4.1",
+    "cypress-qase-reporter": "1.4.3",
     "dotenv": "^10.0.0",
     "typescript": "^4.5.2"
   },


### PR DESCRIPTION
Small bump to https://www.npmjs.com/package/cypress-qase-reporter/v/1.4.3

Normal ci 2.8: https://github.com/rancher/fleet-e2e/actions/runs/9317264575
