### PR TITLE
Fleetqa/further adjustments 152 test

### DIFF
--- a/tests/assets/disable_polling.yaml
+++ b/tests/assets/disable_polling.yaml
@@ -20,3 +20,4 @@ spec:
             values:
               - harvester
 __clone: true
+

--- a/tests/assets/webhook-tests/webhook_ingress.yaml
+++ b/tests/assets/webhook-tests/webhook_ingress.yaml
@@ -15,4 +15,5 @@ spec:
               name: gitjob
               port:
                 number: 80
+
                 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -345,7 +345,7 @@ describe('Test Fleet with Webhook', { tags: '@p0' }, () => {
       cy.contains('Connected').should('be.visible');
 
       // Add yaml file to the terminal to create ad-hoc ingress
-      cy.get('button[data-testid="header-action-import-yaml"]').click();
+      cy.get('button > i.icon.icon-upload.icon-lg').click();
       cy.addYamlFile('assets/webhook-tests/webhook_ingress.yaml');
       cy.clickButton('Import');
       cy.clickButton('Close');

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -327,77 +327,69 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
   )});
 };
 
-describe('Test Fleet with Webhook', { tags: '@p0' }, () => {
-  qase(152,
-    it('Fleet-152: Test Fleet with Webhook and disable polling ', { tags: '@fleet-152' }, () => {
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
+  describe('Test Fleet with Webhook', { tags: '@p0' }, () => {
+    qase(152,
+      it('Fleet-152: Test Fleet with Webhook and disable polling ', { tags: '@fleet-152' }, () => {
 
-      const repoName = 'webhook-test-disable-polling';
-      const gh_private_pwd = Cypress.env('gh_private_pwd');
-      
-      // Prepare webhook in Github
-      cy.exec('bash assets/webhook-tests/webhook_setup.sh', { env: { gh_private_pwd } }).then((result) => {
-        cy.log(result.stdout, result.stderr);
-      })
+        const repoName = 'webhook-test-disable-polling';
+        const gh_private_pwd = Cypress.env('gh_private_pwd');
 
-      // Open local terminal in Rancher UI
-      cy.accesMenuSelection('local');
-      cy.get('#btn-kubectl').click();
-      cy.contains('Connected').should('be.visible');
+        // Prepare webhook in Github
+        cy.exec('bash assets/webhook-tests/webhook_setup.sh', { env: { gh_private_pwd } }).then((result) => {
+          cy.log(result.stdout, result.stderr);
+        })
 
-      // Add yaml file to the terminal to create ad-hoc ingress
-      cy.get('button > i.icon.icon-upload.icon-lg').click();
-      cy.addYamlFile('assets/webhook-tests/webhook_ingress.yaml');
-      cy.clickButton('Import');
-      cy.clickButton('Close');
+        // Open local terminal in Rancher UI
+        cy.accesMenuSelection('local');
+        cy.get('#btn-kubectl').click();
+        cy.contains('Connected').should('be.visible');
 
-      // Create webhook secret via terminal to be used in webhook
-      // Workaround for 2.7 and 2.8. TODO: remove once decommissioned.
-      if (/\/2\.7/.test(Cypress.env('rancher_version')) && /\/2\.8/.test(Cypress.env('rancher_version'))) {
-        cy.get('.xterm-rows').then(() => {
-          cy.type('kubectl create secret generic gitjob-webhook -n fleet-local --from-literal=github=webhooksecretvalue{enter}');
-        });
-      }
+        // Add yaml file to the terminal to create ad-hoc ingress
+        cy.get('button > i.icon.icon-upload.icon-lg').click();
+        cy.addYamlFile('assets/webhook-tests/webhook_ingress.yaml');
+        cy.clickButton('Import');
+        cy.clickButton('Close');
 
-      else {
         cy.typeIntoCanvasTermnal('\
-          kubectl create secret generic gitjob-webhook -n cattle-fleet-system --from-literal=github=webhooksecretvalue{enter}');
-      };
+        kubectl create secret generic gitjob-webhook -n cattle-fleet-system --from-literal=github=webhooksecretvalue{enter}');
 
-      // Ensure webhook repo starts with 2 replicas
-      cy.exec('bash assets/webhook-tests/webhook_test_2_replicas.sh', { env: { gh_private_pwd } }).then((result) => {
-        cy.log(result.stdout, result.stderr);
-      });
+        // Ensure webhook repo starts with 2 replicas
+        cy.exec('bash assets/webhook-tests/webhook_test_2_replicas.sh', { env: { gh_private_pwd } }).then((result) => {
+          cy.log(result.stdout, result.stderr);
+        });
 
-      // Gitrepo creation via YAML
-      cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
-      cy.fleetNamespaceToggle('fleet-local');
-      cy.clickButton('Add Repository');
-      cy.clickButton('Edit as YAML');
-      cy.addYamlFile('assets/webhook-tests/webhook_test_disable_polling.yaml');
-      cy.clickButton('Create');
-      cy.verifyTableRow(0, 'Active', '1/1');
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-      cy.verifyJobDeleted(repoName, false);
+        // Gitrepo creation via YAML
+        cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+        cy.fleetNamespaceToggle('fleet-local');
+        cy.clickButton('Add Repository');
+        cy.clickButton('Edit as YAML');
+        cy.addYamlFile('assets/webhook-tests/webhook_test_disable_polling.yaml');
+        cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Active', '1/1');
+        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+        cy.verifyJobDeleted(repoName, false);
 
-      // Verify deployments has 2 replicas only
-      cy.accesMenuSelection('local', 'Workloads', 'Deployments');
-      cy.filterInSearchBox(repoName);
-      cy.wait(500);
-      cy.contains('tr.main-row', repoName, { timeout: 20000 }).should('be.visible');
-      cy.verifyTableRow(0, 'Active', '2/2');
+        // Verify deployments has 2 replicas only
+        cy.accesMenuSelection('local', 'Workloads', 'Deployments');
+        cy.filterInSearchBox(repoName);
+        cy.wait(500);
+        cy.contains('tr.main-row', repoName, { timeout: 20000 }).should('be.visible');
+        cy.verifyTableRow(0, 'Active', '2/2');
 
-      // Give extra time for job to finsih. 
-      // TODO: remove this wait once https://github.com/rancher/fleet/issues/3067  is fixed
-      // or find a way to wait for the job to finish
-      cy.wait(10000);
+        // Give extra time for job to finsih. 
+        // TODO: remove this wait once https://github.com/rancher/fleet/issues/3067  is fixed
+        // or find a way to wait for the job to finish
+        cy.wait(10000);
 
-      // Change replicas to 5
-      cy.exec('bash assets/webhook-tests/webhook_test_5_replicas.sh').then((result) => {
-        cy.log(result.stdout, result.stderr);
-      });
+        // Change replicas to 5
+        cy.exec('bash assets/webhook-tests/webhook_test_5_replicas.sh').then((result) => {
+          cy.log(result.stdout, result.stderr);
+        });
 
-      // Verify deployments has 5 replicas
-      cy.verifyTableRow(0, 'Active', '5/5');
-    })
-  );
-})
+        // Verify deployments has 5 replicas
+        cy.verifyTableRow(0, 'Active', '5/5');
+      })
+    );
+  })
+};


### PR DESCRIPTION
Making locator to import yaml in main page universal to work with 2.8
Refactors pending from https://github.com/rancher/fleet-e2e/pull/238#discussion_r1858747374

Skipping Fleet-152 from ci in 2.7 and 2.8. I tried to make it work [here](https://github.com/rancher/fleet-e2e/pull/239/commits/32ec15ac79dd64cb739d8c53e2e8ad2c44cb9f0e#diff-9f876fdbccb2d9f0d904be7278b8ba99dce7c559f6fe87489f518169b607492aR355) with a similar regex used in other part of the ci (ie [here](https://github.com/rancher/fleet-e2e/blob/main/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts#L312) for tests 64 and 65) without success.
CI 2.8 [correctly skipped for 152](https://github.com/rancher/fleet-e2e/actions/runs/12120949059/job/33790848470)
CI 2.9 [correctly sees it ](https://github.com/rancher/fleet-e2e/actions/runs/12120941945/job/33790825110?pr=239#step:9:267)