### PR TITLE
Removing workaround calls closePopWindow after bug fix

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -288,10 +288,6 @@ if (!/\/2\.8/.test(Cypress.env('rancher_version'))) {
           cy.wait(500); // Needs time for previous command to finish
           cy.clickButton('Save')
           cy.wait(500); // Needs time for previous command to finish
-
-          // TODO: remove once this bug is fixed: 
-          // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-          cy.closePopWindow('ConfigMap Creation Warning')
                 
           // Verify gitrepo is added using default knownhost
           cy.accesMenuSelection('Continuous Delivery', 'Git Repos')

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -482,11 +482,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         cy.clickNavMenu(['Git Repos']);
         cy.wait(500);
 
-
-        // TODO: remove once this bug is fixed: 
-        // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-        cy.closePopWindow('Warning')
-
         cy.clickButton('Add Repository');
         cy.contains('Git Repo:').should('be.visible');
         cy.clickButton('Edit as YAML');
@@ -564,11 +559,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
       cy.clickNavMenu(['Git Repos']);
       cy.wait(500);
       
-      
-      // TODO: remove once this bug is fixed: 
-      // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-      cy.closePopWindow('Warning')
-      
       cy.clickButton('Add Repository');
       cy.contains('Git Repo:').should('be.visible');
       cy.clickButton('Edit as YAML');
@@ -619,10 +609,6 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
         cy.removeClusterLabels(dsCluster, key, value);
       }
     )
-
-    // TODO: remove once this bug is fixed: 
-    // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-    cy.closePopWindow('Warning')
 
     cy.deleteClusterGroups();
     cy.deleteAllFleetRepos();
@@ -682,10 +668,6 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
         // Create a GitRepo targeting cluster group created from YAML.
         cy.clickNavMenu(['Git Repos']);
         cy.wait(500);
-
-        // TODO: remove once this bug is fixed: 
-        // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-        cy.closePopWindow('Warning')
 
         cy.clickButton('Add Repository');
         cy.contains('Git Repo:').should('be.visible');

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -144,20 +144,12 @@ describe('Test Self-Healing of resource modification when correctDrift option us
       // Update exising GitRepo by enabling 'correctDrift'
       cy.addFleetGitRepo({ repoName, correctDrift: 'yes', editConfig: true });
       cy.clickButton('Save');
-      
-      // TODO: remove once this bug is fixed: 
-      // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-      cy.closePopWindow('Warning')
 
       // This test is exception for using 'Force Update'.
       // Wait added to mitigate problems before force ipdate on 2.11 onwards
       // TODO: remove or rework when possible 
       cy.wait(2000);
       cy.open3dotsMenu(repoName, 'Force Update');
-
-      // TODO: remove once this bug is fixed: 
-      // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-      cy.closePopWindow('Warning')
 
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
       cy.checkApplicationStatus(appName);
@@ -495,10 +487,6 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
           cy.filterInSearchBox('nginx-test-polling');
           cy.wait(500);
 
-          // TODO: remove once this bug is fixed: 
-          // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-          cy.closePopWindow('Warning')
-
           cy.log('HERE WE SHOULD SEE 2/2');
           cy.contains('tr.main-row', 'nginx-test-polling', { timeout: 20000 }).should('be.visible');
           cy.screenshot('Screenshot BEFORE reloading should be 2/2');
@@ -551,17 +539,9 @@ if (!/\/2\.7/.test(Cypress.env('rancher_version')) && !/\/2\.8/.test(Cypress.env
           cy.fleetNamespaceToggle('fleet-local');
           cy.open3dotsMenu(repoName, 'Pause');
 
-          // TODO: remove once this bug is fixed: 
-          // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-          cy.closePopWindow('Warning')
-
           cy.verifyTableRow(0, 'Paused');
           cy.wait(2000); // Wait to let time for pause to take effect.
           cy.open3dotsMenu(repoName, 'Unpause');
-
-          // TODO: remove once this bug is fixed: 
-          // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-          cy.closePopWindow('Warning')
 
           cy.verifyTableRow(0, 'Active');
           // Verify deployment changes to 5?

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -267,10 +267,6 @@ Cypress.Commands.add('open3dotsMenu', (name, selection, checkNotInMenu=false) =>
             .contains(selection).should('not.exist');
         }
     });
-    
-    // TODO: remove once this bug is fixed: 
-    // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-    cy.closePopWindow('Warning')
 
     // Close 3 dots button menu
     cy.get('body').should('exist').click({ force: true });
@@ -347,11 +343,6 @@ Cypress.Commands.add('nameSpaceMenuToggle', (namespaceName) => {
   cy.get('div.ns-item').contains(namespaceName).scrollIntoView()
   cy.get('div.ns-item').contains(namespaceName).click()
   cy.get('div.ns-dropdown.ns-open > i.icon.icon-chevron-up').click({ force: true });
-
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
-  
 })
 
 // Command to filter text in searchbox
@@ -490,10 +481,6 @@ Cypress.Commands.add('modifyDeployedApplication', (appName, clusterName='local')
   // TODO: Add logic to increase resource count to given no.
   cy.get('.icon-plus').click();
   cy.get('#trigger > .icon.icon-chevron-up').click({ force: true });
-  
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
 });
 
 // Create Role Template (User & Authentication)
@@ -636,10 +623,6 @@ Cypress.Commands.add('upgradeFleet', () => {
 // Add label to the imported cluster(s)
 Cypress.Commands.add('assignClusterLabel', (clusterName, key, value) => {
   
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
-  
   cy.filterInSearchBox(clusterName);
   cy.open3dotsMenu(clusterName, 'Edit Config');
   cy.clickButton('Add Label');
@@ -655,11 +638,6 @@ Cypress.Commands.add('assignClusterLabel', (clusterName, key, value) => {
 // Create clusterGroup based on label assigned to the cluster
 Cypress.Commands.add('createClusterGroup', (clusterGroupName, key, value, bannerMessageToAssert, assignClusterGroupLabel=false, clusterGroupLabelKey, clusterGroupLabelValue) => {
   cy.fleetNamespaceToggle('fleet-default');
-
-
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
 
   cy.clickButton('Create');
   cy.get('input[placeholder="A unique name"]').type(clusterGroupName);
@@ -707,17 +685,10 @@ Cypress.Commands.add('deleteClusterGroups', () => {
 
 // Remove added labels from the cluster(s)
 Cypress.Commands.add('removeClusterLabels', (clusterName, key, value) => {
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
+
   cy.accesMenuSelection('Continuous Delivery', 'Git Repos');
   cy.clickNavMenu(['Clusters']);
   cy.contains('.title', 'Clusters').should('be.visible');
-
-  // TODO: remove once this bug is fixed: 
-  // https://github.com/rancher/dashboard/issues/14295#issuecomment-2862105017
-  cy.closePopWindow('Warning')
-
   cy.filterInSearchBox(clusterName);
   cy.open3dotsMenu(clusterName, 'Edit Config');
   cy.contains('.title', 'Cluster:').should('be.visible');


### PR DESCRIPTION

Removing calls to `closePopWindow` after fix of https://github.com/rancher/dashboard/issues/14295

Tested in [prime-optimus-alpha/2.10.6-alpha6](https://github.com/rancher/fleet-e2e/actions/runs/15108876055/job/42463642506) and no traces of pop-up window appeared