### PR TITLE
Fix Fleet-79 and Fleet-80 tests and update cy.login with cy.session in P1_2 tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -34,7 +34,11 @@ export const supported_versions_212_and_above = [
 ];
 
 beforeEach(() => {
-  cy.login();
+  cy.session('admin', () => {
+    cy.login();
+    cy.visit('/');
+  });
+
   cy.visit('/');
   cy.deleteAllFleetRepos();
 });

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -422,7 +422,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
               cy.filterInSearchBox(resourceName);
               cy.wait(500);
               if (resourceType === 'ConfigMaps') {
-                cy.deleteConfigMap(resourceName);
+                cy.deleteConfigMap(resourceName, dsCluster);
               }
               else {
                 cy.get('body').then(($body) => {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -511,8 +511,8 @@ Cypress.Commands.add('deleteAll', (fleetCheck=true) => {
       }
       
     else {
-        cy.get('td > span, td.text-center > span', { timeout: 25000 }).invoke('text').should('be.oneOf', noRowsMessages)
-      }
+      cy.contains(new RegExp(noRowsMessages.join('|')), { timeout: 30000 }).should('be.visible');
+    }
   });
 });
 
@@ -1186,8 +1186,8 @@ Cypress.Commands.add('createConfigMap', (configMapName) => {
 })
 
 
-Cypress.Commands.add('deleteConfigMap', (configMapName) => {
-    cy.accesMenuSelection('local', 'Storage', 'ConfigMaps');
+Cypress.Commands.add('deleteConfigMap', (configMapName, clusterName="local") => {
+    cy.accesMenuSelection(clusterName, 'Storage', 'ConfigMaps');
     cy.filterInSearchBox(configMapName);
     cy.wait(1000);
     cy.get('body').then(($body) => {

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -69,7 +69,7 @@ declare global {
       restoreClusterToDefaultWorkspace(clusterName: string, timeout: number, defaultWorkspaceName?: string, restore?: boolean): Chainable<Element>;
       createNewFleetWorkspace(newWorkspaceName: string): Chainable<Element>;
       createConfigMap(configMapName: string): Chainable<Element>;
-      deleteConfigMap(configMapName: string): Chainable<Element>;
+      deleteConfigMap(configMapName: string, clusterName?: string): Chainable<Element>;
       closePopWindow(windowMessage: string): Chainable<Element>;
       k8sUpgradeInRancher(clusterName: string): Chainable<Element>;
       continuousDeliveryMenuSelection(navToAppBundles?: boolean): Chainable<Element>;


### PR DESCRIPTION
- Correct Drift tests: Fleet-79 and Fleet-80 are failing due below erros:
  - https://github.com/rancher/fleet-e2e/actions/runs/24431729190/job/71377508049#step:10:494
  - https://github.com/rancher/fleet-e2e/actions/runs/24321581773/job/71008720310#step:10:503

- Improved deletion of `ConfigMap` from all clusters, earlier it was pointing to `local` cluster only.
- Avoid repeat login in `p1_2` tests by adding `cy.session`.
