### PR TITLE
Remove check on active / modified state due to new icon in 2.9

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -350,8 +350,8 @@ Cypress.Commands.add('assignRoleToUser', (userName, roleName) => {
   cy.clickButton('Save');
   // Sortering by Age so first row is the desired user
   cy.contains('Age').should('be.visible').click();
-  // Since v2.7.14-rc3 and v2.8.5-rc3 the State is Enabled instead of Active in v2.X-head
-  cy.verifyTableRow(0, /Active|Enabled/ , userName);
+  // Verifying name only given in 2.9 there is only icon
+  cy.verifyTableRow(0, userName, '');
 })
 
 // Delete created user


### PR DESCRIPTION
Adapting tests to pass rbac in [2.9](https://github.com/rancher/fleet-e2e/actions/runs/9738013264/job/26870958510#step:9:444) after removal of text `enabled|modified`

![image](https://github.com/rancher/fleet-e2e/assets/37271841/856dd48a-3fb1-4f84-b463-70314becb0bd)



