### PR TITLE
Fleetqa/making polling tests resilient

### DIFF
--- a/tests/assets/webhook-tests/webhook_setup.sh
+++ b/tests/assets/webhook-tests/webhook_setup.sh
@@ -41,6 +41,8 @@ done
 
 echo "All webhooks deleted."
 
+sleep 3 # Adding a bit of sleep to get things to settle
+
 # Create new adhock webhook with the specific Google External IP
 wget --quiet \
      --method=POST \

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -527,7 +527,12 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
     const gh_private_pwd = Cypress.env('gh_private_pwd');
     const repoName = 'test-disable-polling';
 
-    beforeEach('Ensuring Github repo has desired amount of replicas (2)', () => {
+    // Function to prepare Github repo used in the test
+    // It will make sure it starts with 2 replicas and changes it to 5
+    // We use this instead of hook to make it more resilient
+    function prepareGithubRepoReplicas() {
+
+      // Ensuring Github repo has desired amount of replicas (2)
       cy.exec('bash assets/disable_polling_reset_2_replicas.sh', { env: { gh_private_pwd } }).then((result) => {
         cy.log(result.stdout, result.stderr);
       });
@@ -545,9 +550,8 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
       cy.exec('bash assets/disable_polling_setting_5_replicas.sh').then((result) => {
         cy.log(result.stdout, result.stderr);
       });
-      cy.wait(1000); // I think a bit of time here may make the hook more resilient
-    });
-
+    }
+    
     if (!/\/2\.9/.test(Cypress.env('rancher_version'))) { 
     // Skipping in 2.9 due to https://github.com/rancher/fleet/issues/3048
     qase(126,
@@ -555,6 +559,9 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github',
         { tags: '@fleet-126', retries: 1 }, // TODO: Retry added to avoid intermittent failures. Remove once fixed.
         () => {
+
+          prepareGithubRepoReplicas()
+          
           // Forcing 15 seconds of wait to check if changes occur after this time.
           cy.wait(15000);
 
@@ -588,6 +595,9 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         'Fleet-124: Test when `disablePolling=true` Gitrepo will not sync latest changes from Github',
         { tags: '@fleet-124' },
         () => {
+
+          prepareGithubRepoReplicas()
+
           // Forcing 15 seconds of wait to check if changes occur after this time.
           cy.wait(15000);
 
@@ -604,6 +614,9 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
         'Fleet-125: Test when `disablePolling=true` and pausing / unpausing Gitrepo will sync latest changes from Github',
         { tags: '@fleet-125' },
         () => {
+
+          prepareGithubRepoReplicas()
+
           cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
           cy.fleetNamespaceToggle('fleet-local');
           cy.open3dotsMenu(repoName, 'Pause');

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -521,7 +521,9 @@ if (!/\/2\.9/.test(Cypress.env('rancher_version'))) {
 }
 
 if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env('rancher_version'))) {
+
   describe('Tests with disablePolling', { tags: '@p1' }, () => {
+  
     const gh_private_pwd = Cypress.env('gh_private_pwd');
     const repoName = 'test-disable-polling';
 
@@ -543,6 +545,7 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
       cy.exec('bash assets/disable_polling_setting_5_replicas.sh').then((result) => {
         cy.log(result.stdout, result.stderr);
       });
+      cy.wait(1000); // I think a bit of time here may make the hook more resilient
     });
 
     if (!/\/2\.9/.test(Cypress.env('rancher_version'))) { 


### PR DESCRIPTION
## Problem
CI fails too often on a Hook Before each breaking other tests on the describe.

## Remediation
- Added small wait on the tests/assets/webhook-tests/webhook_setup.sh script before next step to ensure better working.
- Changing `BeforeEach` hook in favor on new function `prepareGithubRepoReplicas` which is called each time within each test. This will ensure that if it fails on one test another one is not skipped. 

## Test
Done within the whole p1 suite to ensure it mimics the closer regular ci's
- Head: https://github.com/rancher/fleet-e2e/actions/runs/14730184048/job/41342321803#step:9:313