### PR TITLE
Fix CI failed tests by toggling fleet workspace

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -192,6 +192,9 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
             cy.accesMenuSelection('Continuous Delivery', 'Clusters');
             cy.contains('.title', 'Clusters').should('be.visible');
 
+            //Toggle Fleet namespace on cluster page to `fleet-default` if not being selected already.
+            cy.fleetNamespaceToggle('fleet-default');
+
             // Add label to the third cluster i.e. imported-2
             cy.assignClusterLabel(dsThirdClusterName, key, value);
 
@@ -614,6 +617,10 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
       // Remove label from the Second cluster i.e. imported-1
       cy.wait(500);
       cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+
+      //Toggle Fleet namespace on cluster page to `fleet-default` if not being selected already.
+      cy.fleetNamespaceToggle('fleet-default');
+
       cy.removeClusterLabels(dsSecondClusterName, key, value);
 
       // Check application is absent i.e. removed from second cluster i.e. imported-1
@@ -1666,6 +1673,10 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
       kubectl label clusters.management.cattle.io --all env=override{enter}');
 
       cy.continuousDeliveryMenuSelection();
+
+      //Toggle Fleet namespace on cluster page to `fleet-default` if not being selected already.
+      cy.fleetNamespaceToggle('fleet-default');
+
       cy.verifyTableRow(0, 'Active', repoName);
       cy.checkGitRepoStatus(repoName, '1 / 1', '3 / 3');
 

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -453,9 +453,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   let gitRepoFile
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
-    cy.login();
-    cy.visit('/');
-    cy.deleteAllFleetRepos();
     // Remove labels from the clusters.
     dsAllClusterList.forEach(
       (dsCluster) => {
@@ -489,7 +486,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
     qase(qase_id,
-      it(`Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`, { tags: `@fleet-${qase_id}` }, () => {
+      it(`Fleet-${qase_id}: Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`, { tags: `@fleet-${qase_id}` }, () => {
 
         cy.continuousDeliveryMenuSelection();
         cy.clickNavMenu(['Clusters']);


### PR DESCRIPTION
### Rancher version: prime-alpha/2.14.1-alpha3
### CI Link: https://github.com/rancher/fleet-e2e/actions/runs/24716410196
### Failed tests: Fleet-19, Fleet-27, Fleet-93 and Fleet-131
---

### Problem
#### RCA for Failed tests:
| Test No. | Problem | Screenshot |
|--------|--------|--------|
| Fleet-19 | Unable to find the `imported-`  cluster due to fleet workspace pointing to `fleet-local`  instead of `fleet-default` | <img width="1280" height="720" alt="Test Application deployment based on &#39;clusterSelector&#39; -- Fleet-19 Test remove label from cluster-2 to remove application from it when application deployed using clusterSelector(matchLabels) (failed)" src="https://github.com/user-attachments/assets/05f976f6-ba5c-4bb4-9673-36986f43f539" /> |
| Fleet-27 | Unable to find the `imported-`  cluster due to fleet workspace pointing to `fleet-local`  instead of `fleet-default` | <img width="1280" height="720" alt="Test application deployment based on clusterGroup -- Fleet-27 Test install existing application to the third cluster by adding it to the existing &#39;clusterGroup&#39; (failed)" src="https://github.com/user-attachments/assets/a3e71cf5-54b8-457f-b60d-9ce539945c6b" /> |
| Fleet-93 | `Active` state of the `GitRepo` cannot be verified due to fleet workspace pointing to `fleet-local` instead of `fleet-default` | <img width="1280" height="720" alt="Test bundle deploy with overrideTargets by label availability on clusters -- Fleet-93 Test bundle gets deployed on the target mentioned in the GitRepo provided that `overrideTargets` is present in the `fleet yaml` after adding label on cluster (faile" src="https://github.com/user-attachments/assets/49f1248a-f930-4d9f-8613-ee07e8599785" /> |

 

### Solution 
- Add `cy.fleetNamespaceToggle('fleet-default')` after `Continuous Delivery` navigation.


