### PR TITLE
Tests for FLEET-64 and FLEET-65 testing helmRepoURLRegex feature

### DIFF
--- a/tests/assets/helm-server-with-auth-and-data.yaml
+++ b/tests/assets/helm-server-with-auth-and-data.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-helm-repo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-helm-repo
+  template:
+    metadata:
+      labels:
+        app: nginx-helm-repo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+            - name: auth
+              mountPath: /etc/nginx/conf.d/auth
+            - name: data
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: auth
+          secret:
+            secretName: nginx-auth
+        - name: config
+          configMap:
+            name: nginx-config
+        - name: data
+          configMap:
+            name: helm-repo-data
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location / {
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/conf.d/auth/htpasswd;
+        root /usr/share/nginx/html;
+        index index.yaml;
+        autoindex on;
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-auth
+type: Opaque
+data:
+  htpasswd: dXNlcjokYXByMSR4Tm1CVVFxVCRtWGJNazFGN0NFNmN1U01jWjVzY0gw # user:password
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx-helm-repo
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-repo-data
+data:
+  index.yaml: |
+    apiVersion: v1
+    entries:
+      app:
+        - name: app
+          version: 0.1.0
+          urls:
+            - app-0.1.0.tgz
+binaryData:
+  app-0.1.0.tgz: H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOyVsWrDMBCGPesp7gXinBxHAW8lS6G0Q4fuV/vSilrOYSmBEvLuRSkJOEMztE4o6Fskn43t4/7/F4lMl+/Uh/yTXJuNAiKiKcvDiojnK+pylunSFNqY2SLWtV7MywxwnN8ZsvGB+gx//a3z5v4JJPaFe2/XXQXbQpHI6RJznaNq2Ne9lXAo3cE9tw7qKBhYrXt42Lxy33FgrzpyXAGJqO3wDbduMfED0f9bajfsxwuAS/6P+6H/iwKL5P9rEOcf2ElLgf20Xncr++ZI/lQMF/PfzM/mXxqDaf7XYJD/Wn3YrqlgeZDBI4lyHKihQJUC+A743Q7yZ26ZPOdP5Bj2+8lJNur4rCcnLU9qVx238c7Edt42nE6ERCKRuD1fAQAA//9ZTKl3AA4AAA==

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -281,7 +281,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     const pwdOrPrivateKey = 'password'
     const gitOrHelmAuth = 'Helm'
     const gitAuthType = "http"
-    var helmUrlRegex
+    let helmUrlRegex
 
     const privateHelmData: testData[] = [
       { qase_id: 64,

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -270,6 +270,73 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
   });
 }
 
