### PR TITLE
updating branch to use 2.12-stable branch

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -54,6 +54,10 @@ on:
         description: Qase API token to use for Qase reporting
         required: true
     inputs:
+      branch:
+        description: Specify branch name to run workflow on
+        type: string
+        required: false
       cluster_name:
         description: Name of the provisioned cluster
         type: string
@@ -250,6 +254,11 @@ jobs:
         with:
           cache: false
           go-version-file: tests/go.mod
+      - name: Checkout
+        if: ${{ inputs.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}  
       - name: Install Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -5,6 +5,10 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: '2.12-stable'
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto
@@ -15,7 +19,7 @@ on:
         type: boolean
       rancher_version:
         description: Rancher version channel/version/head_version latest/latest, latest/2.11.x[-rc1], prime/2.11.x, prime/devel/2.11, alpha/2.11.0-alpha1
-        default: latest/2.12.0-rc1
+        default: latest/devel/head
         type: string
         required: true
       upstream_cluster_version:
@@ -55,6 +59,7 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.32.4+k3s1' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/2.12.0-rc1' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}
+      branch: ${{ inputs.branch || '2.12-stable' }}


### PR DESCRIPTION
Updating tests on 2.12 to point to specific branch 2.12-stable
Updating Rancher channel to latest/devel/head

Test on head ci pointing to 2.12 stable branch: https://github.com/rancher/fleet-e2e/actions/runs/16003447775/job/45144680364
