### PR TITLE
Adding screenshots and reload  to investigate flakiness

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -557,6 +557,10 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
           // Verify deployment is 2 despite having changed to 5 in original repo
           cy.accesMenuSelection('local', 'Workloads', 'Deployments');
           cy.filterInSearchBox('nginx-test-polling');
+          cy.log('HERE WE SHOULD SEE 2/2')
+          cy.screenshot('Screenshot BEFORE reloading should be 2/2');
+          cy.reload();
+          cy.screenshot('Screenshot AFTER reloading should be 2/2');
           cy.verifyTableRow(0, 'Active', '2/2');
 
           // Force update


### PR DESCRIPTION
Test 126 has been flaky lately on ci
After many tries, It never does is locally.

After some previous investigation, my assumption is that there is some caching on the state of the latest test in the final deployment status which is 5 replicas.

Although the previously existing gitrepo is completely deleted (and the deployment associated with it), I believe that the page may contain some cache from the previously existing test.

What I have done to prove this is:
1. Take a screenshot in the moment that the test should have 2 replicas
2. Reload the page
3. Take a second screenshot to see, in case the status remains at 5, if it changes to 2 at this point.

If flakiness is removed, it will probably mean that some type of caching has been applied.