### PR TITLE
Allowing value 'Git Updating' to be valid also for 2.8 lanes

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -159,7 +159,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         cy.clickButton('Create');
 
         // Enrure that apps cannot be installed && error appears
-        cy.verifyTableRow(0, 'Error', '0/0');
+        cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
         cy.contains('Ssh: handshake failed: knownhosts: key mismatch').should('be.visible');
     })
   );


### PR DESCRIPTION
## Issue
Implementation of test Fleet-143 for known-host expected the chip on gitrepos to be in [Error](https://github.com/rancher/fleet-e2e/blob/main/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts#L162C4-L162C46) status after missmatched known-host key was passed. This was verified by using `cy.verifyTableRow(0, 'Error', '0/0');`. This is vallid and working for 2.9 lane but had an error on 2.8 because the error shown is `Git Updating`.

Product has given ok to this last value, so this pr incorporates that value also as valid.

## Done
- Passed `cy.verifyTableRow(0, /Error|Git Updating/, '0/0');` to validate also this option.

## Tests

Local screenshot
![2024-09-25_09-55](https://github.com/user-attachments/assets/e04106dd-a768-4f3a-aedb-f7cd48b7ce99)

[CI in 2.8](https://github.com/rancher/fleet-e2e/actions/runs/11028782849/job/30629875288#step:9:290) green

