### PR TITLE
Adding health check on Yaml while creating Gitrepo

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -39,7 +39,10 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@p0' }, () => {
 
       cy.fleetNamespaceToggle('fleet-local');
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
-      cy.clickButton('Create');
+      // Adding check validate "Edit as Yaml" works
+      cy.clickButton('Edit as YAML');
+      cy.contains('apiVersion: fleet.cattle.io/v1alpha1').should('be.visible');
+      cy.clickButton('Create')
       cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6');
       cy.verifyTableRow(1, 'Service', 'frontend');
       cy.verifyTableRow(3, 'Service', 'redis-master');


### PR DESCRIPTION
Implements: #163 on test Fleet-62 

#### Done
On a GitRepo with a path set, I added an extra click on `Edit Yaml` button and asserted text in it prior creating it. 

![image](https://github.com/rancher/fleet-e2e/assets/37271841/6d3df1ca-0327-43e7-8f64-410bfb1dd319)

Attaching video of automation. This can be observed on second 10

[Screencast from 09-07-24 09:38:54.webm](https://github.com/rancher/fleet-e2e/assets/37271841/ee12904e-4d5a-4195-8148-b39c8f93fc6e)



