### PR TITLE
Fix test 155 prevent it for failing

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1258,15 +1258,17 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
   describe('Test Fleet Resource Count', { tags: '@p1'}, () => {
     qase(155,
       it("Fleet-155: Test clusters resource count is correct", { tags: '@fleet-155' }, () => {
+
         const repoName = 'default-cluster-count-155'
         const branch = "master"
         const path = "simple"
         const repoUrl = "https://github.com/rancher/fleet-examples"
         let resourceCount = '18 / 18'
-        let sameResourceEachCluster = false
+        let multipliedResourceCount = true
+
         if (/\/2\.10/.test(Cypress.env('rancher_version')) || /\/2\.9/.test(Cypress.env('rancher_version'))) {
           resourceCount = '6 / 6'
-          sameResourceEachCluster = true
+          multipliedResourceCount = false
         }
 
         // Get Default Resources from single cluster before GitRepo.
@@ -1283,7 +1285,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         cy.actualResourceOnCluster(dsFirstClusterName);
 
         // Compare Resource count from GitRepo with Cluster resource.
-        cy.compareClusterResourceCount(sameResourceEachCluster);
+        cy.compareClusterResourceCount(multipliedResourceCount);
 
         cy.deleteAllFleetRepos();
       })

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1264,7 +1264,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         const repoUrl = "https://github.com/rancher/fleet-examples"
         let resourceCount = '18 / 18'
         let sameResourceEachCluster = false
-        if (/\/2\.10/.test(Cypress.env('rancher_version'))) {
+        if (/\/2\.10/.test(Cypress.env('rancher_version')) || /\/2\.9/.test(Cypress.env('rancher_version'))) {
           resourceCount = '6 / 6'
           sameResourceEachCluster = true
         }

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -1262,19 +1262,28 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         const branch = "master"
         const path = "simple"
         const repoUrl = "https://github.com/rancher/fleet-examples"
+        let resourceCount = '18 / 18'
+        let sameResourceEachCluster = false
+        if (/\/2\.10/.test(Cypress.env('rancher_version'))) {
+          resourceCount = '6 / 6'
+          sameResourceEachCluster = true
+        }
+
+        // Get Default Resources from single cluster before GitRepo.
+        cy.currentClusterResourceCount(dsFirstClusterName);
 
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
         cy.clickButton('Create');
-        cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6');
+        cy.checkGitRepoStatus(repoName, '1 / 1', resourceCount);
 
         // Get the Resource count from GitRepo and store it.
         cy.gitRepoResourceCountAsInteger(repoName, 'fleet-default');
 
-        // Compare Resource count from GitRepo(stored)
-        // with resource count from each downstream cluster.
-        dsAllClusterList.forEach((dsCluster) => {
-          cy.compareClusterResourceCount(dsCluster);
-        })
+        // Get Actual Resources from single cluster by subtracting default resources.
+        cy.actualResourceOnCluster(dsFirstClusterName);
+
+        // Compare Resource count from GitRepo with Cluster resource.
+        cy.compareClusterResourceCount(sameResourceEachCluster);
 
         cy.deleteAllFleetRepos();
       })

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -837,7 +837,7 @@ Cypress.Commands.add('actualResourceOnCluster', (clusterName) => {
   })
 })
 
-Cypress.Commands.add('compareClusterResourceCount', (sameResourceEachCluster) => {
+Cypress.Commands.add('compareClusterResourceCount', (multipliedResourceCount=true) => {
   // Get the stored 'gitRepoResourceCount' value and
   // Multipy 'actualResourceOnCluster' 3 times because 3 clusters.
   // Compare final result with the 'gitRepoTotalResourceCount'.
@@ -845,11 +845,11 @@ Cypress.Commands.add('compareClusterResourceCount', (sameResourceEachCluster) =>
     cy.get('@gitRepoTotalResourceCount').then((gitRepoTotalResourceCount) => {
       // When 'sameResourceEachCluster' is true then each cluster has 
       // 'actualResourceOnCluster' is equal to 'gitRepoResourceCount'
-      if (sameResourceEachCluster) {
-        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster);
+      if (multipliedResourceCount) {
+        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster * 3);
       }
       else {
-        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster * 3);
+        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster);
       }
     })
   })

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -783,6 +783,22 @@ Cypress.Commands.add('checkGitRepoAfterUpgrade', (repoName, fleetNamespace='flee
   cy.verifyTableRow(0, /Active|Modified/, repoName);
 });
 
