### PR TITLE
Regexp support cy.verifyTableRow

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -154,18 +154,18 @@ Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2)
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
     .children({ timeout: 60000 })
-    .should('contain', expectedText1 )
-    // Check if expectedText2 is a RegExp or a string
-    .then(() => {
-      if (expectedText2 instanceof RegExp) {
-        cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
-          .children({ timeout: 60000 })
-          .invoke('text')
-          .should('match', expectedText2);
+    .then(($children) => {
+      // Decide if the text is a RegExp or a string
+      const tableRow = $children.text();
+      if (expectedText1 instanceof RegExp) {
+        expect(tableRow).to.match(expectedText1);
       } else {
-        cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
-          .children({ timeout: 60000 })
-          .should('contain', expectedText2);
+        expect(tableRow).to.contain(expectedText1);
+      }
+      if (expectedText2 instanceof RegExp) {
+        expect(tableRow).to.match(expectedText2);
+      } else {
+        expect(tableRow).to.contain(expectedText2);
       }
     });
 });
@@ -332,7 +332,8 @@ Cypress.Commands.add('assignRoleToUser', (userName, roleName) => {
   cy.clickButton('Save');
   // Sortering by Age so first row is the desired user
   cy.contains('Age').should('be.visible').click();
-  cy.verifyTableRow(0,'Active', userName);
+  // Since v2.7.14-rc3 and v2.8.5-rc3 the State is Enabled instead of Active in v2.X-head
+  cy.verifyTableRow(0, /Active|Enabled/ , userName);
 })
 
 // Delete created user

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -154,20 +154,30 @@ Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2)
   cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
   cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
     .children({ timeout: 60000 })
-    .then(($children) => {
-      // Decide if the text is a RegExp or a string
-      const tableRow = $children.text();
-      if (expectedText1 instanceof RegExp) {
-        expect(tableRow).to.match(expectedText1);
-      } else {
-        expect(tableRow).to.contain(expectedText1);
-      }
-      if (expectedText2 instanceof RegExp) {
-        expect(tableRow).to.match(expectedText2);
-      } else {
-        expect(tableRow).to.contain(expectedText2);
-      }
-    });
+    .then(() => {
+    // Check if expectedText1 is a regular expression or a string
+    if (expectedText1 instanceof RegExp) {
+      cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+        .children({ timeout: 60000 })
+        .invoke('text')
+        .should('match', expectedText1);
+    } else {
+      cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+        .children({ timeout: 60000 })
+        .should('contain', expectedText1);
+    }
+    // Check if expectedText2 is a regular expression or a string
+    if (expectedText2 instanceof RegExp) {
+      cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+        .children({ timeout: 60000 })
+        .invoke('text')
+        .should('match', expectedText2);
+    } else {
+      cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`)
+        .children({ timeout: 60000 })
+        .should('contain', expectedText2);
+    }
+   });
 });
 
 // Namespace Toggle

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -25,7 +25,7 @@ declare global {
       gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string, helmUrlRegex?: string): Chainable<Element>;
       addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string, fleetNamespace?: string): Chainable<Element>;
       fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
-      verifyTableRow(rowNumber: number, expectedText1?: string, expectedText2?: string|RegExp): Chainable<Element>;
+      verifyTableRow(rowNumber: number, expectedText1?: string|RegExp, expectedText2?: string|RegExp): Chainable<Element>;
       nameSpaceMenuToggle(namespaceName: string): Chainable<Element>;
       accesMenuSelection(firstAccessMenu: string, secondAccessMenu?: string, clickOption?: string): Chainable<Element>;
       filterInSearchBox(filterText: string): Chainable<Element>;


### PR DESCRIPTION
From rancher version `v2.7.14-rc3` and `v2.8.5-rc3` the State of user is `Enabled` instead of `Active` in v2.X-head. 

So far we need to support both user states so I introduced regexp support for both text field in `verifyTableRow` function.