### PR TITLE
Add Sanity check for cluster after upgrade

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -394,6 +394,7 @@ jobs:
           RSA_PUBLIC_KEY_QA: ${{ secrets.rsa_public_key_qa }}
           GREPTAGS: ${{ inputs.grep_test_by_tag }}
           UPGRADE: ${{ inputs.upgrade }}
+          FLEET_APP_VERSION: ${{ steps.component.outputs.fleet_app_version }}
           SPEC: |
             cypress/e2e/unit_tests/first_login_rancher.spec.ts
             cypress/e2e/unit_tests/upgrade_fleet.spec.ts

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -48,6 +48,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.rsa_private_key_qa  = process.env.RSA_PRIVATE_KEY_QA;
   config.env.rsa_public_key_qa   = process.env.RSA_PUBLIC_KEY_QA;
   config.env.upgrade             = process.env.UPGRADE;
+  config.env.fleet_app_version   = process.env.FLEET_APP_VERSION;
   
   return config;
 };

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -28,6 +28,7 @@ docker run --init -v $PWD:/workdir -w /workdir              \
     -e "GREP=$GREP"                                         \
     -e "GREPTAGS=$GREPTAGS"                                 \
     -e "UPGRADE=$UPGRADE"                                   \
+    -e "FLEET_APP_VERSION=$FLEET_APP_VERSION"               \
     --add-host host.docker.internal:host-gateway            \
     --ipc=host                                              \
     $CYPRESS_DOCKER                                         \


### PR DESCRIPTION
In this PR below things will be performed:
- Updated `cy.log()` message for upgrade
- Read the Fleet image version before the upgrade
- From all downstream clusters, check the fleet-agent pod image after upgrade only
- This test only run after upgrade only to make sure Fleet is upgraded properly on it's downstream clusters too. 

_**Note: Current CI for PR check is not execute this test.**_