### PR TITLE
Workaround for known-host-tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -300,29 +300,33 @@ if (!/\/2\.8/.test(Cypress.env('rancher_version'))) {
           cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
           cy.contains('Strict host key checks are enforced, but no known_hosts data was found').should('be.visible')
       })
-    );
-
-    after('Returning custom known_host values', () => {
-      
-      cy.accesMenuSelection('local', 'Storage', 'ConfigMaps');
-      cy.nameSpaceMenuToggle('All Namespaces');
-      cy.filterInSearchBox('known-hosts');
-      cy.open3dotsMenu('known-hosts', 'Edit Config')
-      cy.clickButton('Remove')
-      
-      // Attach file from 'fixtures' directory since it is native for Cypress
-      cy.get("section[id='data'] input[type='file']").attachFile('known_hosts')
-      cy.contains('bitbucket').should('be.visible')
-      cy.wait(500); // Needs time for previous command to finnish
-      cy.clickButton('Save')
-      cy.wait(500); // Needs time for previous command to finnish
-      cy.log('"known_host" values returned')
-    })
-    
+    ); 
   })
 };
 
 describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
+
+  // Adding hook hee to ensure its excution if the previous tests fails
+  // TODO: rework this better on the previous known-host tests
+
+  before('Returning custom known_host values', () => {
+    
+    cy.login();
+    cy.accesMenuSelection('local', 'Storage', 'ConfigMaps');
+    cy.nameSpaceMenuToggle('All Namespaces');
+    cy.filterInSearchBox('known-hosts');
+    cy.open3dotsMenu('known-hosts', 'Edit Config')
+    cy.clickButton('Remove')
+    
+    // Attach file from 'fixtures' directory since it is native for Cypress
+    cy.get("section[id='data'] input[type='file']").attachFile('known_hosts')
+    cy.contains('bitbucket').should('be.visible')
+    cy.wait(500); // Needs time for previous command to finnish
+    cy.clickButton('Save')
+    cy.wait(500); // Needs time for previous command to finnish
+    cy.log('"known_host" values returned')
+  })
+
   qase(142,
     it("Fleet-142: Test Fleet can create cabundle secrets", { tags: '@fleet-142' }, () => {;
       


### PR DESCRIPTION
If test 171 is not successfull, hook to restablish known host is not working like [here](https://github.com/rancher/fleet-e2e/actions/runs/14875260608/job/41771294619#step:9:297) in 2.10.

This is a workaround moving the `after` hook at the end of 171 into a `before` hook next test.

It needs to be refined later, but for now it should let 2.10 test cases pass