### PR TITLE
Bumping Cypress to 15.5.0

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -321,7 +321,7 @@ jobs:
       - name: Cypress tests - Basics
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:15.2.0'
+          CYPRESS_DOCKER: 'cypress/included:15.5.0'
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}
@@ -419,7 +419,7 @@ jobs:
         if: ${{ inputs.rancher_upgrade != '' }}
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:15.2.0'
+          CYPRESS_DOCKER: 'cypress/included:15.5.0'
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.2.3",
     "cy-verify-downloads": "^0.1.17",
-    "cypress": "^15.2.0",
+    "cypress": "^15.5.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-mochawesome-reporter": "^4.0.2",


### PR DESCRIPTION

Bump to Cypress 15.5.0 which among other things gets rid off dbus warning issue.

#### Tests:

2.11 -> (on this pr), only 1 test failed.
2.12 -> [1st run](https://github.com/rancher/fleet-e2e/actions/runs/18677574252/job/53250976089#step:10:859), 1 failed on p1, several on p1_2, [2nd retry](https://github.com/rancher/fleet-e2e/actions/runs/18682221004/job/53265791544#step:10:293) over failed ones: green

2.13 -> [1st run](https://github.com/rancher/fleet-e2e/actions/runs/18674960373/job/53244226007) (7 failes on p1) , [2nd run](https://github.com/rancher/fleet-e2e/actions/runs/18680271459/job/53275125619#step:10:472) (4 failed on pq)