### PR TITLE
Bump latest ele-helpers

### DIFF
--- a/.github/workflows/ui-rm_prime_alpha_rc.yaml
+++ b/.github/workflows/ui-rm_prime_alpha_rc.yaml
@@ -14,7 +14,7 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version latest/2.9.x[-rc1], prime/2.9.x, prime/devel/2.9, alpha/2.x.x-alphaX
+        description: Rancher version channel/version/head_version latest/2.9.x[-rc1], prime/2.9.x, prime/devel/2.9, alpha/2.x.x-alphaX, prime-optimus-alpha/2.x.x-alphaX
         default: prime/2.9.1
         type: string
         required: true

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240910211441-8f880e51427f
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -131,10 +131,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240812131424-523dd9f7271f h1:dcYnVWAbw5Ps77BMSnh+31Spyjg1Q1wMx1BOksmkmlI=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240812131424-523dd9f7271f/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad h1:TM0FVtBT+A1RT7mcFVW3i5JaxMcAEWMe0diHLQlUg9s=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240910211441-8f880e51427f h1:xRIhsjCeCLhes++q8r/TvPsopZD6KKullQOwBMPaQxI=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240910211441-8f880e51427f/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
- Bump latest `ele-helpers` to add `prime-optimus-alpha/2.x.x-alphaX` registry.
- Updated description for PRIME CI Lane.