### PR TITLE
Fixing CI due to locators and other issues

### DIFF
--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   defaultCommandTimeout: 10000,
   video: true,
   videoCompression: true,
-  numTestsKeptInMemory: 0,
+  // numTestsKeptInMemory: 0, //This flag causes sporadic erros. Avoid using it.
   experimentalMemoryManagement: true,
   reporter: 'cypress-multi-reporters',
   reporterOptions: {

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -5,7 +5,7 @@ const qaseAPIToken = process.env.QASE_API_TOKEN
 export default defineConfig({
   viewportWidth: 1314,
   viewportHeight: 954,
-  defaultBrowser: 'chrome',
+  // defaultBrowser: 'chrome',
   defaultCommandTimeout: 10000,
   video: true,
   videoCompression: true,

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -311,7 +311,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
       
       cy.contains(repoName).click();
       cy.get('ul[role="tablist"]').contains('Recent Events').click();
-      cy.get('section#events > div > table > tbody > tr.main-row').should('have.length', 2).then(() => {
+      cy.get('section#events table tr.main-row').should('have.length', 2).then(() => {
          cy.contains('GotNewCommit', { timeout: 20000 }).should('be.visible');
          cy.contains('GitJob was created', { timeout: 20000 }).should('be.visible');
          cy.contains('job deletion triggered because job succeeded', { timeout: 20000 }).should('not.exist');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -248,7 +248,7 @@ Cypress.Commands.add('accesMenuSelection', (firstAccessMenu='Continuous Delivery
   // added wait of 500ms to make time for CSS transitions to resolve (addresses tests flakiness)
   // unfortunately there's no "easy" way of waiting for transitions and 500ms is quick and does the trick
   cypressLib.burgerMenuToggle( {animationDistanceThreshold: 10} );
-  cy.wait(500);
+  cy.wait(750);
 
   cy.contains(firstAccessMenu).should('be.visible');
   cypressLib.accesMenu(firstAccessMenu);
@@ -632,8 +632,8 @@ Cypress.Commands.add('verifyJobDeleted', (repoName, verifyJobDeletedEvent = true
   // To be executed there or after cy.checkGitRepoStatus() function;
   if (verifyJobDeletedEvent) {
     cy.get('ul[role="tablist"]').contains('Recent Events').click();
-    cy.get('section#events > div > table > tbody > tr.main-row')
-      .eq(0)
+    cy.get('section#events table tr.main-row')
+      // .eq(0)
       .contains('job deletion triggered because job succeeded', { timeout: 20000 })
       .should('be.visible');
   };


### PR DESCRIPTION
Done:

- Adjusting locators to be compatible in 2.11. (mainly for jobs clean-up tests)
- Extending wait for hamburger menu due to speed in 2.11
- Removing flag `numTestsKeptInMemory`that caused certain issues.
- Confirmed that setting `Chrome` caused some tests to be flaky (in particular test Fleet-103): https://github.com/rancher/fleet-e2e/actions/runs/12991049858/job/36227693722#step:9:366