### PR TITLE
Working PoC for adding ds clusters via rancher API

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -258,7 +258,7 @@ jobs:
         if: ${{ inputs.branch }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}  
+          ref: ${{ inputs.branch }}
       - name: Install Node
         uses: actions/setup-node@v4
         with:
@@ -267,6 +267,7 @@ jobs:
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}
           PUBLIC_DOMAIN: bc.googleusercontent.com
+          RANCHER_PASSWORD: ${{ secrets.rancher_password }}
         run: cd tests && make e2e-install-rancher
       - name: Extract component versions/informations
         id: component
@@ -330,7 +331,7 @@ jobs:
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
-        if: failure() 
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots-basics-${{ inputs.cluster_name }}
@@ -438,7 +439,7 @@ jobs:
           path: tests/cypress/videos
           retention-days: 7
       - name: Upload webhook setup log
-        if: failure() 
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: webhook-setup-log-${{ inputs.cluster_name }}


### PR DESCRIPTION
This PR should resolve problems with unsupported way how we were creating ds clusters for import.

TL;DR - it uses basically two http POST requests:
1. to get rancher API token
2. use the token to create new clusters and parse the output to get internal cluster name
---
* testrun on head/2.11: https://github.com/rancher/fleet-e2e/actions/runs/16624867916

Now it uses Rancher API calls captured on 2.12 for (see cURL equivalents):
* getting a API token:
```bash
RANCHER_PASSWORD=#<<<REPLACE___ME>>>
RANCHER_HOST=1.2.3.4.nip.io #<<<REPLACE___ME>>>
TOKEN=$(curl -k -s -X POST -H 'Accept: application/json' "https://$RANCHER_HOST/v3-public/localProviders/local?action=login" \
 --data '{
  "description": "Artifical UI session for CI",
  "username": "admin",
  "password": "'$RANCHER_PASSWORD'"
}' | jq -r '.token')
echo $TOKEN
```
* creating v3/cluster resource:
```bash
CLUSTER_NAME=imported-0
curl -k -u "$TOKEN" -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' \
"https://$RANCHER_HOST/v3/clusters" \
--data '{
  "type":"cluster","agentEnvVars":[],"labels":{},"annotations":{"rancher.io/imported-cluster-version-management":"system-default"},"importedConfig":{"privateRegistryURL":null},"name":"'$CLUSTER_NAME'"
}'
```

I have successfully tested the ds clusters provisioning on 2.10, 2.11 and 2.12 but I didn't test the upgrade scenario.

To test manually you basically need a minimal `git/fleet-e2e/tests/.env` file containing:
```bash
#!/bin/bash
RANCHER_HOST=1.2.3.4.nip.io #<<<REPLACE___ME>>>
export RANCHER_URL=https://$RANCHER_HOST/dashboard
export PUBLIC_DNS=$RANCHER_HOST
export RANCHER_USER=admin
export RANCHER_PASSWORD=#<<<REPLACE___ME>>>
export K3S_KUBECONFIG_MODE=0644
export RANCHER_VERSION=head/2.10
export DS_CLUSTER_COUNT=3
export INSTALL_K3S_VERSION=v1.31.5+k3s1
```
and then performing:
```
cd git/fleet-e2e/tests
source .env
make e2e-install-rancher
```

Cleanup is also necessary for next runs:
```
k3s-killall.sh && k3s-uninstall.sh
cd git/fleet-e2e/tests
rm ~/.kube/config
rm -f ~/k3s.yaml
git checkout -- assets/local-kubeconfig-token-skel.yaml
k3d cluster delete imported-{0..9}
echo
```