### PR TITLE
Bumping Cypress version

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -321,7 +321,7 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:13.16.0'
+          CYPRESS_DOCKER: 'cypress/included:15.2.0'
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}
@@ -419,7 +419,7 @@ jobs:
         if: ${{ inputs.rancher_upgrade != '' }}
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:13.16.0'
+          CYPRESS_DOCKER: 'cypress/included:15.2.0'
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}


### PR DESCRIPTION
Bumping Cypress to version `15.2.0`

CI 2.11 successful [here](https://github.com/rancher/fleet-e2e/actions/runs/17921365363/job/50957027231#step:10:241) 

CI 2.13 ok p0, p1, p1_2  [here](https://github.com/rancher/fleet-e2e/actions/runs/17938563650/job/51009559265) 

<img width="1149" height="394" alt="image" src="https://github.com/user-attachments/assets/277b43d9-d515-4b6c-8bf8-5ad78275f860" />
