### PR TITLE
Always check resources of gitrepo by regexp

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -40,7 +40,7 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@p0' }, () => {
       cy.fleetNamespaceToggle('fleet-local');
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
       cy.verifyTableRow(1, 'Service', 'frontend');
       cy.verifyTableRow(3, 'Service', 'redis-master');
       cy.verifyTableRow(5, 'Service', 'redis-slave');
@@ -70,7 +70,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' 
         cy.fleetNamespaceToggle('fleet-default')
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
-        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+        cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();
       })
@@ -99,12 +99,10 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
         cy.fleetNamespaceToggle('fleet-default')
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
-        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+        cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();
       })
     );
   });
 });
-
-

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -121,7 +121,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
           cy.fleetNamespaceToggle('fleet-local')
           cy.addFleetGitRepo({ repoName, repoUrl, branch, path, keepResources });
           cy.clickButton('Create');
-          cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+          cy.checkGitRepoStatus(repoName, '1 / 1');
           cy.checkApplicationStatus(appName);
           cy.deleteAllFleetRepos();
           if (keepResources === 'yes') {
@@ -153,7 +153,7 @@ describe('Test Self-Healing of resource modification when correctDrift option us
           cy.fleetNamespaceToggle('fleet-local')
           cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift });
           cy.clickButton('Create');
-          cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+          cy.checkGitRepoStatus(repoName, '1 / 1');
           cy.checkApplicationStatus(appName);
 
           // Modify deployment count of application
@@ -180,7 +180,7 @@ describe('Test Self-Healing of resource modification when correctDrift option us
       cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
       cy.checkApplicationStatus(appName);
 
       // Modify deployment count of application
@@ -194,7 +194,7 @@ describe('Test Self-Healing of resource modification when correctDrift option us
       cy.clickButton('Save');
       // This test is exception for using 'Force Update'.
       cy.open3dotsMenu(repoName, 'Force Update');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
       cy.checkApplicationStatus(appName);
 
       // Modify deployment count of application
@@ -215,14 +215,14 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       cy.fleetNamespaceToggle('fleet-local')
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
       cy.checkApplicationStatus(appName);
 
       // Edit existing GitRepo with 'keepResource: true' to prevent
       // application removal after GitRepo delete.
       cy.addFleetGitRepo({ repoName, keepResources: 'yes', editConfig: true });
       cy.clickButton('Save');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
 
       // Delete GitRepo to check application removed or not.
       cy.deleteAllFleetRepos();
@@ -413,7 +413,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
             cy.fleetNamespaceToggle('fleet-default')
             cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift: 'yes' });
             cy.clickButton('Create');
-            cy.checkGitRepoStatus(repoName, '2 / 2', '2 / 2');
+            cy.checkGitRepoStatus(repoName, '2 / 2');
             cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
             cy.nameSpaceMenuToggle(resourceNamespace);
             cy.filterInSearchBox(resourceName);

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -267,13 +267,13 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.fleetNamespaceToggle('fleet-local');
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
   
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       cy.fleetNamespaceToggle('fleet-default');
       cy.addFleetGitRepo({ repoName: repoNameDefault, repoUrl, branch, path: pathDefault });
       cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoNameDefault, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoNameDefault, '1 / 1');
     })
     
   qase(46,
@@ -743,7 +743,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.
       cy.get('input[placeholder="Optional: Require all resources to be in this namespace"]').type(allowedTargetNamespace);
       cy.clickButton('Create');
       cy.verifyTableRow(0, 'Active', repoName);
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
 
       // Verify application is created in allowed namespace.
       cy.accesMenuSelection('local', 'Workloads', 'Pods');
@@ -793,7 +793,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo applicaiton deployment.
       cy.get('input[placeholder="Optional: Require all resources to be in this namespace"]').type(allowedTargetNamespace);
       cy.clickButton('Save');
       cy.verifyTableRow(0, 'Active', repoName);
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
 
       // Verify application is created in allowed namespace.
       cy.accesMenuSelection('local', 'Workloads', 'Pods');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -251,9 +251,12 @@ Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles) => {
     cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 30000 }).should('be.visible')
     // Since v2.9 the Resources are multiplied by the number of clusters
     // So we always check Resources presence and if both numbers match (like 2 / 2 Resources ready)
-    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).invoke('text')
-    .then((text) => text.replace(/\s+/g, ' ')) // Replace all whitespaces by a space
-    .should('match', /.*([1-9]\d*) \/ \1 Resources ready/);
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).should(($div) => {
+      // Replace whitespaces by a space and trim the string
+      const text = $div.text().replace(/\s+/g, ' ').trim();
+      // Perform the match check within .should callback as .then breaks retry ability
+      expect(text).to.match(/.*([1-9]\d*) \/ \1 Resources ready/);
+    });
   }
 });
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -242,16 +242,18 @@ Cypress.Commands.add('deleteAllFleetRepos', () => {
 });
 
 // Check Git repo deployment status
-Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources) => {
+Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles) => {
   cy.verifyTableRow(0, 'Active', repoName);
   cy.contains(repoName).click()
   cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
-  cy.log(`Checking ${bundles} Bundles and ${resources} Resources`)
+  cy.log(`Checking ${bundles} Bundles and Resources`)
   if (bundles) {
     cy.get('div.fleet-status', { timeout: 30000 }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: 30000 }).should('be.visible')
-  }
-  if (resources) {
-    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).contains(` ${resources} Resources ready `, { timeout: 30000 }).should('be.visible')
+    // Since v2.9 the Resources are multiplied by the number of clusters
+    // So we always check Resources presence and if both numbers match (like 2 / 2 Resources ready)
+    cy.get('div.fleet-status', { timeout: 30000 }).eq(1).invoke('text')
+    .then((text) => text.replace(/\s+/g, ' ')) // Replace all whitespaces by a space
+    .should('match', /.*([1-9]\d*) \/ \1 Resources ready/);
   }
 });
 

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -31,7 +31,7 @@ declare global {
       filterInSearchBox(filterText: string): Chainable<Element>;
       deleteAll(fleetCheck?: boolean): Chainable<Element>;
       deleteAllFleetRepos(): Chainable<Element>;
-      checkGitRepoStatus(repoName: string, bundles?: string, resources?: string): Chainable<Element>;
+      checkGitRepoStatus(repoName: string, bundles?: string): Chainable<Element>;
       checkApplicationStatus(appName: string, clusterName?: string): Chainable<Element>;
       deleteApplicationDeployment(clusterName?: string): Chainable<Element>;
       modifyDeployedApplication(appName: string, clusterName?: string): Chainable<Element>;


### PR DESCRIPTION
Fix for v2.9 - `checkGitRepoStatus` and its calls were simplified - we will always check whether gitrepo Resources are present and their numbers match ( `ready / expected Resources Ready` ).

Edit: originally it was using .then() but it was breaking cy retry ability so I had to switch to .should(callback) way and then within the callback I could use jQuery to manipulate the div object and also do the assertion by expect from jQuery. This approach can be probably used here and there and could help us to avoid wait().