+Cypress.Commands.add('currentClusterResourceCount', (clusterName) => {
+  cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+  cy.contains('.title', 'Clusters').should('be.visible');
+  cy.filterInSearchBox(clusterName);
+  cy.verifyTableRow(0, 'Active', clusterName);
+  cy.get('td.col-link-detail > span').contains(clusterName).click();
+  cy.get("div[primary-color-var='--sizzle-success'] div[class='data compact'] > h1")
+  .invoke('text')
+  .then((clusterResourceCountText) => {
+    // Convert to integer
+    const clusterCurrentResourceCount = parseInt(clusterResourceCountText.trim(), 10);
+    cy.log("Resource count on each cluster is: " + clusterCurrentResourceCount);
+    cy.wrap(clusterCurrentResourceCount).as('clusterCurrentResourceCount');
+  })
+})
+
 Cypress.Commands.add('gitRepoResourceCountAsInteger', (repoName, fleetNamespace='fleet-local') => {
   cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
   cy.fleetNamespaceToggle(fleetNamespace);
@@ -790,35 +806,51 @@ Cypress.Commands.add('gitRepoResourceCountAsInteger', (repoName, fleetNamespace=
   cy.contains(repoName).click()
   cy.get('.primaryheader > h1').contains(repoName).should('be.visible')
 
-  // Get the Resource count text from UI and convert it into integer.
   cy.get("div[data-testid='gitrepo-deployment-summary'] div[class='count']")
   .invoke('text')
-  .then((countText) => {
-    // Add '7' default resource count available on each cluster.
-    const gitRepoResourceCount = parseInt(countText.trim(), 10) + 7;
-    cy.log("GitRepo Resource count is: " + gitRepoResourceCount);
-    cy.wrap(gitRepoResourceCount).as('gitRepoResourceCount');
+  .then((gitRepoResourceCountText) => {
+    const gitRepoTotalResourceCount = parseInt(gitRepoResourceCountText.trim(), 10);
+    cy.log("GitRepo Resource count is: " + gitRepoTotalResourceCount);
+    cy.wrap(gitRepoTotalResourceCount).as('gitRepoTotalResourceCount');
   })
 })
 
-Cypress.Commands.add('compareClusterResourceCount', (clusterName) => {
-  // Check the resource count from each cluster matches with resources created by GitRepo.
+Cypress.Commands.add('actualResourceOnCluster', (clusterName) => {
+// Get Cluster Resources before GitRepo created.
   cy.accesMenuSelection('Continuous Delivery', 'Clusters');
   cy.contains('.title', 'Clusters').should('be.visible');
   cy.filterInSearchBox(clusterName);
   cy.verifyTableRow(0, 'Active', clusterName);
   cy.get('td.col-link-detail > span').contains(clusterName).click();
+  // Get resources from the cluster page after GitRepo install.
+  cy.get("div[primary-color-var='--sizzle-success'] div[class='data compact'] > h1")
+  .invoke('text')
+  .then((clusterResourceCountText) => {
+    const resourceCountOnCluster = parseInt(clusterResourceCountText.trim(), 10);
+    cy.log("Resource count on each cluster is: " + resourceCountOnCluster);
+    cy.get('@clusterCurrentResourceCount').then((clusterCurrentResourceCount) => {
+      // Remove default 6/7 resources from Total resources available
+      // on single cluster after GitRepo install it's resources.
+      const actualResourceOnCluster = resourceCountOnCluster - clusterCurrentResourceCount;
+      cy.wrap(actualResourceOnCluster).as('actualResourceOnCluster');
+    })
+  })
+})
 
+Cypress.Commands.add('compareClusterResourceCount', (sameResourceEachCluster) => {
   // Get the stored 'gitRepoResourceCount' value and
-  // compare with existing resource count from cluster.
-  cy.get('@gitRepoResourceCount').then((gitRepoResourceCount) => {
-    cy.get("div[primary-color-var='--sizzle-success'] div[class='data compact'] > h1")
-    .invoke('text')
-    .then((clusterResourceCountText) => {
-      // Covert it into integer and then compare with resources created via GitRepo.
-      const resourceCountOnCluster = parseInt(clusterResourceCountText.trim(), 10);
-      cy.log("Resource count on each cluster is: " + resourceCountOnCluster);
-      expect(gitRepoResourceCount).to.equal(resourceCountOnCluster);
+  // Multipy 'actualResourceOnCluster' 3 times because 3 clusters.
+  // Compare final result with the 'gitRepoTotalResourceCount'.
+  cy.get('@actualResourceOnCluster').then((actualResourceOnCluster) => {
+    cy.get('@gitRepoTotalResourceCount').then((gitRepoTotalResourceCount) => {
+      // When 'sameResourceEachCluster' is true then each cluster has 
+      // 'actualResourceOnCluster' is equal to 'gitRepoResourceCount'
+      if (sameResourceEachCluster) {
+        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster);
+      }
+      else {
+        expect(gitRepoTotalResourceCount).to.equal(actualResourceOnCluster * 3);
+      }
     })
   })
 })

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -54,9 +54,11 @@ declare global {
       typeIntoCanvasTermnal(textToType: string): Chainable<Element>;
       checkGitRepoAfterUpgrade(repoName: string, fleetNamespace?: string): Chainable<Element>;
       gitRepoResourceCountAsInteger(repoName: string, fleetNamespace?: string): Chainable<Element>;
-      compareClusterResourceCount(clusterName: string): Chainable<Element>;
+      compareClusterResourceCount(sameResourceEachCluster: boolean): Chainable<Element>;
       createNewUser(username: string, password: string, role: string, uncheckStandardUser?: boolean): Chainable<Element>;
       addFleetGitRepoNew(repoName: string, repoUrl?: string, branch?: string, path?: string, path2?: string, fleetNamespace?: string, editConfig?: boolean, helmUrlRegex?: string, deployToTarget?: string, tlsOption?: string, tlsCertificate?: string, allowedTargetNamespace?: string): Chainable<Element>;
+      currentClusterResourceCount(clusterName: string): Chainable<Element>;
+      actualResourceOnCluster(clusterName: string): Chainable<Element>;
     }
   }
 }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -54,7 +54,7 @@ declare global {
       typeIntoCanvasTermnal(textToType: string): Chainable<Element>;
       checkGitRepoAfterUpgrade(repoName: string, fleetNamespace?: string): Chainable<Element>;
       gitRepoResourceCountAsInteger(repoName: string, fleetNamespace?: string): Chainable<Element>;
-      compareClusterResourceCount(sameResourceEachCluster: boolean): Chainable<Element>;
+      compareClusterResourceCount(multipliedResourceCount: boolean): Chainable<Element>;
       createNewUser(username: string, password: string, role: string, uncheckStandardUser?: boolean): Chainable<Element>;
       addFleetGitRepoNew(repoName: string, repoUrl?: string, branch?: string, path?: string, path2?: string, fleetNamespace?: string, editConfig?: boolean, helmUrlRegex?: string, deployToTarget?: string, tlsOption?: string, tlsCertificate?: string, allowedTargetNamespace?: string): Chainable<Element>;
       currentClusterResourceCount(clusterName: string): Chainable<Element>;


### PR DESCRIPTION
## There are few updation in the Resource count, Test is failing due to that.
- https://github.com/rancher/fleet/pull/3209
- https://github.com/rancher/fleet/issues/3186
- https://github.com/rancher/fleet/pull/3238
- https://github.com/rancher/dashboard/pull/13244

---

## How to count Resources In Test :
### Given:
- **Total resources GitRepo will install** = Total 18 
- **Default resources already present per cluster** = 6
- **Number of clusters** = 3

### Step-by-step Calculation:

1. **Total resources after GitRepo created**:
   -  Total 18 resources are created on 3 clusters, i.e. 6 resources each cluster.

2. **Subtract the default resources to find new resources installed**:
   - For each cluster:  
     New resources installed = 12  (total resources) - 6 (default resources) = 6 (_new resources_)
   
3. **Verify total installed resources on all clusters with GitRepo installed resources.**:
   - Total resources installed across **3 clusters** =  **6 * 3 = 18** _new resources_.
   - GitRepo installed resources are 18 **(Matched)**

---

<details>
<summary><b>Here is another example with 3 resources</b></summary>

### Given:
- **Total resources to install** = 3
- **Default resources already present per cluster** = 6
- **Number of clusters** = 3

### Step-by-step Calculation:

1. **Total resources after installation**:
   - Total 3 resources are created on 3 clusters, so, 1 _new resource_ will be installed on each cluster.

2. **Subtract the default resources to find new resources installed**:
   - For each cluster:  
     New resources installed = 7  (total resources) - 6 (default resources) = 1 (_new resources_)

3. **Check total installed resources on all clusters**:
   - Total resources installed across 3 clusters = 1 * 3 = 3 new resources.
</details>

---

<details>
<summary><b>Here is example for 2.10 with 6 resources.</b></summary>

### Given:
- **Total resources GitRepo will install** = 6
- **Default resources already present per cluster** = 6
- **Number of clusters** = 3

### Step-by-step Calculation:

1. **Total resources after GitRepo created**:
   -  6 resources each cluster.
   
2. **Verify total installed resources on all clusters with GitRepo installed resources.**:
   - Total resources installed across **3 clusters** each =  **6** _new resources_.
   - GitRepo installed resources are 6 **(Matched)**
</details>

<details>
<summary><b>For 2.10 UI shows resource same resource count.</b></summary>

![image](https://github.com/user-attachments/assets/3fcbd683-838d-4502-bf01-d5687648ebb3)

</details>