### PR TITLE
Refs/heads/fleet qa/several bumps

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -267,7 +267,7 @@ jobs:
           echo "::endgroup::"
       - name: Install dbus
         run: |
-          sudo zypper -n install -y dbus
+          sudo zypper install -y dbus-1-glib
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -265,9 +265,6 @@ jobs:
           sudo zypper -n install --no-recommends git
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           echo "::endgroup::"
-      - name: Install dbus
-        run: |
-          sudo zypper install -y dbus-1-glib
       - name: Checkout
         uses: actions/checkout@v5
       - name: Install Go
@@ -283,7 +280,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: current
       - name: Install prerequisite components
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -265,6 +265,9 @@ jobs:
           sudo zypper -n install --no-recommends git
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           echo "::endgroup::"
+      - name: Install dbus
+        run: |
+          sudo zypper -n install -y dbus
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -283,7 +283,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
       - name: Install prerequisite components
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -130,7 +130,7 @@ jobs:
     steps:
       # actions/checkout MUST come before auth
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate UUID and Runner hostname
         id: generator
         run: |
@@ -140,11 +140,11 @@ jobs:
           echo "uuid=${UUID//-}" >> ${GITHUB_OUTPUT}
           echo "runner=${GH_REPO//\//-}-ci-${UUID//-}" >> ${GITHUB_OUTPUT}
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.credentials }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       - name: Create runner
         run: |
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
@@ -184,10 +184,10 @@ jobs:
       qase_run_name: ${{ steps.qase.outputs.qase_run_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache-dependency-path: tests/go.sum
           go-version-file: tests/go.mod
@@ -269,19 +269,19 @@ jobs:
         run: |
           sudo zypper install -y dbus-1-glib
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache: false
           go-version-file: tests/go.mod
       - name: Checkout
         if: ${{ inputs.branch }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch }}
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Install prerequisite components
@@ -512,13 +512,13 @@ jobs:
     steps:
       # actions/checkout MUST come before auth
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.credentials }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       - name: Delete PAT token secrets
         run: |
           gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }} || true
@@ -541,10 +541,10 @@ jobs:
       QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache-dependency-path: tests/go.sum
           go-version-file: tests/go.mod

--- a/tests/package.json
+++ b/tests/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.9.5"
   },
   "devDependencies": {
-    "@cypress/grep": "^5.0.0",
+    "@cypress/grep": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint-plugin-cypress": "^2.15.2"

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,10 +23,10 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.2.3",
     "cy-verify-downloads": "^0.1.17",
-    "cypress": "^13.16.0",
+    "cypress": "^15.2.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
-    "cypress-mochawesome-reporter": "^3.8.2",
+    "cypress-mochawesome-reporter": "^4.0.2",
     "cypress-multi-reporters": "^1.6.4",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-qase-reporter": "1.4.1",
@@ -34,7 +34,7 @@
     "typescript": "^4.9.5"
   },
   "devDependencies": {
-    "@cypress/grep": "^4.1.0",
+    "@cypress/grep": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint-plugin-cypress": "^2.15.2"


### PR DESCRIPTION
Upgraded:

### package.json
- `"cypress": "^15.2.0"`
- `"cypress-mochawesome-reporter": "^4.0.2",`

### GitHub Actions

- `actions/checkout@v4` -> `actions/checkout@v5`
- `google-github-actions/auth@v2` -> `google-github-actions/auth@v3`
- `google-github-actions/setup-gcloud@v2`-> `google-github-actions/setup-gcloud@v3`
- `actions/checkout@v4` -> `actions/checkout@v5`
- `actions/setup-go@v5` -> `actions/setup-go@v6`

### Node
- From 20 to `current` to prevent logs like [this](https://github.com/rancher/fleet-e2e/actions/runs/17975800347/job/51134395782#step:11:61) one with newer versions of mochawesome-reporter:
```
# Needed to install Cypress plugins
npm install
+ npm install
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'cypress-mochawesome-reporter@4.0.2',
npm warn EBADENGINE   required: { node: '>=22' },
npm warn EBADENGINE   current: { node: 'v20.19.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'mochawesome-merge@5.0.0',
npm warn EBADENGINE   required: { node: '>=22' },
npm warn EBADENGINE   current: { node: 'v20.19.5', npm: '10.8.2' }
npm warn EBADENGINE }
```

### CI runs:
- [2.13](https://github.com/rancher/fleet-e2e/actions/runs/17975800347) -> Only 1 failure