### PR TITLE
Bringing back modified QASE files prior Cypress 15.13.0 merge

### DIFF
--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const rancherVersion = Cypress.expose('rancher_version');
 export const supported_versions_212_and_above = [

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -14,10 +14,6 @@ limitations under the License.
 
 import './commands';
 
-// This ensures the qase() function exists globally before ANY spec file loads
-(window as any).qase = (id: any, fn: any) => fn;
-console.log('Qase global initialized');
-
 declare global {
   // In Cypress functions should be declared with 'namespace'
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/tests/cypress/support/qase.d.ts
+++ b/tests/cypress/support/qase.d.ts
@@ -1,6 +1,0 @@
-// This makes VS Code happy when we use `qase` in our tests without importing it
-declare global {
-  function qase(id: number | string | number[], test: any): any;
-}
-
-export {};

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,7 +33,7 @@
     "cypress-mochawesome-reporter": "^4.0.2",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-plugin-tab": "^2.0.0",
-    "cypress-qase-reporter": "^1.4.3",
+    "cypress-qase-reporter": "^1.4.1",
     "dotenv": "^17.3.1",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
Reverting changes done related to QASE after [Bump of Cypress 15.13.0](https://github.com/rancher/rancher-turtles-e2e/pull/438/changes)

----

Done:

- Deleted added file `tests/cypress/support/qase.d.ts`
- Added `import { qase } from 'cypress-qase-reporter/dist/mocha';` in `tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts`
- Downgraded `cypress-qase-reporter` version  in `tests/package.json` to `1.4.1` as it was before
-  Removed snippet added in `support/e2e.ts`:
```sh
(window as any).qase = (id: any, fn: any) => fn;
console.log('Qase global initialized');
```