### PR TITLE
Removing parenthesis to avoid collision with Regexp

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -42,7 +42,7 @@ Cypress.Commands.add('gitRepoAuth', (gitOrHelmAuth='Git', gitAuthType, userOrPub
   cy.get('ul.vs__dropdown-menu > li > div', { timeout: 15000 }).contains(gitAuthType, { matchCase: false }).should('be.visible').click();
   
   if (helmUrlRegex) {
-    cy.typeValue('Helm Repos (URL Regex)', helmUrlRegex, false,  false );
+    cy.typeValue('Helm Repos', helmUrlRegex, false,  false ); //not adding (URL Regex) after new regexp in "typeValue" function
   }
 
   if (gitAuthType === 'http') {
@@ -66,7 +66,7 @@ Cypress.Commands.add('gitRepoAuth', (gitOrHelmAuth='Git', gitAuthType, userOrPub
 Cypress.Commands.add('importYaml', ({ clusterName, yamlFilePath }) => {
   cypressLib.burgerMenuToggle();
   cy.get('div.cluster-name').contains(clusterName).click();
-  cy.wait(250);
+  cy.wait(500);
   cy.get('header').find('button').filter(':has(i.icon-upload)').click();
   cy.get('div.card-container').contains('Import YAML').should('be.visible');
 


### PR DESCRIPTION
Latest updated on rancher-ecp-qa/cypress-library to 2.1.0 seems to make function `typeValue` incompatible with parenthesis. 
Tests 64 and 65 contained parentheses and for this reason it was not able to read it. I remove them with a comment pointing at this.

This can be reverted at any time once the function is compatible again with parenthesis.

CI [2.11 green](https://github.com/rancher/fleet-e2e/actions/runs/21353233467/job/61454631598#step:10:325) after this update: 

<img width="1105" height="109" alt="image" src="https://github.com/user-attachments/assets/7622a553-697e-4d45-9d26-29fb791a0525" />
