### PR TITLE
New  known-host and life cycle features

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -137,12 +137,12 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     });
   });
 
-  qase(141,
-    it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
-
-      const repoName = 'local-cluster-fleet-141';
-      const gitAuthType = 'ssh-key-knownhost';
-  
+    // Ensure flag `insecureSkipHostKeyChecks: false` is passed
+    // This is not mant to be in QASE
+    // Workaround to type into canvas
+    // It should be nested data under fleet
+    // TODO: remove this once this becomes default behavior
+    it('Add special flag to test default known-hosts', () => {
       // Open local terminal in Rancher UI
       cy.accesMenuSelection('local');
       cy.get('#btn-kubectl').click();
@@ -168,6 +168,14 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       
       // Close local terminal
       cy.get('i.closer.icon').click();
+    })
+
+  qase(141,
+    it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
+
+      const repoName = 'local-cluster-fleet-141';
+      const gitAuthType = 'ssh-key-knownhost';
+  
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       
       // Create private repo using known host

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -170,6 +170,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       cy.get('i.closer.icon').click();
     })
 
+  // Custom / no default
   qase(141,
     it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
 
@@ -187,6 +188,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );
 
+  // Custom error / no default
   qase(143,
     it('FLEET-143  Test apps cannot be installed when using missmatched "KNOWN HOSTS" auth on PRIVATE repository',
       { tags: '@fleet-143' }, () => {
@@ -205,6 +207,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );
 
+  // Default verify
   qase(168,
     it('FLEET-168 Verify Fleet default known-host is set on configmap',
       { tags: '@fleet-168' }, () => {
@@ -218,6 +221,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );
 
+  // No custom / yes default
   qase(169,
     it('FLEET-169 Verify that without custom known-host, fleet uses default custom ones from defined in configmap',
       { tags: '@fleet-169' }, () => {
@@ -244,6 +248,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );  
 
+  // No ssh , then no default
   qase(170,
     it('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
       { tags: '@fleet-170' }, () => {
@@ -261,6 +266,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );  
 
+  // No custom + no default -> nothing gets deployed
   // TODO: re-do ensuring that known-host default can be brought up safely
   qase(171,
     it.skip('FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed',

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -138,7 +138,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
   });
 
   qase(141,
-    it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
+    it.only('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
 
       const repoName = 'local-cluster-fleet-141';
       const gitAuthType = 'ssh-key-knownhost';
@@ -163,7 +163,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       }'{enter}`
     );
       // Forcing wait to ensure flag is ready
-      cy.wait(30000);
+      // cy.wait(30000);
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       // Create private repo using known host
       cy.fleetNamespaceToggle('fleet-local');
@@ -231,7 +231,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
   );  
 
   qase(170,
-    it('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
+    it.only('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
       { tags: '@fleet-170' }, () => {
 
         const repoName = 'local-cluster-fleet-170';
@@ -249,7 +249,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
   );  
 
   qase(171,
-    it('FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed',
+    it.skip('FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed',
       { tags: '@fleet-171' }, () => {
 
         const repoName = 'local-cluster-fleet-171';
@@ -277,6 +277,8 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         cy.clickButton('Create');
         // Enrure that apps cannot be installed && error appears
         cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
+
+        
     })
   )})
 };

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -163,7 +163,9 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       }'{enter}`
     );
       // Forcing wait to ensure flag is ready
-      // cy.wait(30000);
+      cy.wait(30000);
+      // Close local terminal
+      cy.get('i.closer.icon').click();
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       // Create private repo using known host
       cy.fleetNamespaceToggle('fleet-local');

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -111,6 +111,8 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
   });
 });
 
+if (!/\/2\.8/.test(Cypress.env('rancher_version'))) {
+
 describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p0' }, () => {
   const repoUrl = 'git@github.com:fleetqa/fleet-qa-examples.git';
   const secretKnownHostsKeys = ['assets/known-host.yaml', 'assets/known-host-missmatch.yaml'];
@@ -274,8 +276,8 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         // Enrure that apps cannot be installed && error appears
         cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
     })
-  );  
-});
+  )})
+};
 
 describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
   qase(142,

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -138,7 +138,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
   });
 
   qase(141,
-    it.only('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
+    it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', { tags: '@fleet-141' }, () => {
 
       const repoName = 'local-cluster-fleet-141';
       const gitAuthType = 'ssh-key-knownhost';
@@ -231,7 +231,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
   );  
 
   qase(170,
-    it.only('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
+    it('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
       { tags: '@fleet-170' }, () => {
 
         const repoName = 'local-cluster-fleet-170';

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -162,6 +162,8 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         }
       }'{enter}`
     );
+      // Forcing wait to ensure flag is ready
+      cy.wait(30000);
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
       // Create private repo using known host
       cy.fleetNamespaceToggle('fleet-local');

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -148,25 +148,28 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       cy.get('#btn-kubectl').click();
       cy.contains('Connected').should('be.visible');
       
-    // Ensure flag `insecureSkipHostKeyChecks: false` is passed
-    // Workaround to type into canvas
-    // It needs nested data under fleet
-    // TODO: remove this once default behavior 
-    cy.typeIntoCanvasTermnal(`\
-      kubectl patch configmap rancher-config \
-      -n cattle-system \
-      --type merge \
-      -p '{
-        "data": {
-          "fleet": "insecureSkipHostKeyChecks: false"
-        }
-      }'{enter}`
-    );
+      // Ensure flag `insecureSkipHostKeyChecks: false` is passed
+      // Workaround to type into canvas
+      // It should be nested data under fleet
+      // TODO: remove this once default behavior 
+      cy.typeIntoCanvasTermnal(`\
+        kubectl patch configmap rancher-config \
+        -n cattle-system \
+        --type merge \
+        -p '{
+          "data": {
+            "fleet": "insecureSkipHostKeyChecks: false"
+          }
+        }'{enter}`
+      );
+
       // Forcing wait to ensure flag is ready
       cy.wait(30000);
+      
       // Close local terminal
       cy.get('i.closer.icon').click();
       cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
+      
       // Create private repo using known host
       cy.fleetNamespaceToggle('fleet-local');
       cy.addFleetGitRepo({ repoName, repoUrl, gitAuthType, branch, path });
@@ -250,6 +253,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
     })
   );  
 
