### PR TITLE
Mitiigate Helmops tests 173 to 176

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1062,10 +1062,8 @@ describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
         cy.clickButton('Create');
         cy.verifyTableRow(0, 'Active', repoName);
+        cy.wait(1000);
         cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-
-        // Delete GitRepo
-        cy.deleteAllFleetRepos();
       })
     );
   });


### PR DESCRIPTION


At times bundles and resources element n bar on element `.primaryheader > h1, h1 > span.resource-name.masthead-resource-title` do no appear while it is called by our `cy.get`. This at times break the test. 

<img width="2068" height="1167" alt="image" src="https://github.com/user-attachments/assets/76d78cf3-b818-4c05-93c2-a946c7e08ae1" />


Added small delay after repo is ready, seemed to help: 

<img width="2142" height="1170" alt="2026-April-21_22-52" src="https://github.com/user-attachments/assets/dd945126-a128-41c0-9ab6-565977a04fe2" />

Also in headless mode:

<img width="954" height="439" alt="image" src="https://github.com/user-attachments/assets/b268c9b0-5f5c-431d-80a8-9c34ff2188ef" />


