### PR TITLE
Adding retry to polling disable 126

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -535,7 +535,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     qase(126,
       it(
         'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github',
-        { tags: '@fleet-126' },
+        { tags: '@fleet-126', retries: 1 },
         () => {
           // Forcing 15 seconds of wait to check if changes occur after this time.
           cy.wait(15000);

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -535,7 +535,7 @@ if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
     qase(126,
       it(
         'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github',
-        { tags: '@fleet-126', retries: 1 },
+        { tags: '@fleet-126', retries: 1 }, // TODO: Retry added to avoid intermittent failures. Remove once fixed.
         () => {
           // Forcing 15 seconds of wait to check if changes occur after this time.
           cy.wait(15000);


### PR DESCRIPTION
Adding retry ability to test to validate if on second try test succeeds.

## Considerations

- Test 126 ALWAYS works locally
- Fails recently frequently solely on CI and on 1st attempt (not always: example [here](https://github.com/rancher/fleet-e2e/actions/runs/11455335699/job/31872807159#step:9:316))
- After some investigation it looks UI

I will keep this on radar to investigate further, but if we want to consider trying if ok on 2nd attempt this can be a way. 