### PR TITLE
New 2.11 lane fix and GitRepo function update

### DIFF
--- a/.github/workflows/ui-rm_head_2.11.yaml
+++ b/.github/workflows/ui-rm_head_2.11.yaml
@@ -55,6 +55,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.30.8+k3s1' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.11' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @rbac' }}

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -89,9 +89,10 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path
 
   //Version check for 2.11 (head) onwards
   const alpha_or_prime_versions = [/^(prime|prime-optimus|alpha)\/2\.(1[1-9]|[2-9]\d*)(\..*)?$/];
+  const devel_or_head_versions = ["latest/devel/head", "latest/devel/2.11"]
 
   // TODO: re-work on regex more to include 2.11 onwards and not before versions in it.
-  if ("latest/devel/2.11".includes(rancherVersion) || alpha_or_prime_versions.some(regex => regex.test(rancherVersion))){
+  if (devel_or_head_versions.includes(rancherVersion) || alpha_or_prime_versions.some(regex => regex.test(rancherVersion))){
     cy.addFleetGitRepoNew({ repoName, repoUrl, branch, path, path2, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, tlsOption, tlsCertificate, keepResources, correctDrift, fleetNamespace, editConfig, helmUrlRegex, deployToTarget, allowedTargetNamespace})
   }
   else{


### PR DESCRIPTION
- In this PR, it will fix the default head version instead of 2.11
- Also, added constant to include the head version as well as 2.11 version in `addGitRepo` function.