### PR TITLE
Improving `deleteAllFleetRepos` to wait for bundles to be gone.

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -308,7 +308,6 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
-        // cy.deleteAllFleetRepos();
       })
     )
   
@@ -332,7 +331,6 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
-        // cy.deleteAllFleetRepos();
       })
     )  
   });

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -302,7 +302,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
-        cy.deleteAllFleetRepos();
+        // cy.deleteAllFleetRepos();
       })
     )
   
@@ -326,7 +326,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.filterInSearchBox('fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
-        cy.deleteAllFleetRepos();
+        // cy.deleteAllFleetRepos();
       })
     )  
   });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -523,34 +523,8 @@ Cypress.Commands.add('deleteAllFleetRepos', (namespaceName) => {
 
   cy.fleetNamespaceToggle('fleet-local')
   cy.deleteAll();
-  // // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
-  // cy.wait(2500);
-
   cy.fleetNamespaceToggle('fleet-default')
   cy.deleteAll();
-  // // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
-  // cy.wait(2500);
-
-  // const fleetNamespaces = ['fleet-local', 'fleet-default'];
-  
-  // fleetNamespaces.forEach((namespace) => {
-  //   cy.fleetNamespaceToggle(namespace);
-  //   cy.deleteAll();
-    
-  //   cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]')
-  //     .invoke('text')
-  //     .then((clusterCount) => {
-  //       cy.contains('Resources').should('be.visible').click();
-  //       cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]')
-  //         .invoke('text')
-  //         .then((bundleCount) => {
-  //           cy.log(`###### Fleet-${namespace.toUpperCase()}: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
-  //           cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-  //             expect(subject).to.equal(clusterCount);
-  //           });
-  //         });
-  //     });
-  // });
 
   // Delete all repos from newly created workspace if any.
   if (namespaceName) {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -517,55 +517,55 @@ Cypress.Commands.add('deleteAllFleetRepos', (namespaceName) => {
 
   cy.continuousDeliveryMenuSelection();
 
-  // cy.fleetNamespaceToggle('fleet-local')
-  // cy.deleteAll();
-  // // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
-  // // This way we ensure deletion is completed.
-  // cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
-  //   cy.contains('Resources').should('be.visible').click();
-  //   cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
-  //   cy.log(`###### Fleet-LOCAL: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);    
-  //   cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-  //     expect(subject).to.equal(clusterCount);
-  //   })
-  //   });
-  // });
-
-  // cy.fleetNamespaceToggle('fleet-default')
-  // cy.deleteAll();
-  // // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
-  // // This way we ensure deletion is completed.
-  // cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
-
-  //   cy.contains('Resources').should('be.visible').click();
-  //   cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
-  //   cy.log(`###### Fleet-DEFAULT: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
-  //   cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-  //     expect(subject).to.equal(clusterCount);
-  //   })
-  //   });
-  // });
-
-  const fleetNamespaces = ['fleet-local', 'fleet-default'];
-  
-  fleetNamespaces.forEach((namespace) => {
-    cy.fleetNamespaceToggle(namespace);
-    cy.deleteAll();
-    
-    cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]')
-      .invoke('text')
-      .then((clusterCount) => {
-        cy.contains('Resources').should('be.visible').click();
-        cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]')
-          .invoke('text')
-          .then((bundleCount) => {
-            cy.log(`###### Fleet-${namespace.toUpperCase()}: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
-            cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-              expect(subject).to.equal(clusterCount);
-            });
-          });
-      });
+  cy.fleetNamespaceToggle('fleet-local')
+  cy.deleteAll();
+  // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
+  // This way we ensure deletion is completed.
+  cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
+    cy.contains('Resources').should('be.visible').click();
+    cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
+    cy.log(`###### Fleet-LOCAL: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);    
+    cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+      expect(subject).to.equal(clusterCount);
+    })
+    });
   });
+
+  cy.fleetNamespaceToggle('fleet-default')
+  cy.deleteAll();
+  // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
+  // This way we ensure deletion is completed.
+  cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
+
+    cy.contains('Resources').should('be.visible').click();
+    cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
+    cy.log(`###### Fleet-DEFAULT: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
+    cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+      expect(subject).to.equal(clusterCount);
+    })
+    });
+  });
+
+  // const fleetNamespaces = ['fleet-local', 'fleet-default'];
+  
+  // fleetNamespaces.forEach((namespace) => {
+  //   cy.fleetNamespaceToggle(namespace);
+  //   cy.deleteAll();
+    
+  //   cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]')
+  //     .invoke('text')
+  //     .then((clusterCount) => {
+  //       cy.contains('Resources').should('be.visible').click();
+  //       cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]')
+  //         .invoke('text')
+  //         .then((bundleCount) => {
+  //           cy.log(`###### Fleet-${namespace.toUpperCase()}: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
+  //           cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+  //             expect(subject).to.equal(clusterCount);
+  //           });
+  //         });
+  //     });
+  // });
 
   // Delete all repos from newly created workspace if any.
   if (namespaceName) {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -494,12 +494,16 @@ Cypress.Commands.add('deleteAll', (fleetCheck=true) => {
             .should('exist')
             .click({ctrlKey: true, force: true});
       });
+      // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+      cy.wait(2500);
     };
 
     if ($body.text().includes('Delete')) {
       cy.wait(250) // Add small wait to give time for things to settle
       cy.get('[width="30"] > .checkbox-outer-container.check', { timeout: 50000 }).click();
       cy.get('.btn').contains('Delete').click({ctrlKey: true, force: true});   
+      // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+      cy.wait(2500);
     };
 
     if (fleetCheck === true) {
@@ -519,13 +523,13 @@ Cypress.Commands.add('deleteAllFleetRepos', (namespaceName) => {
 
   cy.fleetNamespaceToggle('fleet-local')
   cy.deleteAll();
-  // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
-  cy.wait(2500);
+  // // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+  // cy.wait(2500);
 
   cy.fleetNamespaceToggle('fleet-default')
   cy.deleteAll();
-  // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
-  cy.wait(2500);
+  // // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+  // cy.wait(2500);
 
   // const fleetNamespaces = ['fleet-local', 'fleet-default'];
   

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -18,7 +18,7 @@ import 'cypress-file-upload';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 
 export const noRowsMessages = ['There are no rows to show.', 'There are no rows which match your search query.']
-export const NoAppBundleOrGitRepoPresentMessages = ['No repositories have been added', 'No App Bundles have been created']
+export const NoAppBundleOrGitRepoPresentMessages = ['No Git Repos have been added', 'No repositories have been added', 'No App Bundles have been created']
 export const rancherVersion = Cypress.expose('rancher_version');
 export const supported_versions_212_and_above = [
   /^(prime|prime-optimus|prime-optimus-alpha|prime-alpha|prime-rc|alpha)\/2\.(1[2-9]|[2-9]\d+)(\..*)?$/,
@@ -514,11 +514,58 @@ Cypress.Commands.add('deleteAll', (fleetCheck=true) => {
 
 // Command to delete all repos pressent in Fleet local and default
 Cypress.Commands.add('deleteAllFleetRepos', (namespaceName) => {
+
   cy.continuousDeliveryMenuSelection();
-  cy.fleetNamespaceToggle('fleet-local')
-  cy.deleteAll();
-  cy.fleetNamespaceToggle('fleet-default')
-  cy.deleteAll();
+
+  // cy.fleetNamespaceToggle('fleet-local')
+  // cy.deleteAll();
+  // // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
+  // // This way we ensure deletion is completed.
+  // cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
+  //   cy.contains('Resources').should('be.visible').click();
+  //   cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
+  //   cy.log(`###### Fleet-LOCAL: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);    
+  //   cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+  //     expect(subject).to.equal(clusterCount);
+  //   })
+  //   });
+  // });
+
+  // cy.fleetNamespaceToggle('fleet-default')
+  // cy.deleteAll();
+  // // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
+  // // This way we ensure deletion is completed.
+  // cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
+
+  //   cy.contains('Resources').should('be.visible').click();
+  //   cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
+  //   cy.log(`###### Fleet-DEFAULT: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
+  //   cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+  //     expect(subject).to.equal(clusterCount);
+  //   })
+  //   });
+  // });
+
+  const fleetNamespaces = ['fleet-local', 'fleet-default'];
+  
+  fleetNamespaces.forEach((namespace) => {
+    cy.fleetNamespaceToggle(namespace);
+    cy.deleteAll();
+    
+    cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]')
+      .invoke('text')
+      .then((clusterCount) => {
+        cy.contains('Resources').should('be.visible').click();
+        cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]')
+          .invoke('text')
+          .then((bundleCount) => {
+            cy.log(`###### Fleet-${namespace.toUpperCase()}: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
+            cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
+              expect(subject).to.equal(clusterCount);
+            });
+          });
+      });
+  });
 
   // Delete all repos from newly created workspace if any.
   if (namespaceName) {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -519,32 +519,13 @@ Cypress.Commands.add('deleteAllFleetRepos', (namespaceName) => {
 
   cy.fleetNamespaceToggle('fleet-local')
   cy.deleteAll();
-  // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
-  // This way we ensure deletion is completed.
-  cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
-    cy.contains('Resources').should('be.visible').click();
-    cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
-    cy.log(`###### Fleet-LOCAL: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);    
-    cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-      expect(subject).to.equal(clusterCount);
-    })
-    });
-  });
+  // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+  cy.wait(2500);
 
   cy.fleetNamespaceToggle('fleet-default')
   cy.deleteAll();
-  // Check the number of clusters into this fleet system and ensure the amount of bundles within resources is the same.
-  // This way we ensure deletion is completed.
-  cy.get('a[aria-label="Clusters"] span[data-testid="type-count"]').invoke('text').then((clusterCount) => {
-
-    cy.contains('Resources').should('be.visible').click();
-    cy.get('a[aria-label="Bundles"] span[data-testid="type-count"]').invoke('text').then((bundleCount) => {
-    cy.log(`###### Fleet-DEFAULT: Cluster count is ${clusterCount} and Bundle count is ${bundleCount} ######`);
-    cy.wrap(bundleCount, { timeout: 10000 }).should((subject) => {
-      expect(subject).to.equal(clusterCount);
-    })
-    });
-  });
+  // Forcefully adding some wait to TRY to ensure that bundle deletion happens after gitrepo deletion.
+  cy.wait(2500);
 
   // const fleetNamespaces = ['fleet-local', 'fleet-default'];
   


### PR DESCRIPTION
### Issue

After improvements on dev side to ensure that after gitrepo deletion the involved resources are actually deleted. Sometimes when we delete gitrepos, it happens that is removed from UI, but still part of the bundles are present and we get an error like this:

`Bundles.fleet.cattle.io` 'bundle name' already exists`

<img width="2432" height="1394" alt="image (2)" src="https://github.com/user-attachments/assets/7f7741a8-1925-4d50-8a49-ae01e96c82c2" />

### Done

- Issue mitigation:  ~~I have implemented a logic where we **ensure** upon gitrepo deletion that the **_number of clusters matches the number of bundles_** (by default 1 for local and 3 for dowstream ones in cloud, but is dynamic), with an implicit wait of 10 seconds. Beyond that will fail.~~ --> Adding 2.5 seconds explicit wait on deleteAll command. The previous implementation was either heavy on a loop or crashing the entire tests if failing.

- Removed `cy.deleteAllFleetRepos();` at the end of OCI tests after good results in local testing. 
- Added new log message in constant `NoAppBundleOrGitRepoPresentMessages`: `No Git Repos have been added'`
since it seems new in UI (I kept the previous existing ones)

Tests [2.13 ](https://github.com/rancher/fleet-e2e/actions/runs/24200634165/job/70643027662#step:10:595)perfect
Tests [2.14](https://github.com/rancher/fleet-e2e/actions/runs/24200667598/job/70643139389) just known failures

<img width="966" height="337" alt="image" src="https://github.com/user-attachments/assets/92dad9b7-9267-440f-9f2e-ae2feb95e5f8" />
