### PR TITLE
Fleetqa/bumping qa library and updating 211 lane

### DIFF
--- a/.github/workflows/ui-rm_head_2.11.yaml
+++ b/.github/workflows/ui-rm_head_2.11.yaml
@@ -15,7 +15,7 @@ on:
         type: boolean
       rancher_version:
         description: Rancher version channel/version/head_version latest/latest, latest/2.11.x[-rc1], prime/2.11.x, prime/devel/2.11, alpha/2.11.0-alpha1
-        default: latest/devel/2.11
+        default: head/2.11
         type: string
         required: true
       upstream_cluster_version:
@@ -55,6 +55,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.32.4+k3s1' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.11' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.11' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -131,10 +131,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250321085640-0562ffe2108e h1:UygAWC2PKLmNiNghmrAOFZs/nN+MUkqw6OYo8MNmT1c=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250321085640-0562ffe2108e/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793 h1:NIioaBqH1VA1NbAqWRG+SjxSW7z/EOU8jcEIFbDW8lc=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a h1:s/tYg69rbYbIa93r4oZcZKU445rfH4mbhHQM/jafm4w=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION

Bumping latest test-ele-helpers library
Updating 2.11 channel:

Working here: https://github.com/rancher/fleet-e2e/actions/runs/16219291065
<img width="1560" height="902" alt="image" src="https://github.com/user-attachments/assets/ec004e98-7d6a-49d6-b0b8-7f3b228a9494" />
