### PR TITLE
Fix 159 test for not loading cronjob from namespace

### DIFF
--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -1038,6 +1038,8 @@ describe("Global settings related tests", { tags: '@rbac'}, () => {
 
         cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
         cy.nameSpaceMenuToggle('All Namespaces');
+        // Load page correctly
+        cy.wait(1000);
         cy.contains('fleet-cleanup-gitrepo-jobs').should('exist');
       })
     )


### PR DESCRIPTION
This PR will fix below error:

<img width="1714" height="304" alt="image" src="https://github.com/user-attachments/assets/5bd4c345-f80f-4a6e-9fc4-308528ee02c6" />
