### PR TITLE
Adding flags for memory improvements

### DIFF
--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -5,6 +5,7 @@ const qaseAPIToken = process.env.QASE_API_TOKEN
 export default defineConfig({
   viewportWidth: 1314,
   viewportHeight: 954,
+  defaultBrowser: 'chrome',
   defaultCommandTimeout: 10000,
   video: true,
   videoCompression: true,
@@ -44,17 +45,16 @@ export default defineConfig({
       // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
       on("before:browser:launch", (browser, launchOptions) => {
         
-        launchOptions.args.push("--js-flags=--max-old-space-size=3500");
-        if (["chrome", "edge", "electron"].includes(browser.name)) {
+        if (["chrome", "edge"].includes(browser.name)) {
           if (browser.isHeadless) {
             launchOptions.args.push("--no-sandbox");
             launchOptions.args.push("--disable-gl-drawing-for-tests");
             launchOptions.args.push("--disable-gpu");
           }
+          launchOptions.args.push("--js-flags=--max-old-space-size=3500");
         }
         return launchOptions;
       });  
-
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('cypress/plugins/index.ts')(on, config)
       // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -62,5 +62,6 @@ export default defineConfig({
       return config;
     },
     specPattern: 'cypress/e2e/unit_tests/*.spec.ts',
+    
   },
 })

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   defaultCommandTimeout: 10000,
   video: true,
   videoCompression: true,
+  numTestsKeptInMemory: 3,
+  experimentalMemoryManagement: true,
   reporter: 'cypress-multi-reporters',
   reporterOptions: {
     reporterEnabled: 'cypress-mochawesome-reporter, cypress-qase-reporter',

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -45,12 +45,12 @@ export default defineConfig({
       // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
       on("before:browser:launch", (browser, launchOptions) => {
         
+        launchOptions.args.push("--js-flags=--max-old-space-size=3500");
         if (["chrome", "edge"].includes(browser.name)) {
           if (browser.isHeadless) {
             launchOptions.args.push("--no-sandbox");
             launchOptions.args.push("--disable-gl-drawing-for-tests");
             launchOptions.args.push("--disable-gpu");
-            launchOptions.args.push("--js-flags=--max-old-space-size=3500");
           }
         }
         return launchOptions;

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   defaultCommandTimeout: 10000,
   video: true,
   videoCompression: true,
-  numTestsKeptInMemory: 3,
+  numTestsKeptInMemory: 0,
   experimentalMemoryManagement: true,
   reporter: 'cypress-multi-reporters',
   reporterOptions: {

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
           return null
         },
       }),
-      // Help for memeory issues.
+      // Help for memory issues.
       // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
       on("before:browser:launch", (browser, launchOptions) => {
         
@@ -50,8 +50,8 @@ export default defineConfig({
             launchOptions.args.push("--no-sandbox");
             launchOptions.args.push("--disable-gl-drawing-for-tests");
             launchOptions.args.push("--disable-gpu");
+            launchOptions.args.push("--js-flags=--max-old-space-size=3500");
           }
-          launchOptions.args.push("--js-flags=--max-old-space-size=3500");
         }
         return launchOptions;
       });  

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -45,12 +45,12 @@ export default defineConfig({
       // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
       on("before:browser:launch", (browser, launchOptions) => {
         
-        launchOptions.args.push("--js-flags=--max-old-space-size=3500");
         if (["chrome", "edge"].includes(browser.name)) {
           if (browser.isHeadless) {
             launchOptions.args.push("--no-sandbox");
             launchOptions.args.push("--disable-gl-drawing-for-tests");
             launchOptions.args.push("--disable-gpu");
+            launchOptions.args.push("--js-flags=--max-old-space-size=3500");
           }
         }
         return launchOptions;

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -39,7 +39,22 @@ export default defineConfig({
           console.log(message)
           return null
         },
-      })  
+      }),
+      // Help for memeory issues.
+      // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
+      on("before:browser:launch", (browser, launchOptions) => {
+        
+        launchOptions.args.push("--js-flags=--max-old-space-size=3500");
+        if (["chrome", "edge", "electron"].includes(browser.name)) {
+          if (browser.isHeadless) {
+            launchOptions.args.push("--no-sandbox");
+            launchOptions.args.push("--disable-gl-drawing-for-tests");
+            launchOptions.args.push("--disable-gpu");
+          }
+        }
+        return launchOptions;
+      });  
+
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('cypress/plugins/index.ts')(on, config)
       // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
## Issue:

We are getting ocassionally on ci memory errors related like this one: https://github.com/rancher/fleet-e2e/actions/runs/12740474984/job/35505731067

```
We detected that the Electron Renderer process just crashed.

We have failed the current spec but will continue running the next spec.

This can happen for a number of different reasons.

If you're running lots of tests on a memory intense application.
  - Try increasing the CPU/memory on the machine you're running on.
  - Try enabling experimentalMemoryManagement in your config file.
  - Try lowering numTestsKeptInMemory in your config file during 'cypress open'.
```

## Task
To try reduce its incidence we will try to follow the indication and enable flags `experimentalMemoryManagement` and reduce `numTestsKeptInMemory`

Edit: I added other improvements as changing default browser to `chrome` plus adding other flags ONLY in headless mode:

```
       if (browser.isHeadless) {
            launchOptions.args.push("--no-sandbox");
            launchOptions.args.push("--disable-gl-drawing-for-tests");
            launchOptions.args.push("--disable-gpu");
            launchOptions.args.push("--js-flags=--max-old-space-size=3500");
```

