### PR TITLE
Updating CI lanes

### DIFF
--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -14,8 +14,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version latest/latest, latest/2.13.x[-rc1], prime/2.13.x, prime/devel/2.13, alpha/2.14.0-alpha1, prime-alpha/2.x.x-alphaX
-        default: head/2.14
+        description: Rancher version channel/version/head_version latest/latest, latest/2.15.x[-rc1], prime/2.15.x, prime/devel/2.15, alpha/2.15.0-alpha1, prime-alpha/2.x.x-alphaX
+        default: head/2.15
         type: string
         required: true
       upstream_cluster_version:
@@ -29,7 +29,7 @@ on:
         type: string
         default: '@login @p0 @p1 @p1_2 @rbac @special_tests'
   schedule:
-    - cron: '30 3 * * 1-5'
+    - cron: '00 23 * * 1-5'
 
 jobs:
   ui:
@@ -60,6 +60,6 @@ jobs:
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.35.2+k3s1' }}
-      rancher_version: ${{ inputs.rancher_version || 'head/2.14' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.15' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.12.yaml
+++ b/.github/workflows/ui-rm_head_2.12.yaml
@@ -29,7 +29,7 @@ on:
         type: string
         default: '@login @p0 @p1 @p1_2 @rbac @special_tests'
   schedule:
-    - cron: '30 2 * * 1-5'
+    - cron: '00 3 * * 2,4'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -29,7 +29,7 @@ on:
         type: string
         default: '@login @p0 @p1 @p1_2 @rbac @special_tests'
   schedule:
-    - cron: '0 3 * * 1-5'
+    - cron: '00 3 * * 1,3,5'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rm_head_2.14.yaml
+++ b/.github/workflows/ui-rm_head_2.14.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-RM_head_2.7
+name: UI-RM_head_2.14
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}` - `{2}` destroy={3}', inputs.rancher_version, inputs.upstream_cluster_version, inputs.grep_test_by_tag, inputs.destroy_runner) || github.workflow }}
 
 on:
@@ -14,20 +14,22 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version latest/latest, latest/2.7.10[-rc2], prime/2.7.12, prime/devel/2.7, prime-optimus/2.7.13-rc4
-        default: latest/devel/2.7
+        description: Rancher version channel/version/head_version latest/latest, latest/2.13.x[-rc1], prime/2.13.x, prime/devel/2.13, alpha/2.14.0-alpha1, prime-alpha/2.x.x-alphaX
+        default: head/2.14
         type: string
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: v1.26.10+k3s2
+        default: 'v1.35.2+k3s1'
         type: string
         required: true
       grep_test_by_tag:
         description: Grep tags. For multiple selection separate with spaces. Keep always @login
         required: false
         type: string
-        default: '@login @p0 @p1 @p1_2 @rbac'
+        default: '@login @p0 @p1 @p1_2 @rbac @special_tests'
+  schedule:
+    - cron: '00 1 * * 1-5'
 
 jobs:
   ui:
@@ -47,13 +49,17 @@ jobs:
       rsa_private_key_qa: ${{ secrets.RSA_PRIVATE_KEY_QA }}
       rsa_public_key_qa: ${{ secrets.RSA_PUBLIC_KEY_QA }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      github_app_id: ${{ secrets.GH_APP_ID }}
+      github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+      github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       # WARNING, VALUES BELOW ARE HARDCODED FOR RUNS SCHEDULED BY CRON
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.26.10+k3s2' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
+      upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.35.2+k3s1' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.14' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
-      grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}
-      
+      grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.14.yaml
+++ b/.github/workflows/ui-rm_head_2.14.yaml
@@ -14,7 +14,7 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher version channel/version/head_version latest/latest, latest/2.13.x[-rc1], prime/2.13.x, prime/devel/2.13, alpha/2.14.0-alpha1, prime-alpha/2.x.x-alphaX
+        description: Rancher version channel/version/head_version latest/latest, latest/2.14.x[-rc1], prime/2.14.x, prime/devel/2.14, alpha/2.14.0-alpha1, prime-alpha/2.x.x-alphaX
         default: head/2.14
         type: string
         required: true


### PR DESCRIPTION
Various updates regarding CI's:


- Repointing head to  2.15 lane
- Changing cronjobs to start much earlier
- Running 2.13 tests 3 times a week
- Running 2.12 tests 2 times a week