### PR TITLE
Bump ele-testhelpers

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113092326-9b43cc34d982
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113123558-e37721f14acb
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -131,10 +131,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a h1:s/tYg69rbYbIa93r4oZcZKU445rfH4mbhHQM/jafm4w=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113092326-9b43cc34d982 h1:pQ0S4n8+impomKiOYBXuOGKGC6/8TV0rbFNLOhGtUFY=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113092326-9b43cc34d982/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113123558-e37721f14acb h1:5mbpMqCBwfiZYcPDasl9j9eZJy9IWrTFEB1j0k1Zulk=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20251113123558-e37721f14acb/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Bumping new ele-testhelpers will install 2.12.4 and 2.13.0 alphas from newly pointed registry.