### PR TITLE
Adding exclusion to test 190 for 2.11

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1064,24 +1064,25 @@ describe('Test move cluster to newly created workspace and deploy application to
   )
 });
 
+if (!/\/2\.11/.test(Cypress.env('rancher_version'))) {
+  describe('Test no HTML error messages in HelmOps', { tags: '@p1_2' }, () => {
 
-describe('Test no HTML error messages in HelmOps', { tags: '@p1_2' }, () => {
+    qase(190,
+      it('FLEET-190: Test Faulty Helm Ops display short error message', { tags: '@fleet-190' }, () => { 
 
-  qase(190,
-    it('FLEET-190: Test Faulty Helm Ops display short error message', { tags: '@fleet-190' }, () => { 
+        cy.addHelmOp({ 
+          fleetNamespace: 'fleet-local', 
+          repoName: 'faulty-helm-ops',
+          repoUrl: 'https://github.com/rancher',
+          chart: 'fleet-examples/tree/master/single-cluster/helm',
+        });
 
-      cy.addHelmOp({ 
-        fleetNamespace: 'fleet-local', 
-        repoName: 'faulty-helm-ops',
-        repoUrl: 'https://github.com/rancher',
-        chart: 'fleet-examples/tree/master/single-cluster/helm',
-      });
+        cy.contains('Could not get a chart version: failed to read helm repo from https://github.com/rancher/index.yaml, error code: 404').should('be.visible');      
 
-      cy.contains('Could not get a chart version: failed to read helm repo from https://github.com/rancher/index.yaml, error code: 404').should('be.visible');      
-
-    })
-  );
-});
+      })
+    );
+  })
+};
 
 describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
   const configMapName = "test-map"


### PR DESCRIPTION
Added exclusion for Rancher 2.11 of test [Fleet-190 ](https://app.qase.io/case/FLEET-190)targeting Helmops given that modern UI implementation is in 2.12 onwards and collides with present one.

The test fails because is unable to find HelmOps on UI changes from 2.12 onwards. On top of this, the fix was not backported to 2.11 so there is no point in testing it there.

