### PR TITLE
Adding workaround for error content check on 2.10 for invalid characters

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -65,11 +65,16 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
             cy.addFleetGitRepo({repoName, repoUrl, branch, path});
             cy.clickButton('Create');
 
+            // Skipping this in 2.10 until this bug is resolved:
+            // https://github.com/rancher/dashboard/issues/12444
+            // TODO: decide what to do with this upon bug resolution
+            if (!/\/2\.10/.test(Cypress.env('rancher_version'))) {
             // Assert errorMessage exists
             cy.get('[data-testid="banner-content"] > span')
               .should('contain', repoName)
               .should('contain', 'RFC 1123')
-
+            }
+            
             // Navigate back to GitRepo page
             cy.clickButton('Cancel')
             cy.contains('No repositories have been added').should('be.visible')


### PR DESCRIPTION
We did not check properly this: https://github.com/rancher/fleet-e2e/pull/228#issuecomment-2449449555

Adapting tests 61 and 105 for 2.10 meanwhile this bug is resolved: `https://github.com/rancher/dashboard/issues/12444`

CI on [2.10.0-alpha5](https://github.com/rancher/fleet-e2e/actions/runs/11614039752)