### PR TITLE
Updating CI to Helm 4

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -268,11 +268,11 @@ jobs:
     steps:
       - name: Adding /usr/local/bin into PATH
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
-      - name: Install latest helm-3 on runner
+      - name: Install latest helm-4 on runner
         run: |
-          echo "::group::Install git and helm-3"
+          echo "::group::Install git and helm-4"
           sudo zypper -n install --no-recommends git
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash
           echo "::endgroup::"
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Updating current script on Helm install step to use helm 4 since it will be legacy soon and as base case to test https://github.com/rancher/fleet/issues/4351

- CI runs:
- [2.11](https://github.com/rancher/fleet-e2e/actions/runs/21444009201/job/61757383588) -> 1 failure
- [2.12](https://github.com/rancher/fleet-e2e/actions/runs/21439026828/job/61737031188#step:10:716) + [p1_2](https://github.com/rancher/fleet-e2e/actions/runs/21443999472/job/61754621363#step:10:481)   -> 2 failures (Had to split them into 2 runs because one of them was skipped)
- [2.14](https://github.com/rancher/fleet-e2e/actions/runs/21436223610/job/61727557299#step:10:959) -> 9 failures (Currently similar to what new ci has)
- [2.13](https://github.com/rancher/fleet-e2e/actions/runs/21470061754/job/61840568557) (on this pr run) -> 1 single failure.

It seems Helm 4 works ok with our CI
