### PR TITLE
Bringing back Azure test with private HTTP auth

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -58,7 +58,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: '@p0' 
     {qase_id: 6, provider: 'GitLab',  repoUrl: 'https://gitlab.com/fleetqa/fleet-qa-examples.git'},
     {qase_id: 7, provider: 'Gh',  repoUrl: 'https://github.com/fleetqa/fleet-qa-examples.git'},
     {qase_id: 8, provider: 'Bitbucket', repoUrl: 'https://bitbucket.org/fleetqa-bb/fleet-qa-examples.git'},
-    // {qase_id: 98, provider: 'Azure',  repoUrl: 'https://dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples'}
+    {qase_id: 98, provider: 'Azure',  repoUrl: 'https://dev.azure.com/fleetqateam/fleet-qa-examples/_git/fleet-qa-examples'}
   ]
 
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {


### PR DESCRIPTION
Done:

- Uncomenting Azure test with private http auth (fleet-98)
- Updated token on ci

Results on 2.13 ok: https://github.com/rancher/fleet-e2e/actions/runs/20913220762/job/60080507402

<img width="1901" height="920" alt="image" src="https://github.com/user-attachments/assets/5ccb1029-0992-4942-8a80-337d13804c6c" />

