### PR TITLE
Fix clusterGroup 2 failed tests and clusterGroup tests added back for 2.12 via YAML.

### DIFF
--- a/tests/assets/cluster-group-tests/clusterGroup.yaml
+++ b/tests/assets/cluster-group-tests/clusterGroup.yaml
@@ -1,0 +1,12 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: default-single-app-cluster-group
+  namespace: fleet-default
+spec:
+  branch: main
+  paths:
+    - qa-test-apps/nginx-app
+  repo: https://github.com/rancher/fleet-test-data/
+  targets:
+    - clusterGroup: cluster-group-env-prod

--- a/tests/assets/cluster-group-tests/clusterGroupMultipleApps.yaml
+++ b/tests/assets/cluster-group-tests/clusterGroupMultipleApps.yaml
@@ -1,0 +1,13 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: default-single-app-cluster-group-26
+  namespace: fleet-default
+spec:
+  branch: main
+  paths:
+    - qa-test-apps/nginx-app
+    - multiple-paths/config
+  repo: https://github.com/rancher/fleet-test-data/
+  targets:
+    - clusterGroup: cluster-group-env-prod

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -117,113 +117,46 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
   )
 });
 
-  describe('Test application deployment based on clusterGroup', { tags: '@p1_2'}, () => {
-    if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-      console.log({message: "UI for `clusterGroup` option is removed and available only via YAML. So Skipping tests."})
-    }
-    else {
-      const value = 'value_prod'
+describe('Test application deployment based on clusterGroup', { tags: '@p1_2'}, () => {
+  const value = 'value_prod'
+  let repoName
 
-      beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
-        cy.login();
-        cy.visit('/');
-        cy.deleteAllFleetRepos();
-        // Remove labels from the clusters.
-        dsAllClusterList.forEach(
-          (dsCluster) => {
-            // Adding wait to load page correctly to avoid interference with hamburger-menu.
-            cy.wait(500);
-            cy.removeClusterLabels(dsCluster, key, value);
+  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+    cy.login();
+    cy.visit('/');
+    cy.deleteAllFleetRepos();
+    // Remove labels from the clusters.
+    dsAllClusterList.forEach(
+      (dsCluster) => {
+        // Adding wait to load page correctly to avoid interference with hamburger-menu.
+        cy.wait(500);
+        cy.removeClusterLabels(dsCluster, key, value);
+      }
+    )
+    cy.deleteClusterGroups();
+  })
+
+  const clusterGroup: testData[] = [
+    {
+      qase_id: 25,
+      test_explanation: "install single application to the all defined clusters in the 'clusterGroup'",
+    },
+    {
+      qase_id: 27,
+      test_explanation: "install existing application to the third cluster by adding it to the existing 'clusterGroup'",
+    },
+  ]
+
+  clusterGroup.forEach(({ qase_id, test_explanation }) => {
+      qase(qase_id,
+        it(`Fleet-${qase_id}: Test ${test_explanation}`, { tags: `@fleet-${qase_id}` }, () => {
+          repoName = `default-single-app-cluster-group-${qase_id}`
+          if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+            repoName = "default-single-app-cluster-group"
           }
-        )
-        cy.deleteClusterGroups();
-      })
 
-      const clusterGroup: testData[] = [
-        {
-          qase_id: 25,
-          test_explanation: "install single application to the all defined clusters in the 'clusterGroup'",
-        },
-        {
-          qase_id: 27,
-          test_explanation: "install existing application to the third cluster by adding it to the existing 'clusterGroup'",
-        },
-      ]
-
-      clusterGroup.forEach(({ qase_id, test_explanation }) => {
-          qase(qase_id,
-            it(`Fleet-${qase_id}: Test ${test_explanation}`, { tags: `@fleet-${qase_id}` }, () => {
-              const repoName = `default-single-app-cluster-group-${qase_id}`
-
-              cy.continuousDeliveryMenuSelection();
-              cy.clickNavMenu(['Clusters']);
-              cy.contains('.title', 'Clusters').should('be.visible');
-
-              // Assign label to the first 2 clusters i.e. imported-0 and imported-1
-              dsFirstTwoClusterList.forEach(
-                (dsCluster) => {
-                  cy.assignClusterLabel(dsCluster, key, value);
-                }
-              )
-
-              // Create group of cluster consists of same label.
-              cy.clickNavMenu(['Cluster Groups']);
-              cy.contains('.title', 'Cluster Groups').should('be.visible');
-              cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
-              cy.clusterCountClusterGroup(clusterGroupName, 2);
-
-              // Create a GitRepo targeting cluster group created.
-              cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
-              cy.clickButton('Create');
-              cy.checkGitRepoStatus(repoName, '1 / 1');
-
-              // Check application status on both clusters i.e. imported-0 and imported-1
-              dsFirstTwoClusterList.forEach(
-                (dsCluster) => {
-                  cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-                }
-              )
-
-              if (qase_id === 27) {
-                cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-                cy.contains('.title', 'Clusters').should('be.visible');
-
-                // Add label to the third cluster i.e. imported-2
-                cy.assignClusterLabel(dsThirdClusterName, key, value);
-
-                // Check existing clusterGroup for third cluster (imported-2) is added.
-                cy.clusterCountClusterGroup(clusterGroupName, 3);
-
-                // Check application is deployed on third cluster i.e. imported-2
-                cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
-
-                // Remove label from the third cluster i.e. imported-2
-                cy.wait(500);
-                cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-                cy.removeClusterLabels(dsThirdClusterName, key, value);
-              }
-
-              // Remove labels from the All 3 clusters.
-              cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-              dsAllClusterList.forEach(
-                (dsCluster) => {
-                  // Adding wait to load page correctly to avoid interference with hamburger-menu.
-                  cy.wait(500);
-                  cy.removeClusterLabels(dsCluster, key, value);
-                }
-              )
-              cy.deleteClusterGroups();
-            })
-          )
-        }
-      )
-
-      qase(26,
-        it("Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'", { tags: '@fleet-26' }, () => {
-          const repoName = 'default-single-app-cluster-group-26'
-          const path2 = 'multiple-paths/config'
-
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+          cy.continuousDeliveryMenuSelection();
+          cy.clickNavMenu(['Clusters']);
           cy.contains('.title', 'Clusters').should('be.visible');
 
           // Assign label to the first 2 clusters i.e. imported-0 and imported-1
@@ -239,189 +172,301 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
           cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
 
           // Create a GitRepo targeting cluster group created.
-          cy.addFleetGitRepo({ repoName, repoUrl, branch, path, path2, deployToTarget: clusterGroupName });
-          cy.clickButton('Create');
-          cy.checkGitRepoStatus(repoName, '2 / 2');
-
-          // Check first application status on both clusters i.e. imported-0 and imported-1
-          dsFirstTwoClusterList.forEach((dsCluster) => {
-            cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-          })
-
-          dsFirstTwoClusterList.forEach((dsCluster) => {
-            // Check second application status on both clusters i.e. imported-0 and imported-1
-            // Adding wait to load page correctly to avoid interference with hamburger-menu.
-            cy.wait(500);
-            cy.accesMenuSelection(dsCluster, "Storage", "ConfigMaps");
-            cy.nameSpaceMenuToggle("test-fleet-mp-config");
-            cy.filterInSearchBox("mp-app-config");
-            cy.get('td.col-link-detail > span').contains("mp-app-config").click();
-          })
-
-          // Remove labels from the clusters i.e. imported-0 and imported-1
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          dsFirstTwoClusterList.forEach(
-            (dsCluster) => {
-              // Adding wait to load page correctly to avoid interference with hamburger-menu.
-              cy.wait(500);
-              cy.removeClusterLabels(dsCluster, key, value);
-            }
-          )
-        })
-      )
-
-      qase(28,
-        it("Fleet-28: Test remove existing application from cluster-2 by removing it from an existing 'clusterGroup'", { tags: '@fleet-28' }, () => {
-          const repoName = 'default-single-app-cluster-group-28'
-          const dsSecondClusterName = dsAllClusterList[1]
-
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.contains('.title', 'Clusters').should('be.visible');
-
-          // Assign label to the clusters 
-          dsFirstTwoClusterList.forEach(
-            (dsCluster) => {
-              cy.assignClusterLabel(dsCluster, key, value);
-            }
-          )
-
-          // Create group of cluster consists of same label.
-          cy.clickNavMenu(['Cluster Groups']);
-          cy.contains('.title', 'Cluster Groups').should('be.visible');
-          cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
-
-          // Create a GitRepo targeting cluster group created.
-          cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
+          if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+            cy.clickNavMenu(['Resources']);
+            cy.clickNavMenu(['Git Repos']);
+            cy.wait(1000);
+            cy.clickButton('Add Repository');
+            cy.wait(1000);
+            cy.clickButton('Edit as YAML');
+            cy.addYamlFile('assets/cluster-group-tests/clusterGroup.yaml');
+          }
+          else {
+            cy.clusterCountClusterGroup(clusterGroupName, 2);
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
+          }
           cy.clickButton('Create');
           cy.checkGitRepoStatus(repoName, '1 / 1');
-
-          // Check first application status on both clusters.
-          dsFirstTwoClusterList.forEach((dsCluster) => {
-            cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-          })
-
-          // Check application is not installed on third cluster i.e. imported-2
-          cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces', false);
-
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.contains('.title', 'Clusters').should('be.visible');
-
-          // Remove label from the Second cluster i.e. imported-1
-          cy.wait(500);
-          cy.removeClusterLabels(dsSecondClusterName, key, value);
-
-          // Check application is absent i.e. removed from second cluster i.e. imported-1
-          cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);
-
-          // Check application is available on first cluster i.e. imported-0
-
-          // Remove labels from the clusters.
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          dsFirstTwoClusterList.forEach(
-            (dsCluster) => {
-              // Adding wait to load page correctly to avoid interference with hamburger-menu.
-              cy.wait(500);
-              cy.removeClusterLabels(dsCluster, key, value);
-            }
-          )
-          // Delete clusterGroups.
-          cy.deleteClusterGroups();
-        })
-      )
-
-      qase(29,
-        it("Fleet-29: Test install app to new set of clusters from old set of clusters using 'clusterGroup'", { tags: '@fleet-29' }, () => {
-          const repoName = 'default-single-app-cluster-group-29'
-          const new_key = 'key_third_cluster'
-          const new_value = 'value_third_cluster'
-          const newClusterGroupName = 'cluster-group-env-third-cluster'
-
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.contains('.title', 'Clusters').should('be.visible');
 
           // Check application status on both clusters i.e. imported-0 and imported-1
           dsFirstTwoClusterList.forEach(
             (dsCluster) => {
-              cy.assignClusterLabel(dsCluster, key, value);
+              cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
             }
           )
 
-          // Create group of cluster consists of same label.
-          cy.clickNavMenu(['Cluster Groups']);
-          cy.contains('.title', 'Cluster Groups').should('be.visible');
-          cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
-
-          // Create a GitRepo targeting cluster group created.
-          cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
-          cy.clickButton('Create');
-          cy.checkGitRepoStatus(repoName, '1 / 1');
-
-          // Check first application status on both clusters i.e. imported-0 and imported-1
-          dsFirstTwoClusterList.forEach((dsCluster) => {
-            cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-          })
-
-          // Add label to the third cluster
-          cy.continuousDeliveryMenuSelection();
-          cy.clickNavMenu(['Clusters']);
-          cy.contains('.title', 'Clusters').should('be.visible');
-          cy.assignClusterLabel(dsThirdClusterName, new_key, new_value);
-
-          // Create another clusterGroup using third cluster.
-          const newBannerMessageToAssert = /Matches 1 of 3 existing clusters: "imported-\d"/
-          cy.clickNavMenu(['Cluster Groups']);
-          cy.contains('.title', 'Cluster Groups').should('be.visible');
-          cy.createClusterGroup(newClusterGroupName, new_key, new_value, newBannerMessageToAssert);
-
-          // Update GitRepo with newly created clusterGroup.
-          cy.addFleetGitRepo({ repoName, deployToTarget: newClusterGroupName, fleetNamespace: 'fleet-default', editConfig: true });
-          cy.clickButton('Save');
-          cy.checkGitRepoStatus(repoName, '1 / 1');
-
-          // Check application is present on third cluster i.e. imported-2
-          cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
-
-          // Applying Force Update in 2.9 and 2.10 versions only as it doesn't have cluster sync logic
-          if (/\/2\.10/.test(Cypress.env('rancher_version')) || /\/2\.9/.test(Cypress.env('rancher_version'))) {
+          if (qase_id === 27) {
             cy.accesMenuSelection('Continuous Delivery', 'Clusters');
             cy.contains('.title', 'Clusters').should('be.visible');
-            dsFirstTwoClusterList.forEach(
-              (dsCluster) => {
-                cy.filterInSearchBox(dsCluster);
-                cy.open3dotsMenu(dsCluster, 'Force Update');
-                cy.wait(2000); // It take some time to Update.
-                cy.verifyTableRow(0, 'Active');
-              }
-            )
+
+            // Add label to the third cluster i.e. imported-2
+            cy.assignClusterLabel(dsThirdClusterName, key, value);
+
+            // Check existing clusterGroup for third cluster (imported-2) is added.
+            if (!(supported_versions_212_and_above.some(r => r.test(rancherVersion)))) {
+              cy.clusterCountClusterGroup(clusterGroupName, 3);
+            }
+
+            // Check application is deployed on third cluster i.e. imported-2
+            cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
+
+            // Remove label from the third cluster i.e. imported-2
+            cy.wait(500);
+            cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+            cy.removeClusterLabels(dsThirdClusterName, key, value);
           }
 
-          // Check application status on first 2 clusters i.e. imported-0 and imported-1
-          // Application should be removed from first 2 clusters i.e. imported-0 and imported-1
-          dsFirstTwoClusterList.forEach(
-            (dsCluster) => {
-              cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces', false);
-            }
-          )
-
-          // Remove labels from the clusters i.e. imported-0 and imported-1
+          // Remove labels from the All 3 clusters.
           cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          dsFirstTwoClusterList.forEach(
+          dsAllClusterList.forEach(
             (dsCluster) => {
               // Adding wait to load page correctly to avoid interference with hamburger-menu.
               cy.wait(500);
               cy.removeClusterLabels(dsCluster, key, value);
             }
           )
-
-          // Remove labels from third cluster i.e. imported-2
-          cy.removeClusterLabels(dsThirdClusterName, new_key, new_value);
-
-          // Delete clusterGroups.
           cy.deleteClusterGroups();
         })
       )
     }
-  });
+  )
+
+  qase(26,
+    it("Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'", { tags: '@fleet-26' }, () => {
+      const repoName = 'default-single-app-cluster-group-26'
+      const path2 = 'multiple-paths/config'
+
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      cy.contains('.title', 'Clusters').should('be.visible');
+
+      // Assign label to the first 2 clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          cy.assignClusterLabel(dsCluster, key, value);
+        }
+      )
+
+      // Create group of cluster consists of same label.
+      cy.clickNavMenu(['Cluster Groups']);
+      cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
+
+      // Create a GitRepo targeting cluster group created.
+      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+        cy.clickNavMenu(['Resources']);
+        cy.clickNavMenu(['Git Repos']);
+        cy.wait(1000);
+        cy.clickButton('Add Repository');
+        cy.wait(1000);
+        cy.clickButton('Edit as YAML');
+        cy.addYamlFile('assets/cluster-group-tests/clusterGroupMultipleApps.yaml');
+      }
+      else {
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, path2, deployToTarget: clusterGroupName });
+      }
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '2 / 2');
+
+      // Check first application status on both clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
+      })
+
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        // Check second application status on both clusters i.e. imported-0 and imported-1
+        // Adding wait to load page correctly to avoid interference with hamburger-menu.
+        cy.wait(500);
+        cy.accesMenuSelection(dsCluster, "Storage", "ConfigMaps");
+        cy.nameSpaceMenuToggle("test-fleet-mp-config");
+        cy.filterInSearchBox("mp-app-config");
+        cy.get('td.col-link-detail > span').contains("mp-app-config").click();
+      })
+
+      // Remove labels from the clusters i.e. imported-0 and imported-1
+      cy.wait(1000);
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          // Adding wait to load page correctly to avoid interference with hamburger-menu.
+          cy.wait(500);
+          cy.removeClusterLabels(dsCluster, key, value);
+        }
+      )
+    })
+  )
+
+  qase(28,
+    it("Fleet-28: Test remove existing application from cluster-2 by removing it from an existing 'clusterGroup'", { tags: '@fleet-28' }, () => {
+      let repoName
+      repoName = 'default-single-app-cluster-group-28'
+      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+        repoName = "default-single-app-cluster-group"
+      }
+
+      const dsSecondClusterName = dsAllClusterList[1]
+
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      cy.contains('.title', 'Clusters').should('be.visible');
+
+      // Assign label to the clusters 
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          cy.assignClusterLabel(dsCluster, key, value);
+        }
+      )
+
+      // Create group of cluster consists of same label.
+      cy.clickNavMenu(['Cluster Groups']);
+      cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
+
+      // Create a GitRepo targeting cluster group created.
+      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+        cy.clickNavMenu(['Resources']);
+        cy.clickNavMenu(['Git Repos']);
+        cy.wait(1000);
+        cy.clickButton('Add Repository');
+        cy.wait(1000);
+        cy.clickButton('Edit as YAML');
+        cy.addYamlFile('assets/cluster-group-tests/clusterGroup.yaml');
+      }
+      else {
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
+      }
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
+
+      // Check first application status on both clusters.
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
+      })
+
+      // Check application is not installed on third cluster i.e. imported-2
+      cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces', false);
+
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      cy.contains('.title', 'Clusters').should('be.visible');
+
+      // Remove label from the Second cluster i.e. imported-1
+      cy.wait(500);
+      cy.removeClusterLabels(dsSecondClusterName, key, value);
+
+      // Check application is absent i.e. removed from second cluster i.e. imported-1
+      cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);
+
+      // Check application is available on first cluster i.e. imported-0
+
+      // Remove labels from the clusters.
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          // Adding wait to load page correctly to avoid interference with hamburger-menu.
+          cy.wait(500);
+          cy.removeClusterLabels(dsCluster, key, value);
+        }
+      )
+      // Delete clusterGroups.
+      cy.deleteClusterGroups();
+    })
+  )
+
+  if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+    console.log({message: "UI for `clusterGroup` option is removed and available only via YAML. So Skipping tests."})
+  }
+  else {
+    qase(29,
+    it("Fleet-29: Test install app to new set of clusters from old set of clusters using 'clusterGroup'", { tags: '@fleet-29' }, () => {
+      const repoName = 'default-single-app-cluster-group-29'
+      const new_key = 'key_third_cluster'
+      const new_value = 'value_third_cluster'
+      const newClusterGroupName = 'cluster-group-env-third-cluster'
+
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      cy.contains('.title', 'Clusters').should('be.visible');
+
+      // Check application status on both clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          cy.assignClusterLabel(dsCluster, key, value);
+        }
+      )
+
+      // Create group of cluster consists of same label.
+      cy.clickNavMenu(['Cluster Groups']);
+      cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
+
+      // Create a GitRepo targeting cluster group created.
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, deployToTarget: clusterGroupName });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
+
+      // Check first application status on both clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
+      })
+
+      // Add label to the third cluster
+      cy.continuousDeliveryMenuSelection();
+      cy.clickNavMenu(['Clusters']);
+      cy.contains('.title', 'Clusters').should('be.visible');
+      cy.assignClusterLabel(dsThirdClusterName, new_key, new_value);
+
+      // Create another clusterGroup using third cluster.
+      const newBannerMessageToAssert = /Matches 1 of 3 existing clusters: "imported-\d"/
+      cy.clickNavMenu(['Cluster Groups']);
+      cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.createClusterGroup(newClusterGroupName, new_key, new_value, newBannerMessageToAssert);
+
+      // Update GitRepo with newly created clusterGroup.
+      cy.addFleetGitRepo({ repoName, deployToTarget: newClusterGroupName, fleetNamespace: 'fleet-default', editConfig: true });
+      cy.clickButton('Save');
+      cy.checkGitRepoStatus(repoName, '1 / 1');
+
+      // Check application is present on third cluster i.e. imported-2
+      cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
+
+      // Applying Force Update in 2.9 and 2.10 versions only as it doesn't have cluster sync logic
+      if (/\/2\.10/.test(Cypress.env('rancher_version')) || /\/2\.9/.test(Cypress.env('rancher_version'))) {
+        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+        cy.contains('.title', 'Clusters').should('be.visible');
+        dsFirstTwoClusterList.forEach(
+          (dsCluster) => {
+            cy.filterInSearchBox(dsCluster);
+            cy.open3dotsMenu(dsCluster, 'Force Update');
+            cy.wait(2000); // It take some time to Update.
+            cy.verifyTableRow(0, 'Active');
+          }
+        )
+      }
+
+      // Check application status on first 2 clusters i.e. imported-0 and imported-1
+      // Application should be removed from first 2 clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces', false);
+        }
+      )
+
+      // Remove labels from the clusters i.e. imported-0 and imported-1
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      dsFirstTwoClusterList.forEach(
+        (dsCluster) => {
+          // Adding wait to load page correctly to avoid interference with hamburger-menu.
+          cy.wait(500);
+          cy.removeClusterLabels(dsCluster, key, value);
+        }
+      )
+
+      // Remove labels from third cluster i.e. imported-2
+      cy.removeClusterLabels(dsThirdClusterName, new_key, new_value);
+
+      // Delete clusterGroups.
+      cy.deleteClusterGroups();
+    })
+    )
+  }
+});
 
 describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_2'}, () => {
   const key = 'key_env'
@@ -839,6 +884,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
         }
 
         // Remove labels from the clusters.
+        cy.wait(1000);
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         dsFirstTwoClusterList.forEach(
           (dsCluster) => {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -204,6 +204,7 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
               }
 
               // Remove labels from the All 3 clusters.
+              cy.accesMenuSelection('Continuous Delivery', 'Clusters');
               dsAllClusterList.forEach(
                 (dsCluster) => {
                   // Adding wait to load page correctly to avoid interference with hamburger-menu.
@@ -403,6 +404,7 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
           )
 
           // Remove labels from the clusters i.e. imported-0 and imported-1
+          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
           dsFirstTwoClusterList.forEach(
             (dsCluster) => {
               // Adding wait to load page correctly to avoid interference with hamburger-menu.


### PR DESCRIPTION
## PR looks big, because, I have updated below:

- [x] There were 2 test failed related to cluster Group, this PR will fix it.
- [x] Add back `clusterGroup` tests for 2.12 via YAML.
- [x] Removed if-else block which skips all clusterGroup tests.
- [x] Remove extra white-spaces
- [x] All clusterGroup tests except test Fleet-29.