### PR TITLE
Update rancher-ecp-qa library to version 2.1.0

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/rancher/fleet-e2e",
   "dependencies": {
-    "@rancher-ecp-qa/cypress-library": "1.2.3",
+    "@rancher-ecp-qa/cypress-library": "2.1.0",
     "cy-verify-downloads": "^0.1.17",
     "cypress": "^15.7.0",
     "cypress-dark": "^1.8.3",


### PR DESCRIPTION
According to recent changes in shared Cypress library `rancher-ecp-qa`, PR from Chandan merged which fixes the recent failures in the Rancher 2.14 login process.

Rancher 2.14 failed CI jobs: https://github.com/rancher/fleet-e2e/actions/runs/21234640122/job/61099945893#step:10:298
Fix link: https://github.com/rancher-sandbox/rancher-ecp-qa/pull/30 