### PR TITLE
Fix 2.15 tests failed due to namespace toggle issue

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -284,10 +284,10 @@ Cypress.Commands.add('deployToClusterOrClusterGroup', (deployToTarget) => {
 
 Cypress.Commands.add('clickCreateGitRepo', (local) => {
   if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-    cy.clickButton('Create App Bundle');
     if (local){
       cy.fleetNamespaceToggle('fleet-local');
     }
+    cy.clickButton('Create App Bundle');
     cy.contains('App Bundle: Create').should('be.visible');
     cy.contains('Git Repos').should('be.visible').click();
     cy.wait(1000);


### PR DESCRIPTION
Problem:
- On 2.15:
  - Lots of tests are failing due to not able to click on Fleet workspace switch/toggle button.
  - CI tests failed screenshot:
   - <img width="1995" height="1027" alt="image" src="https://github.com/user-attachments/assets/b636fd9a-cc65-4932-85aa-38eb172e7ed6" />


Solution:
- In `Fleet-e2e` tests, we need to select the `Fleet workspace` prior to the `GitRepo` creation.
- In recent changes on `Rancher 2.15-head for Fleet UI`, the `Fleet workspace` switch/toggle button is `grey'ed out` (disabled).
- This means that during the process of `GitRepo` creation, user can not toggle the Fleet workspace (from `fleet-local` to `fleet-default` or vice-versa)