### PR TITLE
Going back to old spotinst version

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -112,7 +112,7 @@ on:
         required: false
       runner_template:
         description: Runner template to use
-        default: fleet-e2e-ci-spot-20260413-161128
+        default: fleet-e2e-ci-runner-spot-x86-64-template-v3
         type: string
       test_description:
         description: Short description of the test


### PR DESCRIPTION
Revert of https://github.com/rancher/fleet-e2e/pull/488
For some reason I do not comprehend, the previous pr worked well for few hours but in the end it gave [this](https://github.com/rancher/fleet-e2e/actions/runs/24407860318/job/71296047701) error: 

```
Run gcloud compute instances create fleet-e2e-ci-594619d7247b451686183aa2b06c814c \
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid value for field 'resource.disks[0].initializeParams.sourceImage': 'projects/ei-container-eco/global/images/fleet-e2e-ci-runners-up20260409-1100'. The referenced image resource cannot be found.

Error: Process completed with exit code 1.
```

PS the image template still exists so not sure what happens but not there:

<img width="2435" height="1329" alt="image" src="https://github.com/user-attachments/assets/4f616abb-8ead-4d1c-96f1-1ff28072a936" />
