### PR TITLE
Removing redundant step on Scheduling test

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -107,8 +107,6 @@ describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
       cy.clickButton('Save');
       
       // Verify the cluster is still Active
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters ');
-      cy.fleetNamespaceToggle('fleet-local');
       cy.wait(2000); // Wait to allow time to the status to reach "Wait" before verifying"
       cy.verifyTableRow(0, 'Active', '1');
 


### PR DESCRIPTION

This test has [failed today](https://github.com/rancher/fleet-e2e/actions/runs/19691075126/job/56406808528#step:10:763) because it glitched somehow while attempting to click on hamburger menu to access cluster.
The initial idea to mitigate (not fix) this was to increase sleep time.

However, before doing this I noticed after setting cluster options for Scheduling and clicking save there were unnecessary steps to reach the cluster and check the status

Although the steps were not a problem themselves, instead of adding waits for mitigation I opted for removing this part as the user is immediately taken into cluster page right after saving config.

CI green: https://github.com/rancher/fleet-e2e/actions/runs/19711339402/job/56472578546