### PR TITLE
Bumping cypress/grep plugin

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.5.2"
   },
   "devDependencies": {
-    "@cypress/grep": "^4.0.1",
+    "@cypress/grep": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "eslint-plugin-cypress": "^2.13.0"


### PR DESCRIPTION
## Task
Bumping https://www.npmjs.com/package/@cypress/grep to current `4.1.0`

## Test
Test using grep tag pointing solely to `@login` and `@fleet-62` and working: https://github.com/rancher/fleet-e2e/actions/runs/10716206138/job/29713352923#step:9:326