+  // TODO: re-do ensuring that known-host default can be brought up safely
   qase(171,
     it.skip('FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed',
       { tags: '@fleet-171' }, () => {
@@ -278,9 +282,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, userOrPublicKey, pwdOrPrivateKey });
         cy.clickButton('Create');
         // Enrure that apps cannot be installed && error appears
-        cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
-
-        
+        cy.verifyTableRow(0, /Error|Git Updating/, '0/0');        
     })
   )})
 };
@@ -561,7 +563,7 @@ if (!/\/2\.8/.test(Cypress.env('rancher_version'))) {
     const path = 'simple-chart';
 
     qase(172,
-      it('Test gitjob can store helm values in secret', { tags: '@fleet-172' }, () => {
+      it('Fleet-172 Test gitjob can store helm values in secret', { tags: '@fleet-172' }, () => {
 
         const repoName = 'simple-chart-secret';
   

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -171,6 +171,7 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
       cy.fleetNamespaceToggle('fleet-local');
       cy.addFleetGitRepo({ repoName, repoUrl, gitAuthType, branch, path });
       cy.clickButton('Create');
+      cy.verifyTableRow(0, 'Active', '1/1');
       cy.checkGitRepoStatus(repoName, '1 / 1');
     })
   );
@@ -246,7 +247,6 @@ describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path});
         cy.clickButton('Create');
         cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
-        cy.contains('SSH private key file is required for SSH/SCP-style URLs: git@github.com:fleetqa/fleet-qa-examples.git').should('be.visible');
     })
   );  
 


### PR DESCRIPTION
Description of what automated:

### Tests around new  `default known-host` feature when special flag is set to `false`(currently set to `true`:

- New test to apply special flag
- https://app.qase.io/case/FLEET-168
- https://app.qase.io/case/FLEET-169
- https://app.qase.io/case/FLEET-170
- https://app.qase.io/case/FLEET-171 (Skipped for the moment)

### Test About new life cycle feature:
- https://app.qase.io/case/FLEET-172

---
### CI:

- [2.11 #86](https://github.com/rancher/fleet-e2e/actions/runs/14464264647)
- [prime-optimus-alpha/2.10.5-alpha1 #154](https://github.com/rancher/fleet-e2e/actions/runs/14464307781)
- [2.9 #922](https://github.com/rancher/fleet-e2e/actions/runs/14464331319)

