### PR TITLE
Fixing 2.7 ci

### DIFF
--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -524,7 +524,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.', { tags: '@rbac' }, () => {
   qase(39,
     it('Test "GitRepoRestrictions" on non-existent namespace throws error in the UI', { tags: '@fleet-39' }, () => {
-      cy.deleteAllFleetRepos();
+
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
       cy.clickButton('Create from YAML');
       cy.readFile('assets/git-repo-restrictions-non-exists-ns.yaml').then((content) => {
@@ -547,7 +547,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.
       const repoUrl = "https://github.com/rancher/fleet-test-data/"
       const appName = 'nginx-keep'
       const allowedTargetNamespace = 'allowed-namespace'
-      cy.deleteAllFleetRepos();
+
       // Create GitRepoRestrictions with allowedTargetNamespace
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
       cy.clickButton('Create from YAML');

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -381,8 +381,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
-      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
+      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
       
       // CHECKS IN FLEET-DEFAULT
       // Can't "Create", "Edit" nor "Delete"
@@ -418,8 +417,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
-      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
+      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
 
       // CHECKS IN FLEET-DEFAULT
       // CAN "Create" repos
@@ -458,8 +456,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
-      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
+      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
       
       // CHECKS IN FLEET-DEFAULT
       // CAN "Create" and "Edit"
@@ -500,8 +497,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
-      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
+      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
 
       // CHECKS IN FLEET-DEFAULT
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');       
@@ -528,6 +524,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.', { tags: '@rbac' }, () => {
   qase(39,
     it('Test "GitRepoRestrictions" on non-existent namespace throws error in the UI', { tags: '@fleet-39' }, () => {
+      cy.deleteAllFleetRepos();
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
       cy.clickButton('Create from YAML');
       cy.readFile('assets/git-repo-restrictions-non-exists-ns.yaml').then((content) => {
@@ -550,7 +547,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.
       const repoUrl = "https://github.com/rancher/fleet-test-data/"
       const appName = 'nginx-keep'
       const allowedTargetNamespace = 'allowed-namespace'
-
+      cy.deleteAllFleetRepos();
       // Create GitRepoRestrictions with allowedTargetNamespace
       cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
       cy.clickButton('Create from YAML');

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -381,7 +381,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
+      cy.get('div.fleet-dashboard-data').should('contain', repoName).and('contain', repoNameDefault);
       
       // CHECKS IN FLEET-DEFAULT
       // Can't "Create", "Edit" nor "Delete"
@@ -417,7 +417,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
+      cy.get('div.fleet-dashboard-data').should('contain', repoName).and('contain', repoNameDefault);
 
       // CHECKS IN FLEET-DEFAULT
       // CAN "Create" repos
@@ -456,7 +456,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
+      cy.get('div.fleet-dashboard-data').should('contain', repoName).and('contain', repoNameDefault);
       
       // CHECKS IN FLEET-DEFAULT
       // CAN "Create" and "Edit"
@@ -497,7 +497,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
 
       // CAN go to Continuous Delivery Dashboard and "list" gitrepos
       cy.accesMenuSelection('Continuous Delivery', 'Dashboard');
-      cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
+      cy.get('div.fleet-dashboard-data').should('contain', repoName).and('contain', repoNameDefault);
 
       // CHECKS IN FLEET-DEFAULT
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');       

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -197,7 +197,7 @@ Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery
     cy.get('nav.side-nav').contains(clickOption).should('be.visible').click();
   };
   // Ensure some title exist to proof the menu is loaded
-  cy.get('div.title').eq(1).should('exist').and('not.be.empty');
+  cy.get('div.title').last().should('exist').and('not.be.empty');
 });
 
 // Fleet namespace toggle


### PR DESCRIPTION
Done

## Fix 1

On last pr, I introduced [here](https://github.com/rancher/fleet-e2e/pull/144/files#diff-75965941f29be613c2bab5bdb432b711b86c52a2567d7f08dcf8aaeef907eb0cR200) a locator pointing to 2nd title to ensure page was loaded on `Continuous Delivery` option. Namely, this one:
```ts
cy.get('div.title').eq(1).should('exist').and('not.be.empty');
```
While the locator (`div.title`) is correct for all 3 versions (2.7,2.8,2.9), in 2.7 there is only 1 repetition of this locator IF the left menu is hidden, while in 2.8 and 2.9 there are 2 (hence the `eq(2)`). 

See on 2.7 2 locators of `div.title` with menu unfolded...
![image](https://github.com/rancher/fleet-e2e/assets/37271841/7937a027-d8b7-4548-8fe0-567df30b8048)
...and only 1 if menu is folded:
![image](https://github.com/rancher/fleet-e2e/assets/37271841/b1889c1e-40df-4774-ad5f-f4340451bbf7)


This has caused major failures on [last 2.7 ci](https://github.com/rancher/fleet-e2e/actions/runs/9459472790/job/26062224215#step:9:595), making many tests (18) not to be executed.



I fixed this by changing it to `last()` which should work in all 3.

## Fix 2
Locator [update](https://github.com/rancher/fleet-e2e/compare/main...fleet-qa/fix-27-ci#diff-c733a0f238ad319801716baec570bf81ca21890d58cd0dab2ee570ecdd1db379L384) for `2.7` for tests 46-50:

From:
```ts
cy.get("div[data-testid='collapsible-card-fleet-local']").contains(repoName).should('be.visible');
      cy.get("div[data-testid='collapsible-card-fleet-default']").contains(repoNameDefault).should('be.visible');
``` 
To:
```ts
cy.get('div.fleet-dashboard-data').should('contain',repoName).and('contain',repoNameDefault);
```
 
## Fix 3
~~Adding gitrepo cleansing mechanism for tests after Fleet-50. Tests 46-50 create 2 gitrepos. They have a cleansing mechanism at the end. If the test goes well, it removes the repos. If it doesn't like [here](https://github.com/rancher/fleet-e2e/actions/runs/9464775982/job/26073942434#step:9:405), then [following](https://github.com/rancher/fleet-e2e/actions/runs/9464775982/job/26073942434#step:9:409) tests may be affected.~~
~~I added a `deleteAllFleetRepos` before tests 39 and 40 to help mitigate this.~~

Edit: Undone Fix 3 since it will be tackled [here](https://github.com/rancher/fleet-e2e/pull/147/files#diff-c733a0f238ad319801716baec570bf81ca21890d58cd0dab2ee570ecdd1db379R538) on different pr

---
## CI
[2.9](https://github.com/rancher/fleet-e2e/actions/runs/9464780303/job/26072988350) was ok
[2.8](https://github.com/rancher/fleet-e2e/actions/runs/9464768764/job/26072963303#step:9:483) ok as well. 1 hiccup unrelated
[2.7](https://github.com/rancher/fleet-e2e/actions/runs/9464775982/job/26073942434#step:9:539) ok; 5 last RBAC test failings on 1st round. All Rbac tests ok on 2nd round [here](https://github.com/rancher/fleet-e2e/actions/runs/9466922744/job/26079777771) after fixes 2 & 3