### PR TITLE
Added test automation to check `doNotDeploy: true`

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1407,6 +1407,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
 });
 
 describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.', { tags: '@p1_2'}, () => {
+
   const key = "key_resources"
   const value = "deploy_true"
 
@@ -1426,7 +1427,7 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
 
   qase(88,
 
-    it("Fleet-88: Test bundle did not get deploy when doNotDeploy value set to true option is used in the fleet.yaml.", { tags: '@fleet-88' }, () => {
+    it("Fleet-88: Test bundle did not get deployed when 'doNotDeploy' value set to `true` option is used in the 'fleet.yaml' file.", { tags: '@fleet-88' }, () => {
 
       const repoName = 'test-donot-deploy-true'
       const path = "qa-test-apps/do-not-deploy/true"

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1406,14 +1406,13 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
   )
 });
 
-describe('Test Fleet doNotDeploy.', { tags: '@p1_2'}, () => {
+describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.', { tags: '@p1_2'}, () => {
   const key = "key_resources"
   const value = "deploy_true"
 
-  beforeEach('Cleanup leftover GitRepo or cluster labels if any.', () => {
+  beforeEach('Cleanup leftover Cluster labels if any.', () => {
     cy.login();
     cy.visit('/');
-    cy.deleteAllFleetRepos();
     // Remove labels from the clusters.
     dsAllClusterList.forEach(
       (dsCluster) => {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1430,6 +1430,11 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
 
       const repoName = 'test-donot-deploy-true'
       const path = "qa-test-apps/do-not-deploy/true"
+      let gitRepoWord = "git repo"
+
+      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+        gitRepoWord = "GitRepo"
+      }
 
       // Assign label (similar to label mentioned in fleet.yaml file.) to All the clusters
       dsAllClusterList.forEach(
@@ -1445,7 +1450,7 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
       cy.verifyTableRow(0, 'Active', repoName);
       cy.contains(repoName).click()
       cy.get('.primaryheader > h1, h1 > span.resource-name.masthead-resource-title').contains(repoName).should('be.visible')
-      cy.get("[data-testid='banner-content']").should('exist').contains('This git repo is not targeting any clusters');
+      cy.get("[data-testid='banner-content']").should('exist').contains(`This ${gitRepoWord} is not targeting any clusters`);
 
       // Verify nginx application not deployed clusters as doNotDeploy is set true.
       dsAllClusterList.forEach(

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1414,6 +1414,7 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
     cy.login();
     cy.visit('/');
     // Remove labels from the clusters.
+    cy.accesMenuSelection('Continuous Delivery', 'Clusters');
     dsAllClusterList.forEach(
       (dsCluster) => {
         // Adding wait to load page correctly to avoid interference with hamburger-menu.
@@ -1444,7 +1445,7 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
       cy.verifyTableRow(0, 'Active', repoName);
       cy.contains(repoName).click()
       cy.get('.primaryheader > h1, h1 > span.resource-name.masthead-resource-title').contains(repoName).should('be.visible')
-      cy.get("[data-testid='banner-content']").should('exist').contains('This GitRepo is not targeting any clusters');
+      cy.get("[data-testid='banner-content']").should('exist').contains('This git repo is not targeting any clusters');
 
       // Verify nginx application not deployed clusters as doNotDeploy is set true.
       dsAllClusterList.forEach(


### PR DESCRIPTION
In this PR, test is added to check Fleet's behavior with resources when `doNotDeploy` option is used with values `true` in `fleet.yaml`:

  - `doNotDeploy: true`: When set to `true`, `Fleet` skips deploying resources to clusters that match the specified labels in the `targetCustomizations` section.

More information about `doNotDeploy`: https://fleet.rancher.io/ref-fleet-yaml#targeting-and-customization

| `targetCustomizations` Option | Description |
|--------|--------|
| `targetCustomizations.doNotDeploy` | If true, resources will not be deployed to the matched clusters. | 

_See Issue: #393_ 