### PR TITLE
Adding more time to hardening

### DIFF
--- a/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
@@ -62,7 +62,7 @@ describe('Test Hardened Fleet deployment on PUBLIC repos',  { tags: '@hardening-
       cy.clickButton('Edit as YAML');
       cy.contains('apiVersion: fleet.cattle.io/v1alpha1').should('be.visible');
       cy.clickButton('Create')
-      cy.wait(2000);
+      cy.wait(20000);
       cy.checkGitRepoStatus(repoName, '1 / 1', '18 / 18');
       cy.verifyTableRow(0, 'Active', 'downstream-clusters-ok-simple');
     })


### PR DESCRIPTION
Hardening tests sometimes failed on second test due to timeouts to get deployments up on time.

These test failed after 3 runs:

- [2.12](https://github.com/rancher/fleet-e2e/actions/runs/24709844587)
- [2.13](https://github.com/rancher/fleet-e2e/actions/runs/24709862523)
- [2.14](https://github.com/rancher/fleet-e2e/actions/runs/24709875272)

<img width="1217" height="333" alt="image" src="https://github.com/user-attachments/assets/246bb9e8-a2ec-4ea7-85a0-62a692aca4eb" />


Adding a bit of time proofed successfull on all lanes:

- [2.12](https://github.com/rancher/fleet-e2e/actions/runs/24714669300)
- [2.13](https://github.com/rancher/fleet-e2e/actions/runs/24714646831)
- [2.14](https://github.com/rancher/fleet-e2e/actions/runs/24713824765)