+// RepoURLRegex is supported on v2.8 but error reporting is not working correctly there
+// Ref. https://github.com/rancher/fleet/issues/2462 but it wont be fixed in v2.8
+if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
+  describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: '@p1'}, () => {
+
+    // So far using custom repo, we should expose fleet.yaml somewhere on fleet-qa-examples repo
+    const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'
+    const branch = 'main'
+    const userOrPublicKey = 'user'
+    const pwdOrPrivateKey = 'password'
+    const gitOrHelmAuth = 'Helm'
+    const gitAuthType = "http"
+    var helmUrlRegex
+
+    const privateHelmData: testData[] = [
+      { qase_id: 64,
+        repoName: "local-private-helm-repo-64",
+        path: 'helm-urlregex-repo',
+        test_explanation: 'repo',
+        helmUrlRegex_matching: '^http.*',
+      },
+      { qase_id: 65,
+        repoName: "local-private-helm-chart-65",
+        path: 'helm-urlregex-chart',
+        test_explanation: 'chart',
+        helmUrlRegex_matching: '^http.*app.*tgz$',
+      },
+    ]
+
+    // Actually just a preparation step
+    it("Prepare the private helm registry", { tags: '@preparation' }, () => {
+      cy.importYaml({ clusterName: 'local', yamlFilePath: 'assets/helm-server-with-auth-and-data.yaml' });
+      cy.nameSpaceMenuToggle('default');
+      // The check doesn't wait for Active state, only its presence
+      cy.checkApplicationStatus('nginx-helm-repo');
+      // We keep the resources in cluster forever
+    });
+
+    privateHelmData.forEach(
+      ({qase_id, repoName, path, helmUrlRegex_matching, test_explanation}) => {
+        qase(qase_id,
+          it(`Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`, { tags: '@fleet-64' }, () => {;
+            // Positive test using matching regex
+            helmUrlRegex = helmUrlRegex_matching
+            cy.fleetNamespaceToggle('fleet-local');
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex });
+            cy.clickButton('Create');
+            cy.verifyTableRow(0, 'Active', /([1-9]\d*)\/\1/);
+            cy.accesMenuSelection('local', 'Storage', 'ConfigMaps');
+            cy.nameSpaceMenuToggle('All Namespaces');
+            cy.filterInSearchBox('local-chart-configmap');
+            cy.wait(2000);
+            cy.get('.col-link-detail').contains('local-chart-configmap').should('be.visible').click({ force: true });
+            cy.get('section#data').should('contain', 'sample-cm').and('contain', 'sample-data-inside');
+            cy.deleteAllFleetRepos();
+            // Negative test using non-matching regex 1234.*
+            helmUrlRegex = '1234.*'
+            cy.fleetNamespaceToggle('fleet-local');
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex });
+            cy.clickButton('Create');
+            cy.get('.text-error', { timeout: 120000 }).should('contain', 'code: 401');
+            cy.deleteAllFleetRepos();
+          })
+        )
+      })
+  });
+}
 
   describe('Test OCI support', { tags: '@p1'}, () => {
     qase(60,

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -275,7 +275,6 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
 if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
   describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: '@p1'}, () => {
 
-    // So far using custom repo, we should expose fleet.yaml somewhere on fleet-qa-examples repo
     const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'
     const branch = 'main'
     const userOrPublicKey = 'user'
@@ -311,7 +310,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     privateHelmData.forEach(
       ({qase_id, repoName, path, helmUrlRegex_matching, test_explanation}) => {
         qase(qase_id,
-          it(`Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`, { tags: '@fleet-64' }, () => {;
+          it(`Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`, { tags: `@fleet-${qase_id}` }, () => {;
             // Positive test using matching regex
             helmUrlRegex = helmUrlRegex_matching
             cy.fleetNamespaceToggle('fleet-local');

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -22,7 +22,7 @@ declare global {
       // Functions declared in commands.ts
       open3dotsMenu(name: string, selection?: string, checkNotInMenu?: boolean): Chainable<Element>;
       addPathOnGitRepoCreate(path: string): Chainable<Element>;
-      gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string): Chainable<Element>;
+      gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string, helmUrlRegex?: string): Chainable<Element>;
       addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string, fleetNamespace?: string): Chainable<Element>;
       fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
       verifyTableRow(rowNumber: number, expectedText1?: string, expectedText2?: string|RegExp): Chainable<Element>;
@@ -39,6 +39,7 @@ declare global {
       assignRoleToUser(userName: string, roleName: string): Chainable<Element>;
       deleteUser(userName: string): Chainable<Element>;
       deleteRole(roleName: string, roleTypeTemplate: string): Chainable<Element>;
+      importYaml(clusterName: string, yamlFilePath: string): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
### Two cases automated
* FLEET-64 is testing helmRepoURLRegex matching the helm repo URL via this [fleet.yaml](https://github.com/fleetqa/fleet-qa-examples-public/blob/main/helm-urlregex-repo/fleet.yaml)
* FLEET-65 is testing helmRepoURLRegex matching the full helm chart URL without involving helm repo via this [fleet.yaml](https://github.com/fleetqa/fleet-qa-examples-public/blob/main/helm-urlregex-chart/fleet.yaml)

Both tests are using positive (the regexp matches) and negative (regexp doesn't match) testing. The tests are designed to be working on **local cluster only** and will be executed **only on Rancher:2.9**.

Both cases are using local (deployed on the cluster under test) helm registry and simple helm chart stored there. The needed local helm registry and its resources are deployed by using new `importYaml` function.

Testrun on v2.9 scheduled here: https://github.com/rancher/fleet-e2e/actions/runs/9320045815
![image](https://github.com/rancher/fleet-e2e/assets/12828077/acbb443e-4da1-4e88-9eab-731668d809e2)

(The CI check triggered by this PR is irrelevant as the tests are not executed on v2.8)