### PR TITLE
Fix failing test due to Force Update

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -411,7 +411,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
 
             // Add GitRepo by enabling 'correctDrift'
             cy.fleetNamespaceToggle('fleet-default')
-            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift: 'yes' });
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift: 'yes', deployToTarget: dsClusterName });
             cy.clickButton('Create');
             cy.checkGitRepoStatus(repoName, '2 / 2', '2 / 2');
             cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -78,10 +78,12 @@ Cypress.Commands.add('importYaml', ({ clusterName, yamlFilePath }) => {
 
 // Command add and edit Fleet Git Repository
 // TODO: Rename this command name to 'addEditFleetGitRepo'
-Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, keepResources, correctDrift, fleetNamespace='fleet-local', editConfig=false, helmUrlRegex }) => {
+Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, keepResources, correctDrift, fleetNamespace='fleet-local', editConfig=false, helmUrlRegex, deployToTarget }) => {
   cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
   if (editConfig === true) {
     cy.fleetNamespaceToggle(fleetNamespace);
+    // Adding wait for loading GitRepo after namespace toggle.
+    cy.wait(500);
     // After deployment modification, GitRepo is in 'modified' state.
     // Force update is required to make it active before editing.
     cy.open3dotsMenu(repoName, 'Force Update');
@@ -114,6 +116,17 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, gitO
   }
   cy.clickButton('Next');
   cy.get('button.btn').contains('Previous').should('be.visible');
+  // Target to any cluster or group or no cluster.
+  if (deployToTarget) {
+    cy.deployToClusterOrClusterGroup(deployToTarget);
+  }
+});
+
+// Deploy To target functionality used in addGitRepo
+Cypress.Commands.add('deployToClusterOrClusterGroup', (deployToTarget) => {
+  cy.get('div.labeled-select.create.hoverable').should('be.visible');
+  cy.get('div.labeled-select.create.hoverable').click({ force: true });
+  cy.get('ul.vs__dropdown-menu > li').contains(deployToTarget).should("exist").click();
 });
 
 // 3 dots menu selection

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -40,6 +40,7 @@ declare global {
       deleteUser(userName: string): Chainable<Element>;
       deleteRole(roleName: string, roleTypeTemplate: string): Chainable<Element>;
       importYaml(clusterName: string, yamlFilePath: string): Chainable<Element>;
+      deployToClusterOrClusterGroup(deployToTarget: string): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
- Restricting `Fleet-77` `GitRepo` deployment to single cluster (`imported-0`)
- Added `wait` to execute `Force Update` before editing GitRepo for modification.