### PR TITLE
Fixed 2.7 nav issue and 2.9 banner text with regex

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -481,7 +481,7 @@ describe('Test application deployment based on clusterGroup', { tags: '@p1'}, ()
   const key = 'key_env'
   const value = 'value_prod'
   const clusterGroupName = 'cluster-group-env-prod'
-  const bannerMessageToAssert = 'Matches 2 of 3 existing clusters, including "imported-0"'
+  const bannerMessageToAssert = /Matches 2 of 3 existing clusters, including "imported-\d"/
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
     cy.login();

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -208,7 +208,6 @@ Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery
   // unfortunately there's no "easy" way of waiting for transitions and 500ms is quick and does the trick
   cypressLib.burgerMenuToggle( {animationDistanceThreshold: 10} );
   cy.wait(500);
-  cy.get('[data-testid="side-menu"]').should('have.class', 'menu-open');
 
   cy.contains(firstAccessMenu).should('be.visible');
   cypressLib.accesMenu(firstAccessMenu);
@@ -476,10 +475,7 @@ Cypress.Commands.add('createClusterGroup', (clusterGroupName, key, value, banner
   cy.clickButton('Add Rule');
   cy.get('[data-testid="input-match-expression-key-control-0"]').focus().type(key);
   cy.get('[data-testid="input-match-expression-values-control-0"]').type(value);
-  cy.get('[data-testid="banner-content"]').should(($banner) => {
-    const bannerContent = $banner.text();
-    expect(bannerContent).contain(bannerMessageToAssert)
-  });
+  cy.contains(bannerMessageToAssert).should('be.visible');
   cy.clickButton('Create');
   cy.verifyTableRow(0, 'Active', clusterGroupName);
 })

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -44,7 +44,7 @@ declare global {
       allowRancherPreReleaseVersions(): Chainable<Element>;
       upgradeFleet(): Chainable<Element>;
       assignClusterLabel(clusterName: string, key: string, value: string): Chainable<Element>;
-      createClusterGroup(clusterGroupName: string, key: string, value: string, bannerMessageToAssert: string): Chainable<Element>;
+      createClusterGroup(clusterGroupName: string, key: string, value: string, bannerMessageToAssert: string|RegExp): Chainable<Element>;
       deleteClusterGroups(): Chainable<Element>;
       deployToClusterOrClusterGroup(deployToTarget: string): Chainable<Element>;
       removeClusterLabels(clusterName: string, key: string, value: string): Chainable<Element>;


### PR DESCRIPTION
**Problem: Issue: #171 **
* CI 2.7 is failing due to locator issue: `cy.get('[data-testid="side-menu"]').should('have.class', 'menu-open');`
* CI 2.9 is failing to assert Banner message for test Fleet-25. `const bannerMessageToAssert = 'Matches 2 of 3 existing clusters, including "imported-0"'`

**Fixed:**
* Removed the `cy.get('[data-testid="side-menu"]').should('have.class', 'menu-open');`.
* Updated Banner message from string to Regex to fix it.

**Screenshot:**
Below screenshots are taken with 2 different cluster combination to check Regex working.
<details>
<summary><b>Cluster combination: imported-0 and imported-1</b></summary>

![Screenshot from 2024-07-24 15-09-36](https://github.com/user-attachments/assets/f105e2ab-37b9-4db6-a143-51e1ee0bfc91)
</details>

<details>
<summary><b>Cluster combination: imported-2 and imported-1</b></summary>

![Screenshot from 2024-07-24 15-07-19](https://github.com/user-attachments/assets/b95ba41a-8a00-4c78-9f5c-ebe146af40ee)
</details>

