### PR TITLE
Test Fleet with PC and PDB 

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -100,10 +100,16 @@ describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
         cm.setValue(newYaml);
       });
       cy.clickButton('Save');
+      
+      // Verify the cluster is still Active
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters ');
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.wait(2000); // Wait to allow time to the status to reach "Wait" before verifying"
       cy.verifyTableRow(0, 'Active', '1');
 
       // Verify PriorityClass and PodDisruptionBudget
       cy.accesMenuSelection('local', 'Policy', 'Pod Disruption Budgets');
+      cy.nameSpaceMenuToggle('All Namespaces');
       cy.verifyTableRow(0, 'fleet-agent', '3');
       cy.accesMenuSelection('local', 'More Resources', 'Scheduling');
       cy.contains('PriorityClasses').click();


### PR DESCRIPTION
Automation of https://app.qase.io/case/FLEET-200

Done:

- Deploy on local cluster PC and PDB snippet:  

```
  agentSchedulingCustomization:
    priorityClass:
      value: 888
    podDisruptionBudget:
      minAvailable: "3"`;
```

- Test the values are updated in Priority Class and Pod Disruption Budgets sections in Rancher UI

Side note:

- The test will find the place where to add the `agentSchedulingCustomization` part.
- It is still necessary to remove that part. For now, this has not been done. For this reason, given that may have consequences in other tests, it has been added on `special_fleet_tests.spec.ts`. This can be reconsidered to be moved back to p1 once this cleansing mechanism is implemented.

CI in 2.13-head passing here: https://github.com/rancher/fleet-e2e/actions/runs/19368195301/job/55416877022#step:10:330

