### PR TITLE
Removed 2.10 regex entry

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -251,7 +251,7 @@ Cypress.Commands.add('nameSpaceMenuToggle', (namespaceName) => {
   // in 2.10 an onwards, but it is mandatory for earlier versions
   // To be improved in the future
   const old_versions = ["latest/devel/2.7", "latest/devel/2.8", "latest/devel/2.9"];
-  const old_versions_regex = [/^(prime|prime-optimus|prime-optimus-alpha|alpha)\/2\.(10|[0-9])(\.\d+)*(-[a-zA-Z0-9.-]+)?$/];
+  const old_versions_regex = [/^(prime|prime-optimus|prime-optimus-alpha|alpha)\/2\.[0-9](\.\d+)*(-[a-zA-Z0-9.-]+)?$/];
 
   if (old_versions.includes(rancherVersion) || old_versions_regex.some(r => r.test(rancherVersion))) {
     cy.log('Rancher version is: ' + rancherVersion , 'Clicking WITH force:true');


### PR DESCRIPTION
Yesterday, in this PR: https://github.com/rancher/fleet-e2e/pull/381/files#diff-75965941f29be613c2bab5bdb432b711b86c52a2567d7f08dcf8aaeef907eb0cR254, I accidentally added 2.10 but it was not required there.

To fix this, I created this PR which will remove 2.10 entry from the regex and it will valid till 2.9 only.