### PR TITLE
Adding more job deletion tests

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -577,3 +577,22 @@ Cypress.Commands.add('addYamlFile', (yamlFilePath) => {
     });
   })
 })
+
+// Command to ensure job is deleted
+Cypress.Commands.add('verifyJobDeleted', (repoName, verifyJobDeletedEvent = true) => {
+  // Optional. This is to t verify event on Repo status page
+  // To be executed there or after cy.checkGitRepoStatus() function;
+  if (verifyJobDeletedEvent) {
+    cy.get('ul[role="tablist"]').contains('Recent Events').click();
+    cy.get('section#events > div > table > tbody > tr.main-row')
+      .eq(0)
+      .contains('job deletion triggered because job succeeded', { timeout: 20000 })
+      .should('be.visible');
+  };
+
+  // Confirm job disappears
+  cy.accesMenuSelection('local', 'Workloads', 'Jobs');
+  cy.nameSpaceMenuToggle('All Namespaces');
+  cy.filterInSearchBox(repoName);
+  cy.get('table > tbody > tr').contains('There are no rows which match your search query.').should('be.visible');
+});

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -50,6 +50,7 @@ declare global {
       removeClusterLabels(clusterName: string, key: string, value: string): Chainable<Element>;
       clusterCountClusterGroup(clusterGroupName: string, clusterCount: number): Chainable<Element>;
       addYamlFile(yamlFilePath: string): Chainable<Element>;
+      verifyJobDeleted(repoName: string, verifyJobDeletedEvent?: boolean ): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
Adding new tests for job deletion detection:

- https://app.qase.io/case/FLEET-146 -> Checks event job deletion log and job is deleted after applying force update
- https://app.qase.io/case/FLEET-147 -> Checks event job deletion log and job is deleted after commit change.
- https://app.qase.io/case/FLEET-148 -> Checks upon faulty job, event job deletion log DOES NOT appear and job STAYS
- https://app.qase.io/case/FLEET-145 -> Refactored after introduction of function `verifyJobDeleted`
