### PR TITLE
Fleet qa/rbac std users 46 47 48 50

### DIFF
--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -300,7 +300,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
     cy.checkGitRepoStatus(repoNameDefault, '1 / 1', '1 / 1');
   })
 
-  before ('Preparing Role Templates', () => {
+  before('Preparing Role Templates', () => {
     cy.login();
     // Create Custom Roles
     cy.createRoleTemplate({
@@ -384,14 +384,15 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
       cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
       
-      // CHECKS IN  FLEET-DEFAULT
+      // CHECKS IN FLEET-DEFAULT
       // Can't "Create", "Edit" nor "Delete"
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.get('.btn.role-primary').contains('Add Repository').should('not.exist');
       // Note: listing is checked implictly here
       cy.open3dotsMenu(repoNameDefault, 'Edit Config', true);
       cy.open3dotsMenu(repoNameDefault, 'Delete', true);
-      // CHECKS IN  FLEET-DEFAULT
+      
+      // CHECKS IN FLEET-DEFAULT
       // Can't "Create", "Edit" nor "Delete"
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
@@ -420,7 +421,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
       cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
 
-      // CHECKS IN  FLEET-DEFAULT
+      // CHECKS IN FLEET-DEFAULT
       // CAN "Create" repos
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.clickButton('Add Repository');
@@ -430,7 +431,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.open3dotsMenu(repoNameDefault, 'Edit Config', true);
       cy.open3dotsMenu(repoNameDefault, 'Delete', true);
       
-      // CHECKS IN  FLEET-LOCAL
+      // CHECKS IN FLEET-LOCAL
       // Can't "Edit" nor "Delete" repos
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
@@ -460,7 +461,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
       cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
       
-      // CHECKS IN  FLEET-DEFAULT
+      // CHECKS IN FLEET-DEFAULT
       // CAN "Create" and "Edit"
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.clickButton('Add Repository');
@@ -468,15 +469,15 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.clickButton('Cancel');
       cy.open3dotsMenu(repoNameDefault, 'Edit Config');
       cy.clickButton('Cancel');
-      // Can`t "Delete"
+      // Can't "Delete"
       cy.open3dotsMenu(repoNameDefault, 'Delete', true);
 
-      // CHECKS IN  FLEET-LOCAL
+      // CHECKS IN FLEET-LOCAL
       cy.fleetNamespaceToggle('fleet-local');
       // CAN "Edit"
       cy.open3dotsMenu(repoName, 'Edit Config');
       cy.clickButton('Cancel');
-      // Can`t "Delete"
+      // Can't "Delete"
       cy.open3dotsMenu(repoName, 'Delete', true);
     })
   )
@@ -500,8 +501,9 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
       cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
-      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');      
-      // CHECKS IN  FLEET-DEFAULT
+      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
+
+      // CHECKS IN FLEET-DEFAULT
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');       
       // Can't "Create" repos    
       cy.get('.btn.role-primary').contains('Add Repository').should('not.exist');
@@ -511,7 +513,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.open3dotsMenu(repoNameDefault, 'Delete');
       cy.clickButton('Cancel');
 
-      // CHECKS IN  FLEET-LOCAL
+      // CHECKS IN FLEET-LOCAL
       cy.fleetNamespaceToggle('fleet-local');
       // CAN "Delete"
       cy.open3dotsMenu(repoName, 'Delete');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -311,6 +311,7 @@ Cypress.Commands.add('deleteUser', (userName) => {
   cy.accesMenuSelection('Users & Authentication');
   cy.contains('.title', 'Users').should('be.visible');
   cy.filterInSearchBox(userName);
+  cy.wait(250); // Add small wait to allow typing to conclude
   cy.deleteAll(false);
 })
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -167,7 +167,7 @@ Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery
     cy.get('nav.side-nav').contains(clickOption).should('be.visible').click();
   };
   // Ensure some title exist to proof the menu is loaded
-  cy.get('.m-0').should('exist').and('not.be.empty');
+  cy.get('div.title').eq(1).should('exist').and('not.be.empty');
 });
 
 // Fleet namespace toggle

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -101,6 +101,8 @@ Cypress.Commands.add('open3dotsMenu', (name, selection, checkNotInMenu=false) =>
         cy.get('ul.list-unstyled.menu').contains(selection).should('not.exist')
       }        
     });
