### PR TITLE
Constraining dependsOn tests 2.14 onwards

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -576,80 +576,83 @@ describe('Test GitRepo Bundle do not show hash mismatch error.', { tags: '@p1'},
   )
 });
 
-describe('Test `dependsON` functionality in Fleet GitRepo', { tags: '@p1'}, () => {
+if (!/\/2\.11/.test(Cypress.env('rancher_version')) && !/\/2\.12/.test(Cypress.env('rancher_version')) && !/\/2\.13/.test(Cypress.env('rancher_version'))) {
 
-  qase(207,
-    it("Fleet-207: Test GitRepo with `dependsOn` works as expected.", { tags: '@fleet-207' }, () => {
-  
-      cy.addFleetGitRepo({
-        repoName: "root",
-        repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
-        branch: "main",
-        path: "dependson/root",
-        local: true
-      });
+  describe('Test `dependsON` functionality in Fleet GitRepo', { tags: '@p1'}, () => {
 
-      // Creating root GitRepo which is dependency for leaf GitRepo and verifying it is active and healthy before creating leaf GitRepo.
-      cy.clickButton('Create');
-      cy.verifyTableRow(0, 'Active', 'root');
-      cy.verifyTableRow(0, 'root', '1/1');
-      cy.addFleetGitRepo({
-        repoName: "leaf",
-        repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
-        branch: "main",
-        path: "dependson/leaf",
-        local: true
-      });
+    qase(207,
+      it("Fleet-207: Test GitRepo with `dependsOn` works as expected.", { tags: '@fleet-207' }, () => {
+    
+        cy.addFleetGitRepo({
+          repoName: "root",
+          repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
+          branch: "main",
+          path: "dependson/root",
+          local: true
+        });
 
-      // Verifying leaf GitRepo is in error state because of dependency on root GitRepo and then pausing root GitRepo to check leaf GitRepo is still in error state. After that unpausing root GitRepo and checking leaf GitRepo becomes active.
-      cy.clickButton('Create');
-      cy.verifyTableRow(0, 'Err Applied', 'leaf');
-      cy.verifyTableRow(0, 'Err Applied', '0/1');
+        // Creating root GitRepo which is dependency for leaf GitRepo and verifying it is active and healthy before creating leaf GitRepo.
+        cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Active', 'root');
+        cy.verifyTableRow(0, 'root', '1/1');
+        cy.addFleetGitRepo({
+          repoName: "leaf",
+          repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
+          branch: "main",
+          path: "dependson/leaf",
+          local: true
+        });
 
-      cy.open3dotsMenu('root', 'Pause');
-      cy.wait(750);
-      cy.open3dotsMenu('root', 'Force Update');
-      cy.wait(750);
+        // Verifying leaf GitRepo is in error state because of dependency on root GitRepo and then pausing root GitRepo to check leaf GitRepo is still in error state. After that unpausing root GitRepo and checking leaf GitRepo becomes active.
+        cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Err Applied', 'leaf');
+        cy.verifyTableRow(0, 'Err Applied', '0/1');
 
-      cy.verifyTableRow(0, 'Active', 'leaf');
-      cy.verifyTableRow(0, 'leaf', '1/1');
-      
-      // Clicking "Unpause" to ensure button Delete is visible to later delete both repos
-      cy.open3dotsMenu('root', 'Unpause');
-      cy.wait(1000);
-      cy.deleteAllFleetRepos();      
-    }
-  ));
+        cy.open3dotsMenu('root', 'Pause');
+        cy.wait(750);
+        cy.open3dotsMenu('root', 'Force Update');
+        cy.wait(750);
 
-  qase(208,
-    it("Fleet-208: Verify GitRepo with `dependsOn` with invalid states display invalid error.", { tags: '@fleet-208' }, () => {
-  
-      cy.addFleetGitRepo({
-        repoName: "root",
-        repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
-        branch: "main",
-        path: "dependson/root",
-        local: true
-      });
+        cy.verifyTableRow(0, 'Active', 'leaf');
+        cy.verifyTableRow(0, 'leaf', '1/1');
+        
+        // Clicking "Unpause" to ensure button Delete is visible to later delete both repos
+        cy.open3dotsMenu('root', 'Unpause');
+        cy.wait(1000);
+        cy.deleteAllFleetRepos();      
+      }
+    ));
 
-      // Creating root GitRepo which is dependency for leaf GitRepo and verifying it is active and healthy before creating leaf GitRepo.
-      cy.clickButton('Create');
-      cy.verifyTableRow(0, 'Active', 'root');
-      cy.verifyTableRow(0, 'root', '1/1');
-      cy.addFleetGitRepo({
-        repoName: "leaf-error-state",
-        repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
-        branch: "main",
-        path: "dependson/leaf_bad_states",
-        local: true
-      });
+    qase(208,
+      it("Fleet-208: Verify GitRepo with `dependsOn` with invalid states display invalid error.", { tags: '@fleet-208' }, () => {
+    
+        cy.addFleetGitRepo({
+          repoName: "root",
+          repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
+          branch: "main",
+          path: "dependson/root",
+          local: true
+        });
 
-      // Verifying leaf GitRepo is in error state because of dependency and with an invalid state in acceptedStates and then checking error message is showing correct valid states.
-      cy.clickButton('Create');
-      cy.wait(2000) // Adding wait due to initial change to Git Updating, then Active.
-      cy.verifyTableRow(0, 'Git Updating', 'leaf-error-state');
-      cy.verifyTableRow(0, 'leaf-error-state', '0/0');
-      cy.contains('Failed to process bundle: validating fleet.yaml: dependsOn[0].acceptedStates[0]: invalid state "BadState", valid values are: [Ready NotReady Pending OutOfSync Modified WaitApplied ErrApplied]').should('be.visible');
-    }
-  ));
-});
+        // Creating root GitRepo which is dependency for leaf GitRepo and verifying it is active and healthy before creating leaf GitRepo.
+        cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Active', 'root');
+        cy.verifyTableRow(0, 'root', '1/1');
+        cy.addFleetGitRepo({
+          repoName: "leaf-error-state",
+          repoUrl: "https://github.com/fleetqa/fleet-qa-examples-public",
+          branch: "main",
+          path: "dependson/leaf_bad_states",
+          local: true
+        });
+
+        // Verifying leaf GitRepo is in error state because of dependency and with an invalid state in acceptedStates and then checking error message is showing correct valid states.
+        cy.clickButton('Create');
+        cy.wait(2000) // Adding wait due to initial change to Git Updating, then Active.
+        cy.verifyTableRow(0, 'Git Updating', 'leaf-error-state');
+        cy.verifyTableRow(0, 'leaf-error-state', '0/0');
+        cy.contains('Failed to process bundle: validating fleet.yaml: dependsOn[0].acceptedStates[0]: invalid state "BadState", valid values are: [Ready NotReady Pending OutOfSync Modified WaitApplied ErrApplied]').should('be.visible');
+      }
+    ));
+  });
+}


### PR DESCRIPTION
Adding exclusion of dependson tests for versions prior 2.14


Test correctly being skipped in 2.13: https://github.com/rancher/fleet-e2e/actions/runs/22055395556/job/63722150164
Test passing in 2.14: https://github.com/rancher/fleet-e2e/actions/runs/22055388255/job/63725021055

<img width="990" height="90" alt="image" src="https://github.com/user-attachments/assets/5c29237d-f0b2-41c2-a253-c10956f4d3f1" />
