### PR TITLE
Added QASE ID to upgrade test to report QASE Tool

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	. "github.com/rancher-sandbox/qase-ginkgo"
 )
 
 const (
@@ -37,16 +38,17 @@ const (
 var (
 	arch                 			string
 	clusterName          			string
-	rancherHostname      			string
+	dsClusterCountStr    			string
 	k8sDownstreamVersion 			string
 	rancherChannel       			string
 	rancherHeadVersion   			string
-	rancherVersion       			string
+	rancherHostname      			string
 	rancherUpgrade       			string
-	dsClusterCountStr    			string
+	rancherVersion       			string
 	rancherUpgradeChannel     string
 	rancherUpgradeHeadVersion string
 	rancherUpgradeVersion     string
+	testCaseID                int64
 )
 
 /**
@@ -113,4 +115,14 @@ var _ = BeforeSuite(func() {
 			rancherUpgradeHeadVersion = s[2]
 		}
 	}
+})
+
+var _ = ReportBeforeEach(func(report SpecReport) {
+	// Reset case ID
+	testCaseID = -1
+})
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	// Add result in Qase if asked
+	Qase(testCaseID, report)
 })

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -36,6 +36,8 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 	}
 
 	It("Upgrades Rancher Manager", func() {
+		// Report to Qase
+		testCaseID = 52
 
 		// Get before-upgrade Rancher Manager version
 		getImageVersion := []string{


### PR DESCRIPTION
~Fixes: #266~
- In this PR, I have added the QASE ID to the upgrade test.
- This will ensure when we run CI for Upgrade will update the result of upgrade test in the QASE Tool.
- This PR will implement #266 