### PR TITLE
Increase timeout for namespace deletion check in tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -888,7 +888,7 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       // Check namespace is deleted
       cy.accesMenuSelection('local', 'Projects/Namespaces');
       cy.filterInSearchBox(namespaceName);
-      cy.contains(namespaceName).should('not.exist');
+      cy.contains(namespaceName, { timeout: 30000 }).should('not.exist');
     })
   )
 


### PR DESCRIPTION
#### Problem

- In recent [CI](https://github.com/rancher/fleet-e2e/actions/runs/24552563936/job/71781475361#step:10:406), Fleet-131 test failed.

<img width="1145" height="271" alt="image" src="https://github.com/user-attachments/assets/b719fc42-d9b4-4b8b-ba70-26db8fb380e6" />


#### Solution

- While debugging locally, found that `namespace` is in `Terminating` state while test is trying to check it's non-existence.
- Adding small  30s` `timeout` to the `cy.contains` solved the problem.
