### PR TITLE
Adding extra step verifying box content of Bundles and resources ready

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -540,11 +540,13 @@ Cypress.Commands.add('checkGitRepoStatus', (repoName, bundles, resources, { time
   cy.get('.primaryheader > h1, h1 > span.resource-name.masthead-resource-title').contains(repoName).should('be.visible')
   cy.log(`Checking ${bundles} Bundles and Resources`)
   if (bundles) {
+    cy.contains('Bundles ready', { timeout: timeout }).should('be.visible');
     cy.get('div.fleet-status', { timeout: timeout }).eq(0).contains(` ${bundles} Bundles ready `, { timeout: timeout }).should('be.visible')
   }
   // Ensure this check is performed only for tests in 'fleet-local' namespace.
   if (resources) {
-      cy.get('div.fleet-status', { timeout: timeout }).eq(1).contains(` ${resources} Resources ready `, { timeout: timeout }).should('be.visible')
+    cy.contains('Resources ready', { timeout: timeout }).should('be.visible');
+    cy.get('div.fleet-status', { timeout: timeout }).eq(1).contains(` ${resources} Resources ready `, { timeout: timeout }).should('be.visible')
   } else {
     // On downstream clusters (v2.9+), resources are affected by cluster count.
     // Avoid specifying 'resources' for tests in 'fleet-default' to allow automatic verification.


### PR DESCRIPTION
Added confirmation of box containing Resources and Bundles using only `cy.contains`.

This approach does not contain explicit waits and it helps not to break the following  get command searching for the actual number.

<img width="2176" height="592" alt="image" src="https://github.com/user-attachments/assets/8481555b-509d-478c-919c-6b66e9a1208f" />


[2.14 p1_2 ](https://github.com/rancher/fleet-e2e/actions/runs/24251556198/job/70813806822)test cases seemed ok in cluster group ones

<img width="1495" height="444" alt="image" src="https://github.com/user-attachments/assets/1954bd12-f701-46e4-a62f-5745c2388fd4" />