### PR TITLE
Mitigation addition to improve test resilience in 2.11

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -230,6 +230,9 @@ describe('Test Self-Healing of resource modification when correctDrift option us
       cy.addFleetGitRepo({ repoName, correctDrift: 'yes', editConfig: true });
       cy.clickButton('Save');
       // This test is exception for using 'Force Update'.
+      // Wait added to mitigate problems before force ipdate on 2.11 onwards
+      // TODO: remove or rework when possible 
+      cy.wait(2000);
       cy.open3dotsMenu(repoName, 'Force Update');
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
       cy.checkApplicationStatus(appName);

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -459,6 +459,9 @@ Cypress.Commands.add('deleteApplicationDeployment', (clusterName='local') => {
 
 // Modify given application
 Cypress.Commands.add('modifyDeployedApplication', (appName, clusterName='local') => {
+  // Wait added to mitigate problems unfolding burger menu 2.11 onwards
+  // TODO: remove or rework when possible
+  cy.wait(2000);
   cypressLib.burgerMenuToggle();
   cypressLib.accesMenu(clusterName);
   cy.clickNavMenu(['Workloads', 'Deployments']);


### PR DESCRIPTION
Done:

Mitigated Fleet-77 flakiness in 2.11 by adding explicit waits on 2 key points: one to ensure the hamburger menu is displayed and another one to ensure action before `force update` is triggered is completed.

Note: This is a **MITIGATION** to make the test more resilient, **NOT A FIX**. I left notes explaining the reasons for the waits on the comment and a note to remove it / substitute it for something better in further refactors.

Test passing in Rancher `2.11.0-alpha10` [here](https://github.com/rancher/fleet-e2e/actions/runs/13750612017/job/38451146454#step:9:297)