### PR TITLE
Bumping Cypress to 13.16.0

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -275,7 +275,7 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:13.6.4'
+          CYPRESS_DOCKER: 'cypress/included:13.16.0'
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.1.0",
     "cy-verify-downloads": "^0.1.8",
-    "cypress": "^13.6.4",
+    "cypress": "^13.16.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-mochawesome-reporter": "^3.8.2",


### PR DESCRIPTION
Bumping Cypress to latest 13.16.0
Tests results on different lanes show sporadic  errors on certain tests: 
- [2.8](https://github.com/rancher/fleet-e2e/actions/runs/12356421690) (2 failed tests), 
- [2.9](https://github.com/rancher/fleet-e2e/actions/runs/12356403390/job/34502032064?pr=243) (3 failed tests), 
- [2.10](https://github.com/rancher/fleet-e2e/actions/runs/12356416901/job/34502023894#step:9:602) (1 failed  test)

Perhaps can be merged and see how these tests evolve over next days. Some tweaking including slowing down tests may be considered as well. 