### PR TITLE
Adding dependsOn tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -652,5 +652,4 @@ describe('Test `dependsON` functionality in Fleet GitRepo', { tags: '@p1'}, () =
       cy.contains('Failed to process bundle: validating fleet.yaml: dependsOn[0].acceptedStates[0]: invalid state "BadState", valid values are: [Ready NotReady Pending OutOfSync Modified WaitApplied ErrApplied]').should('be.visible');
     }
   ));
-
 });


### PR DESCRIPTION
Adding tests https://app.qase.io/case/FLEET-207 and https://app.qase.io/case/FLEET-208 to cover new `dependsON ` feature.

- Test 207 will deploy 2 repos one `root` and another `leaf` with accepted status `OutOfSync`. The `leaf` repo will initially faill as the `root` repo is in `Active` status and then will be in `Active` status after the `root` repo is paused.

- Test 208 ensures that when an invalid state is passed, a message is displayed and shows the only valid ones.

CI passing: https://github.com/rancher/fleet-e2e/actions/runs/21869791885