### PR TITLE
Added test for Fleet resource count on cluster

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1249,3 +1249,31 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
     )
   })
 };
+
+if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
+  describe('Test Fleet Resource Count', { tags: '@p1'}, () => {
+    qase(155,
+      it("Fleet-155: Test clusters resource count is correct", { tags: '@fleet-155' }, () => {
+        const repoName = 'default-cluster-count-155'
+        const branch = "master"
+        const path = "simple"
+        const repoUrl = "https://github.com/rancher/fleet-examples"
+
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+        cy.clickButton('Create');
+        cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6');
+
+        // Get the Resource count from GitRepo and store it.
+        cy.gitRepoResourceCountAsInteger(repoName, 'fleet-default');
+
+        // Compare Resource count from GitRepo(stored)
+        // with resource count from each downstream cluster.
+        dsAllClusterList.forEach((dsCluster) => {
+          cy.compareClusterResourceCount(dsCluster);
+        })
+
+        cy.deleteAllFleetRepos();
+      })
+    )
+  });
+}

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -53,6 +53,8 @@ declare global {
       verifyJobDeleted(repoName: string, verifyJobDeletedEvent?: boolean ): Chainable<Element>;
       typeIntoCanvasTermnal(textToType: string): Chainable<Element>;
       checkGitRepoAfterUpgrade(repoName: string, fleetNamespace?: string): Chainable<Element>;
+      gitRepoResourceCountAsInteger(repoName: string, fleetNamespace?: string): Chainable<Element>;
+      compareClusterResourceCount(clusterName: string): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
This PR will do:
- Creates GitRepo with `6 resources` on `each cluster.`
- There are `3 clusters` which already had `7 resources` (`ConfigMap, Fleet-agent, secrets etc.`)
- So the total resource count on `each cluster` will be `6+7=13`
- We are getting resource counts from GitRepo and clusters page itself.

Following actions are performed:
- Get the resources from `GitRepo page`.
- Add `7 default resources` to the count.
- Get the `total count of resource` available on `each cluster page`.
- Verify that `GitRepo Resource count` and `EQUAL TO` `Resource count` available on `each clusters page`.