### PR TITLE
Adding test to deploy gitrepo on private gh without username

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -78,6 +78,22 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' 
       })
     );
   });
+
+  if (!/\/2\.11/.test(Cypress.env('rancher_version'))) {
+  qase(191, 
+    it('FLEET-191: Test Fleet can be deployed in private Github repo using solely private token', {tags : `@fleet-191` }, () => {
+
+      const repoName = '191-test-private-gh-only-token'  
+      const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples.git'
+      const pwdOrPrivateKey = Cypress.env('gh_private_pwd')
+  
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitAuthType, pwdOrPrivateKey, local:true });
+        cy.clickButton('Create');
+        cy.checkGitRepoStatus(repoName, '1 / 1');
+        cy.deleteAllFleetRepos();
+    })
+  )}
+
 });
 
 describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }, () => {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -184,10 +184,6 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path
     cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex);
   }
 
-  // if (gitAuthType && !userOrPublicKey) {
-  //   cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, pwdOrPrivateKey, helmUrlRegex);
-  // }
-
   if (tlsOption) {
     cy.contains(`TLS Certificate Verification`).click();
     // Select the TLS option

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -46,7 +46,9 @@ Cypress.Commands.add('gitRepoAuth', (gitOrHelmAuth='Git', gitAuthType, userOrPub
   }
 
   if (gitAuthType === 'http') {
-    cy.typeValue('Username', userOrPublicKey, false,  false );
+    if (userOrPublicKey) {
+      cy.typeValue('Username', userOrPublicKey, false,  false );
+    }
     cy.typeValue('Password', pwdOrPrivateKey, false,  false );
   }
   
@@ -181,6 +183,10 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path
   if (gitAuthType) {
     cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex);
   }
+
+  // if (gitAuthType && !userOrPublicKey) {
+  //   cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, pwdOrPrivateKey, helmUrlRegex);
+  // }
 
   if (tlsOption) {
     cy.contains(`TLS Certificate Verification`).click();


### PR DESCRIPTION
Added automation for FLEET-191

Added automation to check that gitrepo can be deployed in private Github repository using solely pass token without username.

Valid only 2.12.3 onwards

Added prevention to be executed in 2.11

CI on 2.12 [here](https://github.com/rancher/fleet-e2e/actions/runs/18304894030/job/52119878736#step:10:309)