### PR TITLE
Automated disableDependencyUpdate option true/false to download or ignore dependency of Helm Chart.

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1579,7 +1579,6 @@ if (!/\/2\.11/.test(Cypress.env('rancher_version'))) {
 describe('Test helm chart dependency download with `disableDependencyUpdate: true/false`', { tags: '@p1_2'}, () => {
 
   qase(129,
-
     it("Fleet-129: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `true` in `fleet.yaml`.", { tags: '@fleet-129' }, () => {
 
       const repoName = 'test-disable-dependency-false-helm-chart'
@@ -1599,12 +1598,10 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
           cy.checkApplicationStatus("no-dependency-download-postgresql", dsCluster, 'All Namespaces', false);
         }
       )
-
     })
   )
 
   qase(130,
-
     it("Fleet-130: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `false` in `fleet.yaml`.", { tags: '@fleet-130' }, () => {
 
       const repoName = 'test-disable-dependency-true-helm-chart'
@@ -1624,7 +1621,6 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
           cy.checkApplicationStatus("no-dependency-download-postgresql", dsCluster, 'All Namespaces');
         }
       )
-
     })
   )
 });


### PR DESCRIPTION
Automate `disableDependencyUpdate` options with true/false to enable disable dependency download for Helm Chart.

  - [x]  `disableDependencyUpdate: true` Fleet will not automatically download dependencies found in the Helm chart.
  - [x]  `disableDependencyUpdate: false` (default), Fleet will automatically download all dependencies referenced in the Helm chart.

Current test implementation:

| Test Case   | Dependency Installed | Dependency Name | Resources per Cluster | Number of Clusters |Total Resources Deployed
|--------|-----------------------|---------------------------|------------------------|---------------------|---------------------|
| Fleet-130 | false (installed) | Postgresql | 6 per cluster | 3                   |18  
| Fleet-129 | true (not installed)      | Postgresql | 6 + 7 (dependency) --> 13 per cluster | 3                   | 39       


More documentation about found [here](https://fleet.rancher.io/ref-fleet-yaml#chart-source)