### PR TITLE
Automate Fleet-195 bundle hash mistmatch error

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -575,7 +575,7 @@ describe('Test GitRepo Bundle do not show hash mismatch error.', { tags: '@p1'},
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
       cy.verifyTableRow(0, 'Active', repoName);
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '3 / 3');
 
       // Bundle hash mismatch error will occurs when bundle reconciler, 
       // reconciles bundle which has long description in Chart.yaml and/or


### PR DESCRIPTION
- Automate test Fleet-195

- Problem: bundle shows hash is mismatched, (See below screenshot)
    <details><summary>Bundle show hash mismatch error</summary>
    <p>
   <img width="1213" height="234" alt="Image" src="https://github.com/user-attachments/assets/bcb610e4-3a9e-4ffe-b96a-267cc77eb8f6" />

    </p>
    </details> 

- Solution: bundle should show Active status not the above error.
    <details><summary>Bundle Active status</summary>
    <p>
    
    <img width="1915" height="928" alt="Image" src="https://github.com/user-attachments/assets/e5de5c4e-5c9e-40b5-902e-e30307d94f1c" />
    
    </p>
    </details> 


For more information see this issue: https://github.com/rancher/fleet/issues/3807#issuecomment-3376900740