### PR TITLE
Fix 2.9 tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -439,14 +439,32 @@ describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled'
           cy.clickButton('Save');
           cy.filterInSearchBox(resourceName);
           cy.verifyTableRow(0, resourceName, dataToAssert);
+
+          // Adding more wait for 30seconds to capture the error if occurred after modifying the resources.
+          cy.wait(30000);
+          cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+          cy.verifyTableRow(0, 'Active', repoName);
+
+          // Check All clusters are in healthy state after performing any modification to the resources.
+          dsClusterList.forEach((dsClusterName) => {
+            // Adding wait to load page correctly to avoid interference with hamburger-menu.
+            cy.wait(500);
+            cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+            cy.contains('.title', 'Clusters').should('be.visible');
+            cy.filterInSearchBox(dsClusterName);
+            cy.verifyTableRow(0, 'Active', dsClusterName);
+          })
+
           // Any mutable resource will reconcile to it's original state immediately
-          // But with ConfigMaps and Services it is not because they are immutable i.e.
-          // They didn't reconciled when `correctDrift` is used.
+          // But with ConfigMaps and Services, it is not because they are immutable i.e.
+          // they didn't reconciled when `correctDrift` is enabled.
           cy.deleteAllFleetRepos();
 
           // Delete leftover resources if there are any on each downstream cluster.
           // Currently, service is getting deleted from cluster, hence adding check for it.
           dsClusterList.forEach((dsClusterName) => {
+            // Adding wait to load page correctly to avoid interference with hamburger-menu.
+            cy.wait(500);
             cy.accesMenuSelection(dsClusterName, "Service Discovery", "Services");
             cy.nameSpaceMenuToggle(resourceNamespace);
             cy.filterInSearchBox(resourceName);

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -386,7 +386,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
   describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled', { tags: '@p1'}, () => {
     const correctDriftTestData: testData[] = [
       { qase_id: 80,
-        repoName: "local-cluster-correct-80",
+        repoName: "ds-cluster-correct-80",
         resourceType: "ConfigMaps",
         resourceName: "mp-app-config",
         resourceLocation: "Storage",
@@ -394,7 +394,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
         dataToAssert: "test, test_key",
       },
       { qase_id: 79,
-        repoName: "local-cluster-correct-79",
+        repoName: "ds-cluster-correct-79",
         resourceType: "Services",
         resourceName: "mp-app-service",
         resourceLocation: "Service Discovery",
@@ -408,6 +408,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
         qase(qase_id,
           it(`Fleet-${qase_id}: Test IMMUTABLE resource "${resourceType}" will NOT be self-healed when correctDrift is set to true.`, { tags: `@fleet-${qase_id}` }, () => {
             const path = "multiple-paths"
+            const dsClusterList = ["imported-0", "imported-1", "imported-2"]
 
             // Add GitRepo by enabling 'correctDrift'
             cy.fleetNamespaceToggle('fleet-default')
@@ -443,11 +444,13 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
             // They didn't reconciled when `correctDrift` is used.
             cy.deleteAllFleetRepos();
 
-            // Delete leftover resources if there are any.
-            cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
-            cy.nameSpaceMenuToggle(resourceNamespace);
-            cy.filterInSearchBox(resourceName);
-            cy.deleteAll(false);
+            // Delete leftover resources if there are any on each downstream cluster.
+            dsClusterList.forEach((dsClusterName) => {
+              cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
+              cy.nameSpaceMenuToggle(resourceNamespace);
+              cy.filterInSearchBox(resourceName);
+              cy.deleteAll(false);
+            })
           })
         )
       }

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -383,80 +383,68 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     )  
   });
 
