### PR TITLE
Testing bigger spotinst

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -112,7 +112,7 @@ on:
         required: false
       runner_template:
         description: Runner template to use
-        default: fleet-e2e-ci-runner-spot-x86-64-template-v3
+        default: fleet-e2e-ci-spot-20260413-161128
         type: string
       test_description:
         description: Short description of the test


### PR DESCRIPTION

Re-pointing to a bigger spotsinst to try avoid ci breakages.

I am changing

[fleet-e2e-ci-runner-spot-x86-64-template-v3 n2-standard-8](https://console.cloud.google.com/compute/instanceTemplates/details/fleet-e2e-ci-runner-spot-x86-64-template-v3?project=ei-container-eco&authuser=1) where (n2-standard-8 (8 vCPU, 4 core, 32 GB memory))

to:

[fleet-e2e-ci-spot-20260413-161128 n2-highmem-16](https://console.cloud.google.com/compute/instanceTemplates/details/fleet-e2e-ci-spot-20260413-161128?project=ei-container-eco&authuser=1)	where (n2-standard-16 (16 vCPU, 8 core, 64 GB memory)

CI 2.14 p1_2 was able to run for a while: https://github.com/rancher/fleet-e2e/actions/runs/24388210993/job/71227261239

