### PR TITLE
Skipping test 126 in 2.9 due to unfixed error

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -537,6 +537,8 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
       });
     });
 
+    if (!/\/2\.9/.test(Cypress.env('rancher_version'))) { 
+    // Skipping in 2.9 due to https://github.com/rancher/fleet/issues/3048
     qase(126,
       it(
         'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github',
@@ -568,7 +570,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
           cy.verifyTableRow(0, 'Active', '5/5');
         }
       )
-    );
+    )};
 
     qase(124,
       it(


### PR DESCRIPTION
Skipping test 126 to to unattended bug.
Test is being skipped in 2.9 while passing in [2.10](https://github.com/rancher/fleet-e2e/actions/runs/12429821035/job/34704071319#step:9:316)