+    // Close 3 dots button menu
+    cy.get('.background').should('exist').click({ force: true });
   }
   
   else if (selection) {
@@ -109,7 +111,7 @@ Cypress.Commands.add('open3dotsMenu', (name, selection, checkNotInMenu=false) =>
     cy.get('.list-unstyled.menu > li > span', { timeout: 15000 }).contains(selection).click({ force: true });
     // Ensure dropdown is not present
     cy.contains('Edit Config').should('not.exist')
-  }
+    }
 });
 
 // Verify textvalues in table giving the row number
@@ -164,6 +166,8 @@ Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery
   if (clickOption) {
     cy.get('nav.side-nav').contains(clickOption).should('be.visible').click();
   };
+  // Ensure some title exist to proof the menu is loaded
+  cy.get('.m-0').should('exist').and('not.be.empty');
 });
 
 // Fleet namespace toggle
@@ -181,7 +185,6 @@ Cypress.Commands.add('deleteAll', (fleetCheck=true) => {
     if ($body.text().includes('Delete')) {
       cy.get('[width="30"] > .checkbox-outer-container.check', { timeout: 50000 }).click();
       cy.get('.btn').contains('Delete').click({ctrlKey: true});
-      cy.get('.btn', { timeout: 20000 }).contains('Delete').should('not.exist');
       if (fleetCheck === true) {
         cy.contains('No repositories have been added', { timeout: 20000 }).should('be.visible')
       } else {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -183,6 +183,7 @@ Cypress.Commands.add('deleteAll', (fleetCheck=true) => {
   const noRowsMessages = ['There are no rows to show.', 'There are no rows which match your search query.']
   cy.get('body').then(($body) => {
     if ($body.text().includes('Delete')) {
+      cy.wait(250) // Add small wait to give time for things to settle
       cy.get('[width="30"] > .checkbox-outer-container.check', { timeout: 50000 }).click();
       cy.get('.btn').contains('Delete').click({ctrlKey: true});
       if (fleetCheck === true) {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -111,7 +111,7 @@ Cypress.Commands.add('open3dotsMenu', (name, selection, checkNotInMenu=false) =>
     cy.get('.list-unstyled.menu > li > span', { timeout: 15000 }).contains(selection).click({ force: true });
     // Ensure dropdown is not present
     cy.contains('Edit Config').should('not.exist')
-    }
+  }
 });
 
 // Verify textvalues in table giving the row number


### PR DESCRIPTION
Implementation of tests: [Fleet-46](https://app.qase.io/case/FLEET-46), [Fleet-47](https://app.qase.io/case/FLEET-47), [Fleet-48](https://app.qase.io/case/FLEET-48), [Fleet-50](https://app.qase.io/case/FLEET-50)

**Quick summary:**
- Fleet-46: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List] 
- Fleet-47: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create] 
- Fleet-48: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create, Update, Get]
- Fleet-50: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Delete] 
---
### Done:
- Created `before` hook within `Describe` to add gitrepos to be used in all test cases
- Test implementation. Done in 2 ways
  - With the `createRoleTemplate` per it (as until now)
  - Using another `before` hook where this work is done in 1 piece. PLEASE LET ME KNOW IF YOU LIKE THIS STRUCTURE. The idea behind it is, if we like it, would be to implement it as before hook for all rbac test cases in another pr
- Created an `after` hook to delete all gitrepos, custom roles and users in 1 step. 
- Other minor refactors to provide either more stability or to solve other issues.
- Name refactoring, much simpler.
- Improved order and legibility of items that the user can / can't do depending on the case

### Additional notes
- I found the hook `after` is a bit tricky. I noticed that if for some reason fails, the last test fails also with it. It should be used with care.
- I'm in doubt if in the end this implementation is better. For one thing, it would definitively will help save code by reusing created roles. On the other side it makes it a bit more complex to read and find what we are using and it is not scoped per case. This means that if something is wrong in the hook, several tests may be affected. It also means a bit of more potential work needed when using it locally (for things like commenting outs).
