### PR TITLE
qase reporter back to 1.4.1

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -29,7 +29,7 @@
     "cypress-mochawesome-reporter": "^3.8.2",
     "cypress-multi-reporters": "^1.6.4",
     "cypress-plugin-tab": "^1.0.5",
-    "cypress-qase-reporter": "1.4.3",
+    "cypress-qase-reporter": "1.4.1",
     "dotenv": "^10.0.0",
     "typescript": "^4.5.2"
   },


### PR DESCRIPTION
The newer version is not compatible with go reporter so we need to stick on 1.4.1