### PR TITLE
Mitigating failures in private helm repo tests 

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -262,6 +262,12 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       ({qase_id, repoName, path, helmUrlRegex_matching, test_explanation}) => {
         qase(qase_id,
           it(`Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`, { tags: `@fleet-${qase_id}` }, () => {;
+            
+            // Adding wait for mitigation of intermittent failures due to slow communication with helm registry 
+            // and also to make sure previous test's resources are deleted and not interfering with current test.
+            
+            cy.wait(5000);
+
             // Positive test using matching regex
             helmUrlRegex = helmUrlRegex_matching
             cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex, local: true });


### PR DESCRIPTION
### Issue

Tests 64 and 65 both have a `deleteAll` at the end of the test which deletes all gitrepos.
Also, they have a gitrepo creation involving credential authentication. 

My asumption is that the combination of a `deleteAll` triggering not completed while the new gitrepo creation is occuring creates some kind of race condition in 2.14. I will try to proof this and raise an issue. 

Given that I have not been able to reproduce this manually, I do not see a functional error but a race condition as commented. Hence we can try to mititgate this with a simple wait at the beginning of the tests.

### Done

Added an extra wait at the very beggining of the tests. 

CI works both [individually](https://github.com/rancher/fleet-e2e/actions/runs/24145106267) and within [p1](https://github.com/rancher/fleet-e2e/actions/runs/24145129244/job/70458535222#step:10:341) test cases 