### PR TITLE
Set expiration time for GCP runner secrets

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -125,9 +125,9 @@ jobs:
       - name: Create PAT token secrets
         run: |
           echo -n ${{ secrets.pat_token }} \
-            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
           echo -n ${{ github.repository }} \
-            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
       - name: Get public dns name in GCP
         id: dns
         run: |


### PR DESCRIPTION
There was about 8000 Managed Secrets on GCP created by various GCP runners which costs money.

* This PR will set Expiration time by `--ttl=18000s` for newly created secrets so they will be auto removed after 5h. Before this change the secrets were not deleted when running with `destroy=false` input. The secrets are useless when gh action is done so it won't have any impact for debug VM runs.

![image](https://github.com/user-attachments/assets/2173ed72-faa1-48e4-9380-56c02036c2fb)


Testrun: https://github.com/rancher/fleet-e2e/actions/runs/11178473152