### PR TITLE
Update regex on rancher version to ensure 2.10 is executed

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -217,7 +217,7 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
 
 });
 
-if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
   // New tests for jobs cleanup
   describe('Test Fleet job cleanup', { tags: '@p0' }, () => {
     

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -304,7 +304,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
 
 // RepoURLRegex is supported on v2.8 but error reporting is not working correctly there
 // Ref. https://github.com/rancher/fleet/issues/2462 but it wont be fixed in v2.8
-if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
   describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: '@p1'}, () => {
 
     const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -304,7 +304,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version'))) {
 
 // RepoURLRegex is supported on v2.8 but error reporting is not working correctly there
 // Ref. https://github.com/rancher/fleet/issues/2462 but it wont be fixed in v2.8
-if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
   describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: '@p1'}, () => {
 
     const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'
@@ -507,7 +507,7 @@ describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled'
   )
 });
 
-if (/\/2\.9/.test(Cypress.env('rancher_version'))) {
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
   describe('Tests with disablePolling', { tags: '@p1' }, () => {
     const gh_private_pwd = Cypress.env('gh_private_pwd');
     const repoName = 'test-disable-polling';


### PR DESCRIPTION
Current regex for rancher version will make that new version 2.10 is not executed (example here, where I wanted to run all tests in [this](https://github.com/rancher/fleet-e2e/actions/runs/11511966283/job/32047284771#step:9:294) `2.10.0-alpha3` and some tests like new [Test Fleet job cleanup](https://github.com/rancher/fleet-e2e/actions/runs/11547186580/job/32136699963#step:9:298) were not present.
This pr attempts to workaround this by changing pointing positively to 2.9 by `/\/2\.9/.test(Cypress.env('rancher_version')` to exclude things that are not 2.7 or 2.8.


Results:

| Test | [2.8-head ](https://github.com/rancher/fleet-e2e/actions/runs/11547211639/job/32136758871#step:9:532)| [2.8-pr](https://github.com/rancher/fleet-e2e/actions/runs/11553239393/job/32154030677#step:9:447) | [2.9-head](https://github.com/rancher/fleet-e2e/actions/runs/11547186580/job/32136699963) | [2.9-pr ](https://github.com/rancher/fleet-e2e/actions/runs/11553220545/job/32153972930)| [2.10-pr](https://github.com/rancher/fleet-e2e/actions/runs/11553719703/job/32155513544) |
| --- | --- | --- | --- | --- | --- |
| first_login_rancher.spec.ts | 3 | 3 | 3 | 3 | 3 |
| p0_fleet.spec.ts | 13 | 13 | 17 | 17 | 17 |
| p1_fleet.spec.ts | 26 | 26 | 32 | 32 | 32 |