### PR TITLE
Adding test to check cabundle secret is not created without tls certificate

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -193,5 +193,27 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
       cy.contains('-cabundle').should('not.exist');
     })
   );  
+
+  qase(144,
+    it("Fleet-144 Test cabundle secrets are not created without TLS certificate", { tags: '@fleet-144' }, () => {;
+      
+      const repoName = 'local-144-test-cabundle-secrets-not-created'
+      const repoUrl = 'https://github.com/rancher/fleet-examples'
+      const branch = 'master'
+      const path = 'simple'
+  
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+      cy.clickButton('Create');
+      cy.verifyTableRow(0, 'Active', '1/1');
+      cy.accesMenuSelection('local', 'Storage', 'Secrets');
+  
+      // Confirm cabundle secret is NOT created for the specified gitrepo
+      cy.nameSpaceMenuToggle('All Namespaces');
+      cy.filterInSearchBox(repoName+'-cabundle');
+      cy.contains('There are no rows which match your search query.', { timeout: 2000 }).should('be.visible');
+    })
+  );  
+
 });
 


### PR DESCRIPTION
Implements: https://github.com/rancher/fleet-e2e/issues/212 | https://app.qase.io/case/FLEET-144

--- 
- Creates normal gitrepo without TLS certificate
- Goes to secrets and verify secret with `reponame-cabundle`does not exist.

--
CI 2.9-head passing: https://github.com/rancher/fleet-e2e/actions/runs/11237975337/job/31241726033?pr=214#step:9:258
Failures displayed unrelated to this issue
![image](https://github.com/user-attachments/assets/669ef786-571f-4757-a747-2f907be24424)

Also in 2.8: https://github.com/rancher/fleet-e2e/actions/runs/11238769174/job/31245149823#step:9:294