### PR TITLE
Fleetqa/check gitrepojob cleanup

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1176,3 +1176,35 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
     )
   })
 });
+
+// Note: to be executed after the above test cases.
+// to avoid any interference if continuous-delivery feature is not correctly enabled.
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
+  qase(156,
+    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
+      // Verify is gitrepoJobsCleanup is enabled by default.
+      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+      cy.nameSpaceMenuToggle('All Namespaces');
+      cy.verifyTableRow(0, 'Active', 'fleet-cleanup-gitrepo-jobs');
+      
+      // Disable continuous-delivery feature flag and wait for restart.
+      cy.accesMenuSelection('Global Settings', 'Feature Flags');
+      cy.open3dotsMenu('continuous-delivery', 'Deactivate' )
+      cy.clickButton('Deactivate');
+      cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
+      // Verify is gitrepoJobsCleanup job is not present
+      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+      cy.contains('fleet-cleanup-gitrepo-jobs').should('not.exist');
+
+      // Re-enable continuous-delivery feature flag and wait for restart.
+      cy.accesMenuSelection('Global Settings', 'Feature Flags');
+      cy.open3dotsMenu('continuous-delivery', 'Activate' )
+      cy.clickButton('Activate');
+      cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
+
+      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+      cy.contains('fleet-cleanup-gitrepo-jobs').should('exist');
+    })
+  )
+};
+

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1181,7 +1181,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
 // to avoid any interference if continuous-delivery feature is not correctly enabled.
 if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
   qase(156,
-    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: ['@p0', '@fleet-156'] }, () => {
+    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: ['@p1', '@fleet-156'] }, () => {
       // Verify is gitrepoJobsCleanup is enabled by default.
       cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
       cy.nameSpaceMenuToggle('All Namespaces');

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1181,7 +1181,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
 // to avoid any interference if continuous-delivery feature is not correctly enabled.
 if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
   qase(156,
-    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
+    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: ['@p0', '@fleet-156'] }, () => {
       // Verify is gitrepoJobsCleanup is enabled by default.
       cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
       cy.nameSpaceMenuToggle('All Namespaces');

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1180,7 +1180,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
 // Note: to be executed after the above test cases
 // to avoid any interference (i.e: if continuous-delivery feature is not correctly enabled.)
 describe("Global settings related tests", { tags: '@p1'}, () => {
-  if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
+  if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
     qase(156,
       it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
         // Verify is gitrepoJobsCleanup is enabled by default.

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1177,37 +1177,3 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
   })
 });
 
-// Note: to be executed after the above test cases
-// to avoid any interference (i.e: if continuous-delivery feature is not correctly enabled.)
-describe("Global settings related tests", { tags: '@p1'}, () => {
-  if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
-    qase(156,
-      it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
-        // Verify is gitrepoJobsCleanup is enabled by default.
-        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-        cy.nameSpaceMenuToggle('All Namespaces');
-        cy.verifyTableRow(0, 'Active', 'fleet-cleanup-gitrepo-jobs');
-        
-        // Disable continuous-delivery feature flag and wait for restart.
-        cy.accesMenuSelection('Global Settings', 'Feature Flags');
-        cy.open3dotsMenu('continuous-delivery', 'Deactivate' )
-        cy.clickButton('Deactivate');
-        cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
-        // Verify is gitrepoJobsCleanup job is not present
-        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-        cy.contains('fleet-cleanup-gitrepo-jobs').should('not.exist');
-
-        // Re-enable continuous-delivery feature flag and wait for restart.
-        cy.accesMenuSelection('Global Settings', 'Feature Flags');
-        cy.open3dotsMenu('continuous-delivery', 'Activate' )
-        cy.clickButton('Activate');
-        cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
-
-        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-        cy.contains('fleet-cleanup-gitrepo-jobs').should('exist');
-      })
-    )
-  };
-});
-
-

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1177,34 +1177,37 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
   })
 });
 
-// Note: to be executed after the above test cases.
-// to avoid any interference if continuous-delivery feature is not correctly enabled.
-if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
-  qase(156,
-    it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: ['@p1', '@fleet-156'] }, () => {
-      // Verify is gitrepoJobsCleanup is enabled by default.
-      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-      cy.nameSpaceMenuToggle('All Namespaces');
-      cy.verifyTableRow(0, 'Active', 'fleet-cleanup-gitrepo-jobs');
-      
-      // Disable continuous-delivery feature flag and wait for restart.
-      cy.accesMenuSelection('Global Settings', 'Feature Flags');
-      cy.open3dotsMenu('continuous-delivery', 'Deactivate' )
-      cy.clickButton('Deactivate');
-      cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
-      // Verify is gitrepoJobsCleanup job is not present
-      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-      cy.contains('fleet-cleanup-gitrepo-jobs').should('not.exist');
+// Note: to be executed after the above test cases
+// to avoid any interference (i.e: if continuous-delivery feature is not correctly enabled.)
+describe("Global settings related tests", { tags: '@p1'}, () => {
+  if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version')) && !/\/2\.9/.test(Cypress.env('rancher_version'))) {
+    qase(156,
+      it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
+        // Verify is gitrepoJobsCleanup is enabled by default.
+        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+        cy.nameSpaceMenuToggle('All Namespaces');
+        cy.verifyTableRow(0, 'Active', 'fleet-cleanup-gitrepo-jobs');
+        
+        // Disable continuous-delivery feature flag and wait for restart.
+        cy.accesMenuSelection('Global Settings', 'Feature Flags');
+        cy.open3dotsMenu('continuous-delivery', 'Deactivate' )
+        cy.clickButton('Deactivate');
+        cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
+        // Verify is gitrepoJobsCleanup job is not present
+        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+        cy.contains('fleet-cleanup-gitrepo-jobs').should('not.exist');
 
-      // Re-enable continuous-delivery feature flag and wait for restart.
-      cy.accesMenuSelection('Global Settings', 'Feature Flags');
-      cy.open3dotsMenu('continuous-delivery', 'Activate' )
-      cy.clickButton('Activate');
-      cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
+        // Re-enable continuous-delivery feature flag and wait for restart.
+        cy.accesMenuSelection('Global Settings', 'Feature Flags');
+        cy.open3dotsMenu('continuous-delivery', 'Activate' )
+        cy.clickButton('Activate');
+        cy.contains('Waiting for Restart', { timeout: 180000 }).should('not.exist');
 
-      cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
-      cy.contains('fleet-cleanup-gitrepo-jobs').should('exist');
-    })
-  )
-};
+        cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
+        cy.contains('fleet-cleanup-gitrepo-jobs').should('exist');
+      })
+    )
+  };
+});
+
 


### PR DESCRIPTION
Implements: https://app.qase.io/case/FLEET-156

## Done
- Added check for `gitrepoJobsCleanup` default job on start
- Ensures it is removed when `continuous-delivery` flag is `off`
- Ensure it gets back when `continuous-delivery` flag is `on`

**Important note**: given that if for some reason the continuous-delivery flag is not correctly set it may leave rest of tests untestable, it is better to keep them at the end of tests. Should this be the case, it may be advisable to create a separate lane for it.

CI in `head`: https://github.com/rancher/fleet-e2e/actions/runs/12952129206