-// Perform this test only if rancher_version does not contain "/2.9"
-// Re-iterate this test cases once 2.9.0 released.
-if (!/\/2\.9/.test(Cypress.env('rancher_version'))) {
-  describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled', { tags: '@p1'}, () => {
-    const correctDriftTestData: testData[] = [
-      { qase_id: 80,
-        repoName: "ds-cluster-correct-80",
-        resourceType: "ConfigMaps",
-        resourceName: "mp-app-config",
-        resourceLocation: "Storage",
-        resourceNamespace: "test-fleet-mp-config",
-        dataToAssert: "test, test_key",
-      },
-      { qase_id: 79,
-        repoName: "ds-cluster-correct-79",
-        resourceType: "Services",
-        resourceName: "mp-app-service",
-        resourceLocation: "Service Discovery",
-        resourceNamespace: "test-fleet-mp-service",
-        dataToAssert: "6341 ",
-      },
-    ]
+describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled', { tags: '@p1'}, () => {
+  const correctDriftTestData: testData[] = [
+    { qase_id: 80,
+      repoName: "ds-cluster-correct-80",
+      path: "multiple-paths/config",
+      resourceType: "ConfigMaps",
+      resourceName: "mp-app-config",
+      resourceLocation: "Storage",
+      resourceNamespace: "test-fleet-mp-config",
+      dataToAssert: "test, test_key",
+    },
+    { qase_id: 79,
+      repoName: "ds-cluster-correct-79",
+      path: "multiple-paths/service",
+      resourceType: "Services",
+      resourceName: "mp-app-service",
+      resourceLocation: "Service Discovery",
+      resourceNamespace: "test-fleet-mp-service",
+      dataToAssert: "6341 ",
+    },
+  ]
 
-    correctDriftTestData.forEach(
-      ({qase_id, repoName, resourceType, resourceName, resourceLocation, resourceNamespace, dataToAssert}) => {
-        qase(qase_id,
-          it(`Fleet-${qase_id}: Test IMMUTABLE resource "${resourceType}" will NOT be self-healed when correctDrift is set to true.`, { tags: `@fleet-${qase_id}` }, () => {
-            const path = "multiple-paths"
-            const dsClusterList = ["imported-0", "imported-1", "imported-2"]
+  correctDriftTestData.forEach(
+    ({qase_id, repoName, path, resourceType, resourceName, resourceLocation, resourceNamespace, dataToAssert}) => {
+      qase(qase_id,
+        it(`Fleet-${qase_id}: Test IMMUTABLE resource "${resourceType}" will NOT be self-healed when correctDrift is set to true.`, { tags: `@fleet-${qase_id}` }, () => {
 
-            // Add GitRepo by enabling 'correctDrift'
-            cy.fleetNamespaceToggle('fleet-default')
-            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift: 'yes' });
-            cy.clickButton('Create');
-            cy.checkGitRepoStatus(repoName, '2 / 2');
-            cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
-            cy.nameSpaceMenuToggle(resourceNamespace);
-            cy.filterInSearchBox(resourceName);
-            cy.get('.col-link-detail').contains(resourceName).should('be.visible');
-            cy.open3dotsMenu(resourceName, 'Edit Config');
+          // Add GitRepo by enabling 'correctDrift'
+          cy.fleetNamespaceToggle('fleet-default')
+          cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift: 'yes' });
+          cy.clickButton('Create');
+          cy.checkGitRepoStatus(repoName, '1 / 1');
+          cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
+          cy.nameSpaceMenuToggle(resourceNamespace);
+          cy.filterInSearchBox(resourceName);
+          cy.get('.col-link-detail').contains(resourceName).should('be.visible');
+          cy.open3dotsMenu(resourceName, 'Edit Config');
 
-            if (resourceType === 'ConfigMaps') {
-              cy.clickButton('Add');
-              cy.get('[data-testid="input-kv-item-key-1"]').eq(0).focus().type('test_key');
-              cy.get('div.code-mirror.as-text-area').eq(1).click().type("test_data_value");
-              cy.clickButton('Add');
-            }
-            else if (resourceType === 'Services') {
-              cy.get("input[type=number]").clear().type("6341");
-            }
+          if (resourceType === 'ConfigMaps') {
+            cy.clickButton('Add');
+            cy.get('[data-testid="input-kv-item-key-1"]').eq(0).focus().type('test_key');
+            cy.get('div.code-mirror.as-text-area').eq(1).click().type("test_data_value");
+            cy.clickButton('Add');
+          }
+          else if (resourceType === 'Services') {
+            cy.get("input[type=number]").clear().type("6341");
+          }
 
-            else  {
-              throw new Error(`Resource "${resourceType}" is invalid  / not implemented yet`);
-            }
+          else  {
+            throw new Error(`Resource "${resourceType}" is invalid  / not implemented yet`);
+          }
 
-            cy.wait(500);
-            cy.clickButton('Save');
-            cy.filterInSearchBox(resourceName);
-            cy.verifyTableRow(0, resourceName, dataToAssert);
-            // Any mutable resource will reconcile to it's original state immediately
-            // But with ConfigMaps and Services it is not because they are immutable i.e.
-            // They didn't reconciled when `correctDrift` is used.
-            cy.deleteAllFleetRepos();
-
-            // Delete leftover resources if there are any on each downstream cluster.
-            dsClusterList.forEach((dsClusterName) => {
-              cy.accesMenuSelection(dsClusterName, resourceLocation, resourceType);
-              cy.nameSpaceMenuToggle(resourceNamespace);
-              cy.filterInSearchBox(resourceName);
-              cy.deleteAll(false);
-            })
-          })
-        )
-      }
-    )
-  });
-}
+          cy.wait(500);
+          cy.clickButton('Save');
+          cy.filterInSearchBox(resourceName);
+          cy.verifyTableRow(0, resourceName, dataToAssert);
+          // Any mutable resource will reconcile to it's original state immediately
+          // But with ConfigMaps and Services it is not because they are immutable i.e.
+          // They didn't reconciled when `correctDrift` is used.
+          cy.deleteAllFleetRepos();
+        })
+      )
+    }
+  )
+});

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -383,6 +383,9 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     )  
   });
 
+// Perform this test only if rancher_version does not contain "/2.9"
+// Re-iterate this test cases once 2.9.0 released.
+if (!/\/2\.9/.test(Cypress.env('rancher_version'))) {
   describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled', { tags: '@p1'}, () => {
     const correctDriftTestData: testData[] = [
       { qase_id: 80,
@@ -456,3 +459,4 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
       }
     )
   });
+}


### PR DESCRIPTION
**Problem**: Current 2.9 CI is failing for correctDrift test cases (79,80). The reason for failure is ConfigMap is getting deleted but service is not being removed rather it is being re-created. This behavior is observed after GitRepo deletion.

**Solution**: Used individual paths to ConfigMaps and Services so GitRepo will not install both applications simultaneously. Also, their deletion will be performed separately. 

**Changes made in the PR**: Path is added to individual tests, Removed extra indentation.

While investigating this I found problem: Bundle is not getting removed after deleting GitRepo when multiple paths are used. (https://github.com/rancher/fleet/issues/2586)