### PR TITLE
Workaround for Fleet-97 on 2.9

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -101,6 +101,7 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
         cy.fleetNamespaceToggle('fleet-default')
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Active', '1/1'); // Implicit wait due to https://github.corancher/dashboard/issues/12502
         cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -101,7 +101,8 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
         cy.fleetNamespaceToggle('fleet-default')
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
-        cy.verifyTableRow(0, 'Active', '1/1'); // Implicit wait due to https://github.corancher/dashboard/issues/12502
+        cy.verifyTableRow(0, 'Active'); // Implicit wait due to https://github.corancher/dashboard/issues/12502
+        cy.contains('0/0', { timeout: 20000 }).should('not.exist');
         cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();


### PR DESCRIPTION
Workaround for test Fleet-97 due to https://github.corancher/dashboard/issues/12502 to avoid everyday failures.

### Done:
Added implicit (not explicit) wait on repo status and negative asserting count 0/0