### PR TITLE
Bump node to version 18

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -240,7 +240,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Install prerequisite components
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}


### PR DESCRIPTION
Bump of node version to avoid [this](https://github.com/rancher/fleet-e2e/actions/runs/12386100844/job/34573447275#step:9:51) warn on ci

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'mocha@11.0.1',
npm WARN EBADENGINE   required: { node: '^18.18.0 || ^20.9.0 || >=21.1.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```

CI on `head`: https://github.com/rancher/fleet-e2e/actions/runs/12397332482