### PR TITLE
Manual upgrade fleet from pre release version

### DIFF
--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -36,3 +36,14 @@ describe('First login on Rancher', { tags: '@login' }, () => {
     })
   );
 });
+
+// Upgrade Fleet from chart to latest when this is not the default one.
+describe('Upgrade Fleet via UI', { tags: '@upgrade-fleet-chart' }, () => {
+        
+  it('Upgrade Fleet chart to latest', () => {
+      cy.login();
+      cy.visit('/');
+      cy.allowRancherPreReleaseVersions();
+      cy.upgradeFleet();
+  });
+})

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -395,3 +395,43 @@ Cypress.Commands.add('deleteRole', (roleName, roleTypeTemplate) => {
   // Verify that there are no rows
   cy.contains('There are no rows which match your search query.', { timeout: 2000 }).should('be.visible');
 })
+
+// Allow to select pre-release versions
+Cypress.Commands.add('allowRancherPreReleaseVersions', () => {
+  // Using visit here instead of clicking in prefs to avoid issues in CI
+  cy.visit('/prefs')
+  cy.contains('Include Prerelease Versions', {timeout: 15000}).should('exist').click({ force: true });
+  cy.screenshot('Screenshot Pre-release versions activated');
+  cy.wait(500);
+  cy.visit('/c/local/explorer')
+  cy.wait(500);
+  cy.get('h6').contains('Cluster').should('be.visible')
+});
+
+// Upgrade Fleet to latest version when is not set to default in UI.
+Cypress.Commands.add('upgradeFleet', () => {
+
+  // Refresh the Rancher repository
+  cy.visit('c/local/apps/catalog.cattle.io.clusterrepo');
+  cy.get('h1', { timeout: 20000 }).contains('Repositories').should('be.visible');
+  cy.verifyTableRow(1, 'Active', 'Rancher');
+  cy.open3dotsMenu('Rancher', 'Refresh');
+  cy.verifyTableRow(1, 'Active', 'Rancher');
+  
+  // Update Fleet
+  cy.visit('c/local/apps/catalog.cattle.io.app');
+  cy.get('h1', { timeout: 20000 }).contains('Installed Apps').should('be.visible')
+  cy.nameSpaceMenuToggle('cattle-fleet-system');
+  cy.verifyTableRow(0, 'Deployed', 'fleet');
+  cy.filterInSearchBox('fleet');
+  cy.open3dotsMenu('fleet', 'Edit/Upgrade');
+  cy.contains('Loading...', { timeout: 20000 }).should('not.exist');
+  cy.get('#vs1__combobox').click();
+  cy.wait(250);
+  cy.get('ul.vs__dropdown-menu > li').first().click();
+  cy.clickButton('Next');
+  cy.clickButton(/Upgrade|Update/);
+  cy.contains('Updating...', { timeout: 20000 }).should('not.exist');
+  cy.contains('SUCCESS: helm upgrade', { timeout: 60000 }).should('be.visible');
+  cy.screenshot('Screenshot Fleet upgraded');
+});

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -41,6 +41,8 @@ declare global {
       deleteAllUsers(): Chainable<Element>;
       deleteRole(roleName: string, roleTypeTemplate: string): Chainable<Element>;
       importYaml(clusterName: string, yamlFilePath: string): Chainable<Element>;
+      allowRancherPreReleaseVersions(): Chainable<Element>;
+      upgradeFleet(): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
## Issue
At time latest version of Fleet is not found in charts. This can be also achieved by installing it using `Pre-release` version flag and later upgrading the chart from catalog.

## Done
- Added new test within `first_login_rancher.spec.ts` where this applies.
  - Added `@upgrade` tag on test; so by default it will be skipped unless called with that tag. 
- Added function `allowRancherPreReleaseVersions` to ensure pre-release option is enabled.
- Added refresh on Rancher repository to ensure pre-release selection is reflected
- Added `upgadeFleet` function to upgrade to latest existing version

## CI:
CI shows `Pending` when tag not called (ie: [here](https://github.com/rancher/fleet-e2e/actions/runs/10042782282/job/27754037197#step:9:216)): 
![image](https://github.com/user-attachments/assets/67df3c38-e968-4fb8-8d24-998f34a75afe)

CI executes the test when tag `@upgrade` is called (ie: [here](https://github.com/rancher/fleet-e2e/actions/runs/10043041592/job/27754896688)):
![image](https://github.com/user-attachments/assets/56da120a-1ef1-413e-b455-e81ed64a1ba8)


