### PR TITLE
Fleetqa/qase rework

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -427,7 +427,7 @@ jobs:
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (after-upgrade)
-        if: failure() && ${{ inputs.rancher_upgrade != '' }}
+        if: ${{ failure() && inputs.rancher_upgrade != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cypress-screenshots-after-upgrade-${{ inputs.cluster_name }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -216,7 +216,7 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
       QASE_TESTOPS_COMPLETE_RUN: true
-      QASE_LOGGING: false
+      QASE_LOGGING_CONSOLE: false
 
     steps:
       - name: Adding /usr/local/bin into PATH

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -306,6 +306,8 @@ jobs:
           GH_APP_ID: ${{ secrets.github_app_id }}
           GH_APP_INSTALLATION_ID: ${{ secrets.github_app_installation_id }}
           GH_APP_PRIVATE_KEY: ${{ secrets.github_app_private_key }}
+          QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
+          QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
           GREPTAGS: ${{ inputs.grep_test_by_tag }}
           UPGRADE: 'false'
           # Add cypress/e2e/unit_tests/user.spec.ts again when implementing RBAC tests.

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -216,6 +216,7 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
       QASE_TESTOPS_COMPLETE_RUN: true
+      QASE_LOGGING: false
 
     steps:
       - name: Adding /usr/local/bin into PATH

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -81,9 +81,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      qase_run_id:
-        description: Case run ID where the results will be reported
-        type: string
+      qase_report:
+        description: Report to QASE
+        default: false
+        type: boolean
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
@@ -181,68 +182,14 @@ jobs:
             false
           fi
 
-  pre-qase:
-    runs-on: ubuntu-latest
-    env:
-      QASE_API_TOKEN: ${{ secrets.qase_api_token }}
-      QASE_PROJECT_CODE: FLEET
-    outputs:
-      qase_run_description: ${{ steps.qase.outputs.qase_run_description }}
-      qase_run_id: ${{ steps.qase.outputs.qase_run_id }}
-      qase_run_name: ${{ steps.qase.outputs.qase_run_name }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          cache-dependency-path: tests/go.sum
-          go-version-file: tests/go.mod
-
-      - name: Create/Export Qase Run
-        id: qase
-        env:
-          QASE_RUN_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.rancher_version || github.workflow }}
-        run: |
-          case ${{ inputs.qase_run_id }} in
-            'auto')
-              # Define and export URL of GH test run in Qase run description
-              GH_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              QASE_DESC="${{ inputs.test_description }} (${GH_RUN_URL})"
-              export QASE_RUN_DESCRIPTION="${QASE_DESC}"
-
-              # Use full rancher version
-              QASE_RUN_NAME=$(echo $QASE_RUN_NAME | grep -P '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?' || true)
-              # Or workflow name if the full rancher version is not found
-              if [ -z "$QASE_RUN_NAME" ]; then
-                QASE_RUN_NAME="${{ github.workflow }}"
-              fi
-
-              # Create a Qase run, get its ID
-              ID=$(cd tests && make create-qase-run)
-
-              # Export outputs for future use
-              echo "qase_run_description=${QASE_DESC}" >> ${GITHUB_OUTPUT}
-              echo "qase_run_id=${ID}" >> ${GITHUB_OUTPUT}
-              echo "qase_run_name=${QASE_RUN_NAME}" >> ${GITHUB_OUTPUT}
-
-              # Just an info for debugging purposes
-              echo -e "Exported values:\nQASE_RUN_ID=${ID}\nQASE_RUN_DESCRIPTION=${QASE_DESC}\nQASE_RUN_NAME=${QASE_RUN_NAME}"
-              ;;
-            'none')
-              echo "qase_run_id=" >> ${GITHUB_OUTPUT}
-              echo "### Test not reported in QASE!" >> ${GITHUB_STEP_SUMMARY}
-              ;;
-            [0-9]*)
-              # If the run ID has been specified
-              echo "qase_run_id=${{ inputs.qase_run_id }}" >> ${GITHUB_OUTPUT}
-              ;;
-          esac
-
   e2e:
-    needs: [create-runner, pre-qase]
+    needs: [create-runner]
     runs-on: ${{ needs.create-runner.outputs.uuid }}
+    # DELETE NOTES:
+    # Adapted from https://github.com/rancher/rancher-turtles-e2e/pull/269/changes#diff-24ccba33d5b3aea3f85952e4b5113c9546bf141bafee2c130d95abda98816d1bR233
+    # Not sure how this worked after removal of qase_run_id
+    outputs:
+      qase_run_id: ${{ steps.qase_run_id.outputs.qase_run_id }} 
     env:
       DS_CLUSTER_COUNT: 3
       ARCH: amd64
@@ -261,6 +208,11 @@ jobs:
       # QASE variables
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
       QASE_PROJECT_CODE: FLEET
+      QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
+      # DELETE NOTES:
+      # turtles_dev_chart not appearing for us. Removing. Not sure if we need an equivalent variable here.
+      QASE_TESTOPS_RUN_TITLE: ${{ format('[{3}] Rancher-{0} - {1} destroy={2} dev={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, github.run_number) }}
+      QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
       # NOTE: this REPORT var is needed for Cypress!
       QASE_REPORT: 1
@@ -383,6 +335,14 @@ jobs:
           name: cypress-videos-basics-${{ inputs.cluster_name }}
           path: tests/cypress/videos
           retention-days: 7
+      - name: Store QASE_TESTOPS_RUN_ID for later use
+        if: ${{ always() && inputs.qase_report == true }}
+        id: qase_run_id
+        run: |
+          if [ -f tests/cypress/e2e/unit_tests/QASE_TESTOPS_RUN_ID.txt ]; then
+            QASE_TESTOPS_RUN_ID=$(cat tests/cypress/e2e/unit_tests/QASE_TESTOPS_RUN_ID.txt)
+            echo "qase_run_id=${QASE_TESTOPS_RUN_ID}" >> ${GITHUB_OUTPUT}
+          fi
       - name: Upgrade Rancher Manager
         id: rancher_upgrade
         if: ${{ inputs.rancher_upgrade != '' }}
@@ -390,6 +350,7 @@ jobs:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}
           PUBLIC_DOMAIN: bc.googleusercontent.com
           RANCHER_UPGRADE: ${{ inputs.rancher_upgrade }}
+          QASE_TESTOPS_RUN_ID: ${{ steps.qase_run_id.outputs.qase_run_id }}
         run: |
           cd tests
 
@@ -514,7 +475,12 @@ jobs:
             echo "Fleet App version: ${{ steps.upgraded_component.outputs.fleet_app_upgraded_version }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Fleet images in local cluster: ${{ steps.upgraded_component.outputs.fleet_images_after_upgrade }}" >> ${GITHUB_STEP_SUMMARY}
           fi
-
+          if [[ -n "${{ steps.qase_run_id.outputs.qase_run_id }}" ]]; then
+            echo -e "\n### QASE Report" >> ${GITHUB_STEP_SUMMARY}
+            echo "View the detailed report [here](https://app.qase.io/run/FLEET/dashboard/${{ steps.qase_run_id.outputs.qase_run_id }})" >> ${GITHUB_STEP_SUMMARY}
+          else
+            echo -e "\n### Test not reported in QASE!" >> ${GITHUB_STEP_SUMMARY}
+          fi
   delete-runner:
     if: ${{ always() && inputs.destroy_runner == true }}
     needs: [create-runner, e2e]
@@ -539,42 +505,42 @@ jobs:
             --delete-disks all \
             --zone ${{ inputs.zone }}
 
-  post-qase:
-    if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
-    needs: [e2e, pre-qase]
-    runs-on: ubuntu-latest
-    env:
-      QASE_API_TOKEN: ${{ secrets.qase_api_token }}
-      QASE_PROJECT_CODE: FLEET
-      QASE_REPORT: 1
-      QASE_RUN_COMPLETE: 1
-      QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+  # post-qase:
+  #   if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
+  #   needs: [e2e, pre-qase]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     QASE_API_TOKEN: ${{ secrets.qase_api_token }}
+  #     QASE_PROJECT_CODE: FLEET
+  #     QASE_REPORT: 1
+  #     QASE_RUN_COMPLETE: 1
+  #     QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          cache-dependency-path: tests/go.sum
-          go-version-file: tests/go.mod
+  #     - name: Setup Go
+  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+  #       with:
+  #         cache-dependency-path: tests/go.sum
+  #         go-version-file: tests/go.mod
 
-      - name: Finalize Qase Run and publish Results
-        if: ${{ always() && !contains(needs.e2e.result, 'cancelled') }}
-        run: |
-          REPORT=$(cd tests && make publish-qase-run)
-          echo "${REPORT}"
+  #     - name: Finalize Qase Run and publish Results
+  #       if: ${{ always() && !contains(needs.e2e.result, 'cancelled') }}
+  #       run: |
+  #         REPORT=$(cd tests && make publish-qase-run)
+  #         echo "${REPORT}"
 
-          # Extract report URL and put it in summary
-          REPORT_URL=$(awk '/available:/ { print $NF }' <<<${REPORT})
-          if [[ -n "${REPORT_URL}" ]]; then
-            echo "## QASE Reporting" >> ${GITHUB_STEP_SUMMARY}
-            echo "Public Qase report: ${REPORT_URL}" >> ${GITHUB_STEP_SUMMARY}
-          fi
+  #         # Extract report URL and put it in summary
+  #         REPORT_URL=$(awk '/available:/ { print $NF }' <<<${REPORT})
+  #         if [[ -n "${REPORT_URL}" ]]; then
+  #           echo "## QASE Reporting" >> ${GITHUB_STEP_SUMMARY}
+  #           echo "Public Qase report: ${REPORT_URL}" >> ${GITHUB_STEP_SUMMARY}
+  #         fi
 
-      - name: Delete Qase Run if job has been cancelled
-        if: ${{ always() && contains(needs.e2e.result, 'cancelled') }}
-        run: cd tests && make delete-qase-run
+  #     - name: Delete Qase Run if job has been cancelled
+  #       if: ${{ always() && contains(needs.e2e.result, 'cancelled') }}
+  #       run: cd tests && make delete-qase-run
 
   # Just to signify that something has been cancelled and it's not useful to check the test
   declare-cancelled:
@@ -584,3 +550,14 @@ jobs:
     steps:
       - name: Specify in summary if something has been cancelled
         run: echo "# TEST CANCELLED!" >> ${GITHUB_STEP_SUMMARY}
+      - name: Complete the QASE run if cancelled
+        # Otherwise the cancelled run would stay in "In Progress" state
+        run: |
+          RUN_ID=${{ needs.e2e.outputs.qase_run_id }}
+          if [ -n "$RUN_ID" ]; then
+            curl -X POST \
+              --url https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete \
+              -H "Token: ${{ secrets.QASE_API_TOKEN }}" \
+              -H 'accept: application/json'
+          fi
+          echo "QASE run $RUN_ID marked as Completed" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -190,9 +190,6 @@ jobs:
   e2e:
     needs: [create-runner]
     runs-on: ${{ needs.create-runner.outputs.uuid }}
-    # DELETE NOTES:
-    # Adapted from https://github.com/rancher/rancher-turtles-e2e/pull/269/changes#diff-24ccba33d5b3aea3f85952e4b5113c9546bf141bafee2c130d95abda98816d1bR233
-    # Not sure how this worked after removal of qase_run_id
     outputs:
       qase_run_id: ${{ steps.qase_run_id.outputs.qase_run_id }}
     env:
@@ -214,9 +211,6 @@ jobs:
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
       QASE_PROJECT_CODE: FLEET
       QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
-      # DELETE NOTES:
-      # turtles_dev_chart not appearing for us. Removing. Not sure if we need an equivalent variable here.
-      # QASE_TESTOPS_RUN_TITLE: ${{ format('[{3}] Rancher-{0} - {1} destroy={2} dev={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, github.run_number) }}
       QASE_TESTOPS_RUN_TITLE: ${{ format('[{0}] Rancher-{1} - {2} destroy={3}', github.run_number, inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner) }}
 
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -321,12 +315,6 @@ jobs:
             cypress/e2e/unit_tests/hardened_fleet.spec.ts
             cypress/e2e/unit_tests/special_fleet_tests.spec.ts
         run: |
-          # if ${{ inputs.qase_run_id == 'none' }}; then
-          #   # Unset default QASE_* variables when reporting is disabled
-          #   unset QASE_REPORT
-          #   unset QASE_API_TOKEN
-          #   # QASE_RUN_ID is empty string already
-          # fi
           if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN
           fi
@@ -348,7 +336,6 @@ jobs:
           path: tests/cypress/videos
           retention-days: 7
       - name: Store QASE_TESTOPS_RUN_ID for later use
-        ## TODO: revise this step for QASE ID tracking
         if: ${{ always() && inputs.qase_report == true }}
         id: qase_run_id
         run: |
@@ -383,6 +370,7 @@ jobs:
           fi
       - name: Extract component versions/informations after Upgrade
         id: upgraded_component
+        if: ${{ inputs.rancher_upgrade != '' }}
         run: |
           # Extract Rancher Manager version
           RM_UPGRADED_VERSION=$(kubectl get pod \
@@ -428,16 +416,12 @@ jobs:
           RANCHER_VERSION: ${{ inputs.rancher_upgrade }}
           K8S_VERSION_UPGRADE_DS_CLUSTER: ${{ inputs.k8s_version_upgrade_ds_cluster }}
           K8S_VERSION_UPGRADE_DS_CLUSTER_TO: ${{ inputs.k8s_version_to_upgrade_ds_cluster_to }}
+          QASE_TESTOPS_RUN_ID: ${{ steps.qase_run_id.outputs.qase_run_id }}
+          QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
           SPEC: |
             cypress/e2e/unit_tests/first_login_rancher.spec.ts
             cypress/e2e/unit_tests/upgrade_fleet.spec.ts
         run: |
-          # if ${{ inputs.qase_run_id == 'none' }}; then
-          #   # Unset default QASE_* variables when reporting is disabled
-          #   unset QASE_REPORT
-          #   unset QASE_API_TOKEN
-          #   # QASE_RUN_ID is empty string already
-          # fi
           if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN
           fi
@@ -525,7 +509,7 @@ jobs:
   # Just to signify that something has been cancelled and it's not useful to check the test
   declare-cancelled:
     if: ${{ always() && contains(needs.e2e.result, 'cancelled') }}
-    needs: e2e
+    needs: [create-runner, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Specify in summary if something has been cancelled

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -526,3 +526,4 @@ jobs:
               -H 'accept: application/json'
           fi
           echo "QASE run $RUN_ID marked as Completed" >> ${GITHUB_STEP_SUMMARY}
+          

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -85,6 +85,11 @@ on:
         description: Report to QASE
         default: false
         type: boolean
+      qase_run_id:
+        description: Existing QASE run ID to report into (leave empty to create a new one)
+        required: false
+        type: string
+        default: ''
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
@@ -211,8 +216,12 @@ jobs:
       QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
       # DELETE NOTES:
       # turtles_dev_chart not appearing for us. Removing. Not sure if we need an equivalent variable here.
-      QASE_TESTOPS_RUN_TITLE: ${{ format('[{3}] Rancher-{0} - {1} destroy={2} dev={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, github.run_number) }}
+      # QASE_TESTOPS_RUN_TITLE: ${{ format('[{3}] Rancher-{0} - {1} destroy={2} dev={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, github.run_number) }}
+      QASE_TESTOPS_RUN_TITLE: ${{ format('[{0}] Rancher-{1} - {2} destroy={3}', github.run_number, inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner) }}
+
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
+      QASE_TESTOPS_COMPLETE_RUN: true
 
     steps:
       - name: Adding /usr/local/bin into PATH
@@ -310,11 +319,14 @@ jobs:
             cypress/e2e/unit_tests/hardened_fleet.spec.ts
             cypress/e2e/unit_tests/special_fleet_tests.spec.ts
         run: |
-          if ${{ inputs.qase_run_id == 'none' }}; then
-            # Unset default QASE_* variables when reporting is disabled
-            unset QASE_REPORT
+          # if ${{ inputs.qase_run_id == 'none' }}; then
+          #   # Unset default QASE_* variables when reporting is disabled
+          #   unset QASE_REPORT
+          #   unset QASE_API_TOKEN
+          #   # QASE_RUN_ID is empty string already
+          # fi
+          if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN
-            # QASE_RUN_ID is empty string already
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
@@ -418,11 +430,14 @@ jobs:
             cypress/e2e/unit_tests/first_login_rancher.spec.ts
             cypress/e2e/unit_tests/upgrade_fleet.spec.ts
         run: |
-          if ${{ inputs.qase_run_id == 'none' }}; then
-            # Unset default QASE_* variables when reporting is disabled
-            unset QASE_REPORT
+          # if ${{ inputs.qase_run_id == 'none' }}; then
+          #   # Unset default QASE_* variables when reporting is disabled
+          #   unset QASE_REPORT
+          #   unset QASE_API_TOKEN
+          #   # QASE_RUN_ID is empty string already
+          # fi
+          if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN
-            # QASE_RUN_ID is empty string already
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (after-upgrade)
@@ -520,7 +535,7 @@ jobs:
           if [ -n "$RUN_ID" ]; then
             curl -X POST \
               --url https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete \
-              -H "Token: ${{ secrets.QASE_API_TOKEN }}" \
+              -H "Token: ${{ secrets.qase_api_token }}" \
               -H 'accept: application/json'
           fi
           echo "QASE run $RUN_ID marked as Completed" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -189,7 +189,7 @@ jobs:
     # Adapted from https://github.com/rancher/rancher-turtles-e2e/pull/269/changes#diff-24ccba33d5b3aea3f85952e4b5113c9546bf141bafee2c130d95abda98816d1bR233
     # Not sure how this worked after removal of qase_run_id
     outputs:
-      qase_run_id: ${{ steps.qase_run_id.outputs.qase_run_id }} 
+      qase_run_id: ${{ steps.qase_run_id.outputs.qase_run_id }}
     env:
       DS_CLUSTER_COUNT: 3
       ARCH: amd64
@@ -213,9 +213,7 @@ jobs:
       # turtles_dev_chart not appearing for us. Removing. Not sure if we need an equivalent variable here.
       QASE_TESTOPS_RUN_TITLE: ${{ format('[{3}] Rancher-{0} - {1} destroy={2} dev={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, github.run_number) }}
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
-      # NOTE: this REPORT var is needed for Cypress!
-      QASE_REPORT: 1
+
     steps:
       - name: Adding /usr/local/bin into PATH
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
@@ -336,6 +334,7 @@ jobs:
           path: tests/cypress/videos
           retention-days: 7
       - name: Store QASE_TESTOPS_RUN_ID for later use
+        ## TODO: revise this step for QASE ID tracking
         if: ${{ always() && inputs.qase_report == true }}
         id: qase_run_id
         run: |
@@ -481,6 +480,7 @@ jobs:
           else
             echo -e "\n### Test not reported in QASE!" >> ${GITHUB_STEP_SUMMARY}
           fi
+
   delete-runner:
     if: ${{ always() && inputs.destroy_runner == true }}
     needs: [create-runner, e2e]
@@ -504,43 +504,6 @@ jobs:
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
             --delete-disks all \
             --zone ${{ inputs.zone }}
-
-  # post-qase:
-  #   if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
-  #   needs: [e2e, pre-qase]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     QASE_API_TOKEN: ${{ secrets.qase_api_token }}
-  #     QASE_PROJECT_CODE: FLEET
-  #     QASE_REPORT: 1
-  #     QASE_RUN_COMPLETE: 1
-  #     QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-
-  #     - name: Setup Go
-  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-  #       with:
-  #         cache-dependency-path: tests/go.sum
-  #         go-version-file: tests/go.mod
-
-  #     - name: Finalize Qase Run and publish Results
-  #       if: ${{ always() && !contains(needs.e2e.result, 'cancelled') }}
-  #       run: |
-  #         REPORT=$(cd tests && make publish-qase-run)
-  #         echo "${REPORT}"
-
-  #         # Extract report URL and put it in summary
-  #         REPORT_URL=$(awk '/available:/ { print $NF }' <<<${REPORT})
-  #         if [[ -n "${REPORT_URL}" ]]; then
-  #           echo "## QASE Reporting" >> ${GITHUB_STEP_SUMMARY}
-  #           echo "Public Qase report: ${REPORT_URL}" >> ${GITHUB_STEP_SUMMARY}
-  #         fi
-
-  #     - name: Delete Qase Run if job has been cancelled
-  #       if: ${{ always() && contains(needs.e2e.result, 'cancelled') }}
-  #       run: cd tests && make delete-qase-run
 
   # Just to signify that something has been cancelled and it's not useful to check the test
   declare-cancelled:

--- a/.github/workflows/ui-pr_rm_current.yaml
+++ b/.github/workflows/ui-pr_rm_current.yaml
@@ -43,5 +43,5 @@ jobs:
       upstream_cluster_version: 'v1.34.3+k3s1'
       rancher_version: 'head/2.13'
       # If qase_run_id is none the run is getting deleted in QASE
-      qase_run_id: 'none'
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: '@login @pr-tests'

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -64,6 +69,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
       rancher_version: ${{ inputs.rancher_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       hardening: ${{ inputs.hardening }}

--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -61,5 +66,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.35.2+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.15' }}
-      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.11.yaml
+++ b/.github/workflows/ui-rm_head_2.11.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''   
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -58,5 +63,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.32.10+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.11' }}
-      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.12.yaml
+++ b/.github/workflows/ui-rm_head_2.12.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -58,5 +63,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.33.7+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
-      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       qase_report:
         description: Report to QASE
-        default: false
+        default: true
         type: boolean
       qase_run_id:
         description: Existing QASE run ID (leave empty to create a new one)

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -5,10 +5,10 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
+      qase_report:
+        description: Report to QASE
+        default: false
+        type: boolean
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -62,4 +62,5 @@ jobs:
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.34.3+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.13' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -61,6 +61,5 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.34.3+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.13' }}
-      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -9,6 +9,11 @@ on:
         description: Report to QASE
         default: false
         type: boolean
+      qase_run_id:
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
+        type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -62,4 +67,5 @@ jobs:
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.34.3+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.13' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_2.14.yaml
+++ b/.github/workflows/ui-rm_head_2.14.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('`{0}` on `{1}`
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -61,5 +66,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.35.2+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.14' }}
-      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}

--- a/.github/workflows/ui-rm_head_upgrade.yaml
+++ b/.github/workflows/ui-rm_head_upgrade.yaml
@@ -5,10 +5,15 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('Upgrade from `
 on:
   workflow_dispatch:
     inputs:
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -76,5 +81,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       upgrade: ${{ inputs.upgrade }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}

--- a/.github/workflows/ui-rm_prime_alpha_rc.yaml
+++ b/.github/workflows/ui-rm_prime_alpha_rc.yaml
@@ -8,10 +8,15 @@ on:
       branch:
         description: 'Branch to run the workflow on (Update when using 2.10 or less)'
         required: false
+      qase_report:
+        description: Report to QASE
+        default: true
+        type: boolean
       qase_run_id:
-        description: Qase run ID where the results will be reported. (Please update with custom run ID.)
-        default: none
+        description: Existing QASE run ID (leave empty to create a new one)
+        required: false
         type: string
+        default: ''
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -61,7 +66,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
       rancher_version: ${{ inputs.rancher_version }}
-      # QASE RUN ID, 'auto' WILL CREATE RANDOM RUN ID.
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
+      qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       branch: ${{ inputs.branch }}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,14 +6,6 @@ deps:
 	@go get github.com/onsi/gomega@$(GOMEGA_VERSION)
 	@go mod tidy
 
-# # Qase commands
-# create-qase-run: deps
-# 	@go run qase/qase_cmd.go -create
-# delete-qase-run: deps
-# 	@go run qase/qase_cmd.go -delete
-# publish-qase-run: deps
-# 	@go run qase/qase_cmd.go -publish
-
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,13 +6,13 @@ deps:
 	@go get github.com/onsi/gomega@$(GOMEGA_VERSION)
 	@go mod tidy
 
-# Qase commands
-create-qase-run: deps
-	@go run qase/qase_cmd.go -create
-delete-qase-run: deps
-	@go run qase/qase_cmd.go -delete
-publish-qase-run: deps
-	@go run qase/qase_cmd.go -publish
+# # Qase commands
+# create-qase-run: deps
+# 	@go run qase/qase_cmd.go -create
+# delete-qase-run: deps
+# 	@go run qase/qase_cmd.go -delete
+# publish-qase-run: deps
+# 	@go run qase/qase_cmd.go -publish
 
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'cypress'
 import { plugin as cypressGrepPlugin } from '@cypress/grep/plugin'
+import { afterSpecHook } from 'cypress-qase-reporter/hooks';
+import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
 
@@ -20,13 +22,23 @@ export default defineConfig({
       charts: true,
     },
     cypressQaseReporterReporterOptions: {
-      apiToken: qaseAPIToken,
-      projectCode: 'FLEET',
-      logging: false,
-      basePath: 'https://api.qase.io/v1',
-      // Screenshots are not supported in cypress-qase-reporter@1.4.1 and broken in @1.4.3
-      // screenshotFolder: 'screenshots',
-      // sendScreenshot: true,
+      mode: "testops",
+        debug: false,
+        testops: {
+          api: {
+           token: qaseAPIToken,
+          },
+          project: 'FLEET',
+          uploadAttachments: true,
+          run: {
+            complete: true,
+          },
+        },
+      framework: {
+        cypress: {
+          screenshotsFolder: './screenshots',
+        },
+      },
     },
   },
   expose: {
@@ -38,7 +50,8 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // Adding task logger
       on('task', {
-        log(message) {
+        // Register the 'suiteLog' task
+        suiteLog(message) {
           console.log(message)
           return null
         },
@@ -60,6 +73,30 @@ export default defineConfig({
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('cypress/plugins/index.ts')(on, config)
       cypressGrepPlugin(config)
+      require('cypress-qase-reporter/plugin')(on, config);
+      require('cypress-qase-reporter/metadata')(on);
+      on('after:spec', async (spec, results) => {
+        await afterSpecHook(spec, config);
+      });
+      on('before:spec', () => {
+        // Writes QASE_TESTOPS_RUN_ID to a file before running each spec
+        // and overwrites it with the same content over and over again
+        // but it is ok as the value is the same during the whole run.
+        // Later this file is used as output value in .github/workflows/master-e2e.yaml for:
+        // 1) Marking cancelled test run in Qase TestOps as Completed
+        // 2) Linking the run in the summary
+        const qaseRunId = process.env.QASE_TESTOPS_RUN_ID;
+        if (qaseRunId) {
+          // process.stdout.write(`QASE_TESTOPS_RUN_ID=${qaseRunId}\n`);
+          writeFileSync('./QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
+        } else {
+          // process.stdout.write('QASE_TESTOPS_RUN_ID is not set.\n');
+        }
+        // Output all environment variables to stdout for debugging purposes
+        // for (const [key, value] of Object.entries(process.env)) {
+        //   process.stdout.write(`${key}=${value}\n`);
+        // }Expand commentComment on lines R76 to R81Resolved
+      });
       
       return config;
     },

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -4,7 +4,7 @@ import { afterSpecHook } from 'cypress-qase-reporter/hooks';
 import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
-const qaseRunId = process.env.QASE_TESTOPS_RUN_ID
+// const qaseRunId = process.env.QASE_TESTOPS_RUN_ID
 const qaseMode = qaseAPIToken ? 'testops' : 'off'
 
 export default defineConfig({
@@ -34,7 +34,6 @@ export default defineConfig({
           uploadAttachments: true,
           run: {
             complete: true,
-            id: qaseRunId ? parseInt(qaseRunId) : undefined,
           },
         },
       framework: {

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -4,7 +4,8 @@ import { afterSpecHook } from 'cypress-qase-reporter/hooks';
 import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
-const qaseMode = qaseAPIToken ? 'testops' : 'off'
+const qaseMode = (process.env.QASE_MODE === 'testops' && qaseAPIToken) ? 'testops' : 'off'
+
 
 export default defineConfig({
   viewportWidth: 1596,
@@ -25,6 +26,9 @@ export default defineConfig({
     cypressQaseReporterReporterOptions: {
       mode: qaseMode,
         debug: false,
+        logging: {
+          console: false,
+        },
         testops: {
           api: {
            token: qaseAPIToken,

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -90,7 +90,9 @@ export default defineConfig({
         const qaseRunId = process.env.QASE_TESTOPS_RUN_ID;
         if (qaseRunId) {
           // process.stdout.write(`QASE_TESTOPS_RUN_ID=${qaseRunId}\n`);
-          writeFileSync('./QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
+          // writeFileSync('./QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
+          writeFileSync('./cypress/e2e/unit_tests/QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
+
         } else {
           // process.stdout.write('QASE_TESTOPS_RUN_ID is not set.\n');
         }

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -4,7 +4,6 @@ import { afterSpecHook } from 'cypress-qase-reporter/hooks';
 import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
-// const qaseRunId = process.env.QASE_TESTOPS_RUN_ID
 const qaseMode = qaseAPIToken ? 'testops' : 'off'
 
 export default defineConfig({
@@ -63,6 +62,7 @@ export default defineConfig({
       on("before:browser:launch", (browser, launchOptions) => {
         
         if (["chrome", "edge"].includes(browser.name)) {
+          
           if (browser.isHeadless) {
             launchOptions.args.push("--no-sandbox");
             launchOptions.args.push("--disable-gl-drawing-for-tests");
@@ -81,25 +81,16 @@ export default defineConfig({
         await afterSpecHook(spec, config);
       });
       on('before:spec', () => {
-        // Writes QASE_TESTOPS_RUN_ID to a file before running each spec
-        // and overwrites it with the same content over and over again
-        // but it is ok as the value is the same during the whole run.
-        // Later this file is used as output value in .github/workflows/master-e2e.yaml for:
+        // Writes QASE_TESTOPS_RUN_ID to a file before running each spec.
+        // Used in .github/workflows/master-e2e.yaml for:
         // 1) Marking cancelled test run in Qase TestOps as Completed
         // 2) Linking the run in the summary
         const qaseRunId = process.env.QASE_TESTOPS_RUN_ID;
+
         if (qaseRunId) {
-          // process.stdout.write(`QASE_TESTOPS_RUN_ID=${qaseRunId}\n`);
-          // writeFileSync('./QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
           writeFileSync('./cypress/e2e/unit_tests/QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
 
-        } else {
-          // process.stdout.write('QASE_TESTOPS_RUN_ID is not set.\n');
-        }
-        // Output all environment variables to stdout for debugging purposes
-        // for (const [key, value] of Object.entries(process.env)) {
-        //   process.stdout.write(`${key}=${value}\n`);
-        // }Expand commentComment on lines R76 to R81Resolved
+        } 
       });
       
       return config;

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -6,7 +6,6 @@ import { writeFileSync } from 'fs';
 const qaseAPIToken = process.env.QASE_API_TOKEN
 const qaseMode = (process.env.QASE_MODE === 'testops' && qaseAPIToken) ? 'testops' : 'off'
 
-
 export default defineConfig({
   viewportWidth: 1596,
   viewportHeight: 954,
@@ -93,7 +92,6 @@ export default defineConfig({
 
         if (qaseRunId) {
           writeFileSync('./cypress/e2e/unit_tests/QASE_TESTOPS_RUN_ID.txt', qaseRunId, { encoding: 'utf8' });
-
         } 
       });
       

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -4,6 +4,8 @@ import { afterSpecHook } from 'cypress-qase-reporter/hooks';
 import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
+const qaseRunId = process.env.QASE_TESTOPS_RUN_ID
+const qaseMode = qaseAPIToken ? 'testops' : 'off'
 
 export default defineConfig({
   viewportWidth: 1596,
@@ -22,7 +24,7 @@ export default defineConfig({
       charts: true,
     },
     cypressQaseReporterReporterOptions: {
-      mode: "testops",
+      mode: qaseMode,
         debug: false,
         testops: {
           api: {
@@ -32,6 +34,7 @@ export default defineConfig({
           uploadAttachments: true,
           run: {
             complete: true,
+            id: qaseRunId ? parseInt(qaseRunId) : undefined,
           },
         },
       framework: {

--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -21,14 +21,11 @@ export const supported_versions_212_and_above = [
 
 Cypress.config();
 describe('First login on Rancher', { tags: ['@login', '@pr-tests'] }, () => {
-  qase(120,
-    it('Log in and accept terms and conditions', { tags: '@fleet-120' },  () => {
+    it(qase(120,'Log in and accept terms and conditions'), { tags: '@fleet-120' }, () => {
       cypressLib.firstLogin();
-    })
-  );
+    });
 
-  qase(114,
-    it('Check ready state of local cluster after Rancher login', { tags: '@fleet-114' }, () => {
+  it(qase(114,'Check ready state of local cluster after Rancher login'), { tags: '@fleet-114' }, () => {
       cy.login();
       cy.visit('/');
       cypressLib.burgerMenuToggle();
@@ -46,7 +43,6 @@ describe('First login on Rancher', { tags: ['@login', '@pr-tests'] }, () => {
         cy.get("td[data-testid='sortable-cell-0-2']", { timeout: 300000 }).should("not.contain", '0');
       }
     })
-  );
 });
 
 // Upgrade Fleet from chart to latest when this is not the default one.

--- a/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
+++ b/tests/cypress/e2e/unit_tests/first_login_rancher.spec.ts
@@ -47,12 +47,10 @@ describe('First login on Rancher', { tags: ['@login', '@pr-tests'] }, () => {
 
 // Upgrade Fleet from chart to latest when this is not the default one.
 describe('Upgrade Fleet via UI', { tags: '@upgrade-fleet-chart' }, () => {
-  qase(189,
-    it('Upgrade Fleet chart to latest', () => {
+    it(qase(189, 'Upgrade Fleet chart to latest'), () => {
       cy.login();
       cy.visit('/');
       cy.allowRancherPreReleaseVersions();
       cy.upgradeFleet();
     })
-  );
 })

--- a/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
@@ -13,7 +13,6 @@ limitations under the License.
 */
 
 import 'cypress/support/commands';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const appName = "nginx-keep";
 export const clusterName = "imported-0";

--- a/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/hardened_fleet.spec.ts
@@ -28,8 +28,7 @@ beforeEach(() => {
 
 Cypress.config();
 describe('Test Hardened Fleet deployment on PUBLIC repos',  { tags: '@hardening-tests' }, () => {
-  qase(128,
-    it('FLEET-128: Deploy application to LOCAL cluster is NOT possible', { tags: '@fleet-128' }, () => {
+  it(qase(128, 'FLEET-128: Deploy application to LOCAL cluster is NOT possible'), { tags: '@fleet-128' }, () => {
 
       const repoName = "local-cluster-error"
       const branch = "master"
@@ -45,11 +44,10 @@ describe('Test Hardened Fleet deployment on PUBLIC repos',  { tags: '@hardening-
       cy.verifyTableRow(0, 'Error', 'local-cluster-error-simple');
       cy.contains('NotReady(1) [Cluster fleet-local/local];').should('be.visible');
       cy.deleteAllFleetRepos();
-    })
+    }
   );
 
-  qase(185,
-    it('FLEET-185: Deploy application to DOWNSTREAM clusters IS possible', { tags: '@fleet-185' }, () => {
+  it(qase(185, 'FLEET-185: Deploy application to DOWNSTREAM clusters IS possible'), { tags: '@fleet-185' }, () => {
 
       const repoName = "downstream-clusters-ok"
       const branch = "master"
@@ -64,7 +62,7 @@ describe('Test Hardened Fleet deployment on PUBLIC repos',  { tags: '@hardening-
       cy.wait(20000);
       cy.checkGitRepoStatus(repoName, '1 / 1', '18 / 18');
       cy.verifyTableRow(0, 'Active', 'downstream-clusters-ok-simple');
-    })
+    }
   );
 
 });

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -13,7 +13,6 @@ limitations under the License.
 */
 
 import 'cypress/support/commands';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const appName = "nginx-keep";
 export const clusterName = "imported-0";

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -28,8 +28,7 @@ beforeEach(() => {
 
 Cypress.config();
 describe('Test Fleet deployment on PUBLIC repos',  { tags: ['@p0', '@pr-tests'] }, () => {
-  qase(62,
-    it('FLEET-62: Deploy application to local cluster', { tags: '@fleet-62' }, () => {
+  it(qase(62, 'FLEET-62: Deploy application to local cluster'), { tags: '@fleet-62' }, () => {
 
       const repoName = "local-cluster-fleet-62"
       const branch = "master"
@@ -47,7 +46,7 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: ['@p0', '@pr-tests'] 
       cy.verifyTableRow(5, 'Service', 'redis-slave');
       cy.deleteAllFleetRepos();
     })
-  );
+
 });
 
 describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: ['@p0', '@pr-tests'] }, () => {
@@ -61,8 +60,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: ['@p0'
   ]
 
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {
-    qase(qase_id,
-      it(`FLEET-${qase_id}: Test to install "NGINX" app using "HTTP" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
+    it(qase(qase_id, `FLEET-${qase_id}: Test to install "NGINX" app using "HTTP" auth on "${provider}" PRIVATE repository`), { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
 
         const repoName = `default-cluster-fleet-${qase_id}`
         const userOrPublicKey = Cypress.expose(`${provider.toLowerCase()}_private_user`)
@@ -75,12 +73,11 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: ['@p0'
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();
       })
-    );
+  
   });
 
   if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
-  qase(191, 
-    it('FLEET-191: Test Fleet can be deployed in private Github repo using solely private token', {tags : `@fleet-191` }, () => {
+  it(qase(191, 'FLEET-191: Test Fleet can be deployed in private Github repo using solely private token'), {tags : `@fleet-191` }, () => {
 
       const repoName = '191-test-private-gh-only-token'  
       const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples.git'
@@ -91,7 +88,7 @@ describe('Test Fleet deployment on PRIVATE repos with HTTP auth', { tags: ['@p0'
         cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.deleteAllFleetRepos();
     })
-  )}
+  }
 
 });
 
@@ -108,8 +105,7 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
   ]
   
   repoTestData.forEach(({ qase_id, provider, repoUrl }) => {
-    qase(qase_id,
-      it(`FLEET-${qase_id}: Test to install "NGINX" app using "SSH" auth on "${provider}" PRIVATE repository`, { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
+    it(qase(qase_id, `FLEET-${qase_id}: Test to install "NGINX" app using "SSH" auth on "${provider}" PRIVATE repository`), { tags: `@fleet-${qase_id}`, retries: 1 }, () => {
         
         const repoName = `default-cluster-fleet-${qase_id}`
 
@@ -121,13 +117,11 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
         cy.checkGitRepoStatus(repoName, '1 / 1');
         cy.checkApplicationStatus(appName, clusterName);
         cy.deleteAllFleetRepos();
-      })
-    );
+      })    
   });
 });
 
-  describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', 
-    { tags: '@p0' }, () => {
+  describe('Test Fleet deployment on PRIVATE repos using KNOWN HOSTS', { tags: '@p0' }, () => {
 
     const repoUrl = 'git@github.com:fleetqa/fleet-qa-examples.git';
     const secretKnownHostsKeys = ['assets/known-host.yaml', 'assets/known-host-missmatch.yaml'];
@@ -181,8 +175,7 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
     });
 
     // Custom / no default
-    qase(141,
-      it('FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository', 
+    it(qase(141, 'FLEET-141  Test to install "NGINX" app using "KNOWN HOSTS" auth on PRIVATE repository'), 
         { tags: '@fleet-141' }, () => {
 
         const repoName = 'local-cluster-fleet-141';
@@ -195,12 +188,11 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
         cy.clickButton('Create');
         cy.verifyTableRow(0, 'Active', '1/1');
         cy.checkGitRepoStatus(repoName, '1 / 1');
-      })
+      }
     );
 
     // Custom error / no default
-    qase(143,
-      it('FLEET-143  Test apps cannot be installed when using missmatched "KNOWN HOSTS" auth on PRIVATE repository',
+    it(qase(143, 'FLEET-143  Test apps cannot be installed when using missmatched "KNOWN HOSTS" auth on PRIVATE repository'),
         { tags: '@fleet-143' }, () => {
 
           const repoName = 'local-cluster-fleet-143';
@@ -213,12 +205,11 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
           // Enrure that apps cannot be installed && error appears
           cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
           cy.contains('Ssh: handshake failed: knownhosts: key mismatch').should('be.visible');
-      })
+      }
     );
 
     // Default verify
-    qase(168,
-      it('FLEET-168 Verify Fleet default known-host is set on configmap',
+    it(qase(168, 'FLEET-168 Verify Fleet default known-host is set on configmap'),
         { tags: '@fleet-168' }, () => {
 
           // Create private repo using known host
@@ -227,12 +218,11 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
           cy.filterInSearchBox('known-hosts');
           cy.open3dotsMenu('known-hosts', 'Edit YAML');
           cy.contains('ssh-rsa').its(length).should('be.visible')
-      })
+      }
     );
 
     // No custom / yes default
-    qase(169,
-      it('FLEET-169 Verify that without custom known-host, fleet uses default custom ones from defined in configmap',
+    it(qase(169, 'FLEET-169 Verify that without custom known-host, fleet uses default custom ones from defined in configmap'),
         { tags: '@fleet-169' }, () => {
 
           const repoName = 'local-cluster-fleet-169';
@@ -251,11 +241,9 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
           cy.clickButton('Create');
           cy.checkGitRepoStatus(repoName, '1 / 1');
       })
-    );  
 
     // No ssh , then no default
-    qase(170,
-      it('FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply',
+    it(qase(170, 'FLEET-170 Verify that without ssh-key on private repo, custom known-host does not apply'),
         { tags: '@fleet-170' }, () => {
 
           const repoName = 'local-cluster-fleet-170';
@@ -270,11 +258,9 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
           cy.wait(15000) 
           cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
       })
-    );  
 
     // No custom + no default -> nothing gets deployed
-    qase(171,
-      it('FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed',
+    it(qase(171, 'FLEET-171 Verify that without custom nor default known-host a gitrepo that needs this validation cannot be installed'),
         { tags: '@fleet-171' }, () => {
 
           const repoName = 'local-cluster-fleet-171';
@@ -322,10 +308,8 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@p0' }
           cy.wait(500); // Wait to avoid initial 'updating'
           cy.verifyTableRow(0, /Error|Git Updating/, '0/0');
           cy.contains('Strict host key checks are enforced, but no known_hosts data was found').should('be.visible')
-      })
-    ); 
-  }
-  );
+      }) 
+  });
 
 describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
 
@@ -350,8 +334,7 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
     cy.log('"known_host" values returned')
   })
 
-  qase(142,
-    it("Fleet-142: Test Fleet can create cabundle secrets", { tags: '@fleet-142' }, () => {;
+  it(qase(142, "Fleet-142: Test Fleet can create cabundle secrets"), { tags: '@fleet-142' }, () => {;
       
       const repoName = 'local-142-test-bundle-secrets'
       const repoUrl = 'https://github.com/rancher/fleet-examples'
@@ -374,11 +357,10 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
       cy.deleteAllFleetRepos();
       cy.accesMenuSelection('local', 'Storage', 'Secrets');
       cy.contains('-cabundle').should('not.exist');
-    })
+    }
   );  
 
-  qase(144,
-    it("Fleet-144 Test cabundle secrets are not created without TLS certificate", { tags: '@fleet-144' }, () => {;
+  it(qase(144, "Fleet-144 Test cabundle secrets are not created without TLS certificate"), { tags: '@fleet-144' }, () => {;
       
       const repoName = 'local-144-test-cabundle-secrets-not-created'
       const repoUrl = 'https://github.com/rancher/fleet-examples'
@@ -394,7 +376,7 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
       cy.nameSpaceMenuToggle('All Namespaces');
       cy.filterInSearchBox(repoName+'-cabundle');
       cy.contains('There are no rows which match your search query.').should('be.visible');
-    })
+    }
   );  
 
 });
@@ -425,9 +407,7 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
 
     });
 
-    qase(152,
-
-      it('Fleet-152: Test Fleet with Webhook and disable polling ', { tags: '@fleet-152' }, () => {
+    it(qase(152, 'Fleet-152: Test Fleet with Webhook and disable polling '), { tags: '@fleet-152' }, () => {
 
         const repoName = 'webhook-test-disable-polling';
 
@@ -474,14 +454,12 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
 
         // Verify deployments has 5 replicas
         cy.verifyTableRow(0, 'Active', '5/5');
-      })
+      }
     );
     
     if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
   
-    qase(178,
-
-      it('Fleet-178: Test Fleet with Webhook and secret on gitrepo directly ', { tags: '@fleet-178' }, () => {
+    it(qase(178, 'Fleet-178: Test Fleet with Webhook and secret on gitrepo directly '), { tags: '@fleet-178' }, () => {
 
         const repoName = 'test-disable-polling';
 
@@ -532,12 +510,10 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
         cy.filterInSearchBox('gitjob')
         cy.open3dotsMenu('gitjob', 'View Logs')
         cy.contains('"Webhook processing failed"').should('exist');
-      })
+      }
     )
 
-    qase(177,
-
-      it('Fleet-177: Test Fleet with Webhook and secret using "gitjob-webhhook" on "cattle-fleet-system" ', { tags: '@fleet-177' }, () => {
+    it(qase(177, 'Fleet-177: Test Fleet with Webhook and secret using "gitjob-webhhook" on "cattle-fleet-system" '), { tags: '@fleet-177' }, () => {
 
         const repoName = 'test-disable-polling';
 
@@ -589,7 +565,7 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
         cy.open3dotsMenu('gitjob', 'View Logs')
         cy.contains('HMAC verification failed').should('exist');
       })
-    )}
+    }
   })
 
   // New tests for jobs cleanup
@@ -599,8 +575,7 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
   const branch = 'master';
   const path = 'qa-test-apps/nginx-app';
 
-  qase(145,
-    it('Fleet-145: Test Fleet job cleanup', { tags: '@fleet-145' }, () => {
+  it(qase(145, 'Fleet-145: Test Fleet job cleanup'), { tags: '@fleet-145' }, () => {
 
       const repoName = 'local-145-test-job-cleanup';
 
@@ -611,11 +586,10 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
       // Check jobs on recent events tab
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
       cy.verifyJobDeleted(repoName); 
-    })
+    }
   );
 
-  qase(146,
-    it('Fleet-146: Test Fleet job clean-up works with Force Update', { tags: '@fleet-146' }, () => {
+  it(qase(146, 'Fleet-146: Test Fleet job clean-up works with Force Update'), { tags: '@fleet-146' }, () => {
 
       const repoName = 'local-146-test-job-cleanup';
 
@@ -632,11 +606,10 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
       cy.verifyJobDeleted(repoName);
 
-    })
+    }
   );
 
-  qase(147,
-    it('Fleet-147: Test Fleet job clean-up works upon commit change', { tags: '@fleet-147' }, () => {
+  it(qase(147, 'Fleet-147: Test Fleet job clean-up works upon commit change'), { tags: '@fleet-147' }, () => {
 
       const gh_private_pwd = Cypress.expose('gh_private_pwd');
       const repoName = 'test-disable-polling';
@@ -666,11 +639,10 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
 
       // Verify event deletion on recent events tab and job deletion
       cy.verifyJobDeleted(repoName);
-    })
+    }
   );
 
-  qase(148,
-    it('Fleet-148: Test Fleet job clean-up with unsuccessful job is not deleted', { tags: '@fleet-148' }, () => {
+  it(qase(148, 'Fleet-148: Test Fleet job clean-up with unsuccessful job is not deleted'), { tags: '@fleet-148' }, () => {
   
       const repoName = 'local-148-test-unsuscessful-job-is-not-deleted';
       const path = 'qa-test-apps/nginx-app-bad-path';
@@ -693,13 +665,12 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
       cy.nameSpaceMenuToggle('All Namespaces');
       cy.filterInSearchBox(repoName);
       cy.get('table > tbody > tr').contains(repoName).should('be.visible');
-    })
+    }
   )
 });
 
   describe('Test GitJob security context',  { tags: ['@p0', '@pr-tests'] }, () => {
-    qase(160,
-      it('FLEET-160: Test GitJob pod security context', { tags: '@fleet-160' }, () => {
+    it(qase(160, 'FLEET-160: Test GitJob pod security context'), { tags: '@fleet-160' }, () => {
         // Check the GitJob pod for Security Context.
         cy.accesMenuSelection('local', 'Workloads', 'Pods');
         cy.filterInSearchBox('gitjob');
@@ -745,7 +716,6 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
           .contains('ALL')
           .should('be.visible')
       })
-    );
   }
 );
 
@@ -755,8 +725,7 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
     const branch = 'master';
     const path = 'simple-chart';
 
-    qase(172,
-      it('Fleet-172 Test gitjob can store helm values in secret', { tags: '@fleet-172' }, () => {
+    it(qase(172, 'Fleet-172 Test gitjob can store helm values in secret'), { tags: '@fleet-172' }, () => {
 
         const repoName = 'simple-chart-secret';
   
@@ -783,5 +752,4 @@ describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {
         cy.clickButton('Cancel');
         
       })
-    )
   })

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -67,8 +67,7 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
   repoTestData.forEach(
     ({ qase_id, repoName, test_explanation }) => {
       if ((qase_id === 105 || qase_id === 61)) {
-        qase(qase_id,
-          it(`Fleet-${qase_id}: Test GitRepo NAME with "${test_explanation}" displays ERROR message and does NOT get created`, { tags: `@fleet-${qase_id}` }, () => {
+        it(qase(qase_id, `Fleet-${qase_id}: Test GitRepo NAME with "${test_explanation}" displays ERROR message and does NOT get created`), { tags: `@fleet-${qase_id}` }, () => {
             // Add Fleet repository and create it
             cy.addFleetGitRepo({repoName, repoUrl, branch, path});
             cy.clickButton('Create');
@@ -77,10 +76,8 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
             cy.clickButton('Cancel')
             cy.contains(new RegExp(NoAppBundleOrGitRepoPresentMessages.join('|'))).should('be.visible')
           })
-          )
       } else {
-        qase(qase_id,
-          it(`Fleet-${qase_id}: Test GitRepo bundle name TRIMMING behavior. GitRepo with "${test_explanation}"`, { tags: `@fleet-${qase_id}` }, () => {
+        it(qase(qase_id, `Fleet-${qase_id}: Test GitRepo bundle name TRIMMING behavior. GitRepo with "${test_explanation}"`), { tags: `@fleet-${qase_id}` }, () => {
             // Change namespace to fleet-local
 
             // Add Fleet repository and create it
@@ -104,7 +101,6 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
             cy.checkApplicationStatus(appName);
             cy.deleteAllFleetRepos();
           })
-        )
       }
     }
   )
@@ -141,8 +137,7 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
   ]
 
   clusterGroup.forEach(({ qase_id, test_explanation }) => {
-      qase(qase_id,
-        it(`Fleet-${qase_id}: Test ${test_explanation}`, { tags: `@fleet-${qase_id}` }, () => {
+      it(qase(qase_id, `Fleet-${qase_id}: Test ${test_explanation}`), { tags: `@fleet-${qase_id}` }, () => {
           repoName = `default-single-app-cluster-group-${qase_id}`
           if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
             repoName = "default-single-app-cluster-group"
@@ -223,12 +218,10 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
           )
           cy.deleteClusterGroups();
         })
-      )
     }
   )
 
-  qase(26,
-    it("Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'", { tags: '@fleet-26' }, () => {
+  it(qase(26, "Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'"), { tags: '@fleet-26' }, () => {
       const repoName = 'default-single-app-cluster-group-26'
       const path2 = 'multiple-paths/config'
 
@@ -288,11 +281,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
           cy.removeClusterLabels(dsCluster, key, value);
         }
       )
-    })
+    }
   )
+  
 
-  qase(28,
-    it("Fleet-28: Test remove existing application from cluster-2 by removing it from an existing 'clusterGroup'", { tags: '@fleet-28' }, () => {
+  it(qase(28, "Fleet-28: Test remove existing application from cluster-2 by removing it from an existing 'clusterGroup'"), { tags: '@fleet-28' }, () => {
       let repoName
       repoName = 'default-single-app-cluster-group-28'
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
@@ -363,15 +356,14 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       )
       // Delete clusterGroups.
       cy.deleteClusterGroups();
-    })
+    }
   )
 
   if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
     console.log({message: "UI for `clusterGroup` option is removed and available only via YAML. So Skipping tests."})
   }
   else {
-    qase(29,
-    it("Fleet-29: Test install app to new set of clusters from old set of clusters using 'clusterGroup'", { tags: '@fleet-29' }, () => {
+    it(qase(29, "Fleet-29: Test install app to new set of clusters from old set of clusters using 'clusterGroup'"), { tags: '@fleet-29' }, () => {
       const repoName = 'default-single-app-cluster-group-29'
       const new_key = 'key_third_cluster'
       const new_value = 'value_third_cluster'
@@ -446,7 +438,6 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       // Delete clusterGroups.
       cy.deleteClusterGroups();
     })
-    )
   }
 });
 
@@ -488,8 +479,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   ]
 
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
-    qase(qase_id,
-      it(`Fleet-${qase_id}: Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`, { tags: `@fleet-${qase_id}` }, () => {
+    it(qase(qase_id, `Fleet-${qase_id}: Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`), { tags: `@fleet-${qase_id}` }, () => {
 
         cy.continuousDeliveryMenuSelection();
         cy.clickNavMenu(['Clusters']);
@@ -578,11 +568,9 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
           }
         )
       })
-    )
   })
 
-  qase(19,
-    it("Fleet-19: Test remove label from cluster-2 to remove application from it when application deployed using clusterSelector(matchLabels)", { tags: '@fleet-19' }, () => {
+  it(qase(19, "Fleet-19: Test remove label from cluster-2 to remove application from it when application deployed using clusterSelector(matchLabels)"), { tags: '@fleet-19' }, () => {
       const dsSecondClusterName = dsAllClusterList[1]
       gitRepoFile = 'assets/git-repo-multiple-app-cluster-selector.yaml'
 
@@ -638,10 +626,9 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
           cy.removeClusterLabels(dsCluster, key, value);
         }
       )
-    })
+    }
   )
-  qase(22,
-    it("Fleet-22: Test install app to new set of clusters from old set of clusters", { tags: '@fleet-22' }, () => {
+  it(qase(22, "Fleet-22: Test install app to new set of clusters from old set of clusters"), { tags: '@fleet-22' }, () => {
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
         console.log({message: "UI for `clusterGroup` option is removed and available only via YAML. So Skipping tests."})
       }
@@ -715,7 +702,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         cy.removeClusterLabels(dsThirdClusterName, new_key, new_value);
       }
     })
-  )
 });
 
 describe("Test Application deployment based on 'clusterGroupSelector'", { tags: '@p1_2'}, () => {
@@ -761,8 +747,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
   ]
 
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
-    qase(qase_id,
-      it(`Fleet-${qase_id}: Test install ${test_explanation}  cluster using "clusterGroupSelector"`, { tags: `@fleet-${qase_id}` }, () => {
+    it(qase(qase_id, `Fleet-${qase_id}: Test install ${test_explanation}  cluster using "clusterGroupSelector"`), { tags: `@fleet-${qase_id}` }, () => {
 
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         cy.contains('.title', 'Clusters').should('be.visible');
@@ -863,14 +848,13 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
           }
         )
       })
-    )
   })
 });
 
+
 describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@pr-tests'] }, () => {
 
-  qase(131,
-    it("Fleet-131: Test NAMESPACE will be DELETED after GitRepo is deleted.", { tags: '@fleet-131' }, () => {
+  it(qase(131, "Fleet-131: Test NAMESPACE will be DELETED after GitRepo is deleted."), { tags: '@fleet-131' }, () => {
       const repoName = 'test-ns-deleted-when-bundle-deleted'
       const namespaceName = 'my-custom-namespace'
 
@@ -893,11 +877,10 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       cy.accesMenuSelection('local', 'Projects/Namespaces');
       cy.filterInSearchBox(namespaceName);
       cy.contains(namespaceName, { timeout: 30000 }).should('not.exist');
-    })
+    }
   )
 
-  qase(164,
-    it("Fleet-164: Test NAMESPACE will be DELETED after main NESTED GitRepo is deleted.", { tags: '@fleet-164' }, () => {
+  it(qase(164, "Fleet-164: Test NAMESPACE will be DELETED after main NESTED GitRepo is deleted."), { tags: '@fleet-164' }, () => {
       const repoName = 'test-ns-deleted-with-nested-bundle'
       const repoName2= 'my-gitrepo'
       const namespaceName = 'my-custom-namespace'
@@ -932,13 +915,11 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       cy.filterInSearchBox(namespaceName);
       cy.contains(namespaceName, {timeout: 20000 }).should('not.exist');
     })
-  )
 });
 
 describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
 
-  qase(155,
-    it("Fleet-155: Test clusters resource count is correct", { tags: '@fleet-155' }, () => {
+  it(qase(155, "Fleet-155: Test clusters resource count is correct"), { tags: '@fleet-155' }, () => {
 
       const repoName = 'default-cluster-count-155'
       const branch = "master"
@@ -965,14 +946,12 @@ describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
 
       cy.deleteAllFleetRepos();
     })
-  )
 });
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
   describe('Test HelmOps', { tags: ['@p1_2'] }, () => {
 
-    qase(165, 
-      it('FLEET-165: Test basic HelmOps creation', { tags: '@fleet-165' }, () => {
+    it(qase(165, 'FLEET-165: Test basic HelmOps creation'), { tags: '@fleet-165' }, () => {
 
         cy.addHelmOp({ 
           fleetNamespace: 'fleet-local', 
@@ -982,11 +961,10 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
         });
 
         cy.verifyTableRow(0, 'Active', '1/1');
-      })
+      }
     );
 
-    qase(197,
-      it('FLEET-197: Test Helmops creation with a fixed version', { tags: '@fleet-197' }, () => {
+    it(qase(197, 'FLEET-197: Test Helmops creation with a fixed version'), { tags: '@fleet-197' }, () => {
 
         cy.addHelmOp({ 
           fleetNamespace: 'fleet-default', 
@@ -998,11 +976,10 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
         });
 
         cy.verifyTableRow(0, 'Active', '10.1.0');
-      })
+      }
     );
         
-    qase(198,
-      it('FLEET-198: Test incorrect chart version cannot be installed', { tags: '@fleet-198' }, () => {
+    it(qase(198, 'FLEET-198: Test incorrect chart version cannot be installed'), { tags: '@fleet-198' }, () => {
 
         cy.addHelmOp({ 
           fleetNamespace: 'fleet-local', 
@@ -1014,11 +991,10 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
 
         cy.verifyTableRow(0, 'Error', '0/0');
         cy.contains('Could not get a chart version: no chart version found for grafana-999999999').should('be.visible');
-      })
+      }
     );
 
-    qase(190,
-      it('FLEET-190: Test Faulty Helm Ops display short error message', { tags: '@fleet-190' }, () => { 
+    it(qase(190, 'FLEET-190: Test Faulty Helm Ops display short error message'), { tags: '@fleet-190' }, () => { 
 
         cy.addHelmOp({ 
           fleetNamespace: 'fleet-local', 
@@ -1031,9 +1007,8 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
         cy.contains('DOCTYPE html').should('not.exist');
 
       })
-    );
-  })
-};
+  });
+}
 
 describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
   const configMapName = "test-map"
@@ -1052,8 +1027,7 @@ describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
   })
 
   repoTestData.forEach(({ qase_id, message, path }) => {
-    qase(qase_id,
-      it(`FLEET-${qase_id}: Test helm-app using "${message}" values in the fleet.yaml file.`, { tags: `@fleet-${qase_id}`}, () => {
+    it(qase(qase_id, `FLEET-${qase_id}: Test helm-app using "${message}" values in the fleet.yaml file.`), { tags: `@fleet-${qase_id}`}, () => {
         const repoName = `local-cluster-fleet-${qase_id}`
 
         // Create ConfigMap before create GitRepo
@@ -1069,7 +1043,6 @@ describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
         cy.wait(1000);
         cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
       })
-    );
   });
 });
 
@@ -1139,7 +1112,7 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
     })
 
     repoTestData.forEach(({ qase_id, test_name, repoName, gitrepo_file, bundle_count, resource_count, expectedBundles }) => {
-      it(`FLEET-${qase_id}: ${test_name}`, { tags: `@fleet-${qase_id}`}, () => {
+      it(qase(qase_id, `FLEET-${qase_id}: ${test_name}`), { tags: `@fleet-${qase_id}`}, () => {
         // Create GitRepo
         cy.continuousDeliveryMenuSelection()
         cy.clickCreateGitRepo();
@@ -1156,16 +1129,14 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
 
         // Delete GitRepo
         cy.deleteAllFleetRepos();
-      })
+      });
     });
   }
 });
 
 describe('Test Fleet bundle status for longhorn-crd', { tags: '@p1_2'}, () => {
 
-  qase(139,
-
-    it("Fleet-139: Test CRD's for longhorn application should be in active state not in modified state when correctDrift enabled", { tags: '@fleet-139' }, () => {
+  it(qase(139, "Fleet-139: Test CRD's for longhorn application should be in active state not in modified state when correctDrift enabled"), { tags: '@fleet-139' }, () => {
 
       const repoName = 'default-longhorn-crd-bundle-status'
       const path = "qa-test-apps/longhorn-crd"
@@ -1182,14 +1153,11 @@ describe('Test Fleet bundle status for longhorn-crd', { tags: '@p1_2'}, () => {
       cy.deleteAllFleetRepos();
 
     })
-  )
 });
 
 describe('Test non-yaml file into bundle.', { tags: '@p1_2'}, () => {
 
-  qase(87,
-
-    it("Fleet-87: Test .fleetignore ignores content of non-yaml file into bundle.", { tags: '@fleet-87' }, () => {
+  it(qase(87, "Fleet-87: Test .fleetignore ignores content of non-yaml file into bundle."), { tags: '@fleet-87' }, () => {
 
       const repoName = 'test-resource-ignore'
       const path = "qa-test-apps/fleet-ignore-test"
@@ -1213,7 +1181,6 @@ describe('Test non-yaml file into bundle.', { tags: '@p1_2'}, () => {
       cy.deleteAllFleetRepos();
 
     })
-  )
 });
 
 describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.', { tags: '@p1_2' }, () => {
@@ -1229,8 +1196,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
     cy.deleteAllFleetRepos();
   })
 
-  qase(39,
-    it('Test "GitRepoRestrictions" on non-existent namespace throws error in the UI', { tags: '@fleet-39' }, () => {
+  it(qase(39, 'Test "GitRepoRestrictions" on non-existent namespace throws error in the UI'), { tags: '@fleet-39' }, () => {
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
         cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
       }
@@ -1247,11 +1213,10 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.clickButton('Create');
       cy.get('[data-testid="banner-content"] > span').contains('namespaces "iamnotexists" not found');
       cy.clickButton('Cancel');
-    })
+    }
   )
 
-  qase(40,
-    it('Test "GitRepoRestrictions" override "defaultNamespace" in fleet.yaml of application over "allowedTargetNamespace"', { tags: '@fleet-40' }, () => {
+  it(qase(40, 'Test "GitRepoRestrictions" override "defaultNamespace" in fleet.yaml of application over "allowedTargetNamespace"'), { tags: '@fleet-40' }, () => {
       const repoName = 'local-gitreporestrictions-fleet-40'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
@@ -1296,11 +1261,10 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
 
       // Delete GitRepo
       cy.deleteAllFleetRepos();
-    })
+    }
   )
 
-  qase(41,
-    it('Test "allowedTargetNamespace" from "GitRepoRestrictions" overrides "defaultNamespace" in fleet.yaml of application on existing GitRepo', { tags: '@fleet-41' }, () => {
+  it(qase(41, 'Test "allowedTargetNamespace" from "GitRepoRestrictions" overrides "defaultNamespace" in fleet.yaml of application on existing GitRepo'), { tags: '@fleet-41' }, () => {
       const repoName = 'local-gitreporestrictions-fleet-41'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
@@ -1353,7 +1317,6 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       // Delete GitRepo
       cy.deleteAllFleetRepos();
     })
-  )
 });
 
 describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.', { tags: '@p1_2'}, () => {
@@ -1375,9 +1338,7 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
     )
   })
 
-  qase(88,
-
-    it("Fleet-88: Test bundle did not get deployed when 'doNotDeploy' value set to `true` option is used in the 'fleet.yaml' file.", { tags: '@fleet-88' }, () => {
+  it(qase(88, "Fleet-88: Test bundle did not get deployed when 'doNotDeploy' value set to `true` option is used in the 'fleet.yaml' file."), { tags: '@fleet-88' }, () => {
 
       const repoName = 'test-donot-deploy-true'
       const path = "qa-test-apps/do-not-deploy/true"
@@ -1414,14 +1375,11 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
       cy.deleteAllFleetRepos();
 
     })
-  )
 });
 
 describe('Test Fleet `doNotDeploy: false` will deploy resources to all clusters.', { tags: '@p1_2'}, () => {
 
-  qase(89,
-
-    it("Fleet-89: Test bundle gets deploy to all clusters when `doNotDeploy: false` is used in the fleet.yaml.", { tags: '@fleet-89' }, () => {
+  it(qase(89, "Fleet-89: Test bundle gets deploy to all clusters when `doNotDeploy: false` is used in the fleet.yaml."), { tags: '@fleet-89' }, () => {
 
       const repoName = 'test-donot-deploy-false'
       const path = "qa-test-apps/do-not-deploy/false"
@@ -1441,14 +1399,12 @@ describe('Test Fleet `doNotDeploy: false` will deploy resources to all clusters.
       cy.deleteAllFleetRepos();
 
     })
-  )
 });
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypress.expose('rancher_version'))) {
   
   describe('Test Git App with Fleet', { tags: '@p1_2'}, () => {
-    qase(199,
-      it("Fleet-199: Test Git App deployment using Fleet.", { tags: '@fleet-199' }, () => {
+    it(qase(199, "Fleet-199: Test Git App deployment using Fleet."), { tags: '@fleet-199' }, () => {
 
         const github_app_id = Cypress.expose("gh_app_id")
         const github_app_installation_id = Cypress.expose("gh_app_installation_id")
@@ -1482,16 +1438,13 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.addFleetRepoFromYaml('assets/gitapp-test/fleet.yaml');
         cy.verifyTableRow(0, 'Active', '1/1');
       })
-    )
   }); 
 };
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
   describe('Test availability of annotation created-by-user-id in YAML not in UI.', { tags: '@p1_2'}, () => {
 
-  qase(192,
-
-    it("Fleet-192: Test username to log messages, created resources and user-id is only available in YAML not in UI.", { tags: '@fleet-192' }, () => {
+  it(qase(192, "Fleet-192: Test username to log messages, created resources and user-id is only available in YAML not in UI."), { tags: '@fleet-192' }, () => {
 
       const repoName = 'test-created-by-user-id'
 
@@ -1529,14 +1482,12 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
 
       cy.clickButton('Close');
       })
-  )
   });
 }
 
 describe('Test helm chart dependency download with `disableDependencyUpdate: true/false`', { tags: '@p1_2'}, () => {
 
-  qase(129,
-    it("Fleet-129: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `true` in `fleet.yaml`.", { tags: '@fleet-129' }, () => {
+  it(qase(129, "Fleet-129: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `true` in `fleet.yaml`."), { tags: '@fleet-129' }, () => {
 
       const repoName = 'test-disable-dependency-false-helm-chart'
       const path = "qa-test-apps/disable-dependency-update/true"
@@ -1555,11 +1506,10 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
           cy.checkApplicationStatus("no-dependency-download-nginx", dsCluster, 'All Namespaces', false);
         }
       )
-    })
+    }
   )
 
-  qase(130,
-    it("Fleet-130: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `false` in `fleet.yaml`.", { tags: '@fleet-130' }, () => {
+  it(qase(130, "Fleet-130: Test dependency should be downloaded along with the application when `disableDependencyUpdate` is set to `false` in `fleet.yaml`."), { tags: '@fleet-130' }, () => {
 
       const repoName = 'test-disable-dependency-true-helm-chart'
       const path = "qa-test-apps/disable-dependency-update/false"
@@ -1579,14 +1529,11 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
         }
       )
     })
-  )
 });
 
 describe('Test GitRepo shows Active state for missing resources when `diff` used in `fleet.yaml`', { tags: '@p1_2' }, () => {
 
-  qase(179,
-
-    it(`FLEET-179: Test GitRepo shows Active state for missing resources when 'diff' used in 'fleet.yaml'`, { tags: `@fleet-179}`}, () => {
+  it(qase(179, `FLEET-179: Test GitRepo shows Active state for missing resources when 'diff' used in 'fleet.yaml'`), { tags: '@fleet-179'}, () => {
       const repoName = 'ds-cluster-fleet-179'
       const pathWithoutDiff = 'qa-test-apps/ignore-missing-resources/without-diff'
 
@@ -1610,13 +1557,11 @@ describe('Test GitRepo shows Active state for missing resources when `diff` used
       // Delete GitRepo
       cy.deleteAllFleetRepos();
     })
-  )
 })
 
 describe('Test bundle deploy with overrideTargets by label availability on clusters.', { tags: '@p1_2'}, () => {
 
-  qase(92,
-    it("Fleet-92: Test bundle did not get deployed on the target mentioned in the GitRepo when `overrideTargets` is set in the `fleet.yaml` when label is missing on cluster.", { tags: '@fleet-92' }, () => {
+  it(qase(92, "Fleet-92: Test bundle did not get deployed on the target mentioned in the GitRepo when `overrideTargets` is set in the `fleet.yaml` when label is missing on cluster."), { tags: '@fleet-92' }, () => {
 
       const repoName = 'test-override-targets'
       const path = "qa-test-apps/overrideTargets"
@@ -1641,11 +1586,10 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
           cy.checkApplicationStatus("nginx-override-test", dsCluster, 'All Namespaces', false);
         }
       )
-    })
+    }
   )
 
-  qase(93,
-    it("Fleet-93: Test bundle gets deployed on the target mentioned in the GitRepo provided that `overrideTargets` is present in the `fleet.yaml` after adding label on cluster.", { tags: '@fleet-93' }, () => {
+  it(qase(93, "Fleet-93: Test bundle gets deployed on the target mentioned in the GitRepo provided that `overrideTargets` is present in the `fleet.yaml` after adding label on cluster."), { tags: '@fleet-93' }, () => {
 
       const repoName = 'test-override-targets-with-label'
       const path = "qa-test-apps/overrideTargets"
@@ -1697,5 +1641,4 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
       cy.typeIntoCanvasTermnal('\
       kubectl label clusters.management.cattle.io --all env-{enter}');
     })
-  )
-});
+})

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -13,7 +13,6 @@ limitations under the License.
 */
 
 import 'cypress/support/commands';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const appName = "nginx-keep"
 export const branch = "master"

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -29,8 +29,7 @@ beforeEach(() => {
 
 
 describe('Test resource behavior after deleting GitRepo using keepResources option using YAML', { tags: ['@p1', '@pr-tests'] }, () => {
-  qase(68, 
-    it('Fleet-68: Test RESOURCES will be KEPT and NOT be DELETED after GitRepo is deleted when keepResources: true used in the GitRepo yaml file.', { tags: '@fleet-68' }, () => {
+  it(qase(68, 'Fleet-68: Test RESOURCES will be KEPT and NOT be DELETED after GitRepo is deleted when keepResources: true used in the GitRepo yaml file.'), { tags: '@fleet-68' }, () => {
       cy.continuousDeliveryMenuSelection();
       cy.fleetNamespaceToggle('fleet-local')
       cy.clickCreateGitRepo();
@@ -49,7 +48,6 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       cy.checkApplicationStatus(appName);
       cy.deleteApplicationDeployment();
     })
-  )
 })
 
 describe('Test resource behavior after deleting GitRepo using keepResources option', { tags: '@p1'}, () => {
@@ -65,8 +63,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
   ]
   keepResourceData.forEach(
     ({ qase_id, keepResources, test_explanation}) => {
-      qase(qase_id,
-        it(`Fleet-${qase_id}: Test ${test_explanation}`, { tags: `@fleet-${qase_id}` }, () => {
+      it(qase(qase_id, `Fleet-${qase_id}: Test ${test_explanation}`), { tags: `@fleet-${qase_id}` }, () => {
           const repoName = `local-cluster-fleet-${qase_id}`
           cy.addFleetGitRepo({ repoName, repoUrl, branch, path, keepResources, local: true });
           cy.clickButton('Create');
@@ -78,10 +75,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
             cy.deleteApplicationDeployment();
           }
         })
-      )
-    }
-  )
-});
+    });
+  });
 
 describe('Test Self-Healing of resource modification when correctDrift option used', { tags: ['@p1', '@pr-tests'] }, () => {
   const correctDriftData: testData[] = [
@@ -96,8 +91,7 @@ describe('Test Self-Healing of resource modification when correctDrift option us
   ]
   correctDriftData.forEach(
     ({ qase_id, correctDrift, test_explanation}) => {
-      qase(qase_id,
-        it(`Fleet-${qase_id}: Test ${test_explanation}`, { tags: `@fleet-${qase_id}` }, () => {
+      it(qase(qase_id, `Fleet-${qase_id}: Test ${test_explanation}`), { tags: `@fleet-${qase_id}` }, () => {
           const repoName = `local-cluster-correct-${qase_id}`
           cy.addFleetGitRepo({ repoName, repoUrl, branch, path, correctDrift, local: true });
           cy.clickButton('Create');
@@ -118,14 +112,13 @@ describe('Test Self-Healing of resource modification when correctDrift option us
           }
           cy.deleteAllFleetRepos();
         })
-      )
-    }
-  )
-});
+    });
+  });
+
+
 
 describe('Test Self-Healing of resource modification when correctDrift option used for exisiting GitRepo', { tags: '@p1'}, () => {
-  qase(77,
-    it("Fleet-77: Test MODIFICATION to resources will be self-healed when correctDrift is set to true in existing GitRepo.", { tags: '@fleet-77', retries: 1 }, () => {
+  it(qase(77, "Fleet-77: Test MODIFICATION to resources will be self-healed when correctDrift is set to true in existing GitRepo."), { tags: '@fleet-77', retries: 1 }, () => {
       const repoName = "local-cluster-correct-77"
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
       cy.clickButton('Create');
@@ -161,12 +154,10 @@ describe('Test Self-Healing of resource modification when correctDrift option us
 
       cy.deleteAllFleetRepos();
     })
-  )
 });
 
 describe('Test resource behavior after deleting GitRepo using keepResources option for exisiting GitRepo', { tags: ['@p1', '@pr-tests'] }, () => {
-  qase(71,
-    it("Fleet-71: Test RESOURCES will be KEPT and NOT be DELETED after GitRepo is deleted when keepResources is set to true in existing GitRepo.", { tags: '@fleet-71' }, () => {
+  it(qase(71, "Fleet-71: Test RESOURCES will be KEPT and NOT be DELETED after GitRepo is deleted when keepResources is set to true in existing GitRepo."), { tags: '@fleet-71' }, () => {
       const repoName = "local-cluster-keep-71"
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
       cy.clickButton('Create');
@@ -186,17 +177,14 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       cy.checkApplicationStatus(appName);
       cy.deleteApplicationDeployment();
     })
-  )
 });
 
   describe('Test local cluster behavior with New workspace', { tags: '@p1'}, () => {
-    qase(107,
-      it("Fleet-107: Test LOCAL CLUSTER cannot be moved to another workspace as no 'Change workspace' option available..", { tags: '@fleet-107' }, () => {
+    it(qase(107, "Fleet-107: Test LOCAL CLUSTER cannot be moved to another workspace as no 'Change workspace' option available.."), { tags: '@fleet-107' }, () => {
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         cy.fleetNamespaceToggle('fleet-local');
         cy.open3dotsMenu('local', 'Change workspace', true);
       })
-    )
   });
 
   // Imagescan are disabled by default after: https://github.com/rancher/fleet-product-docs/pull/175/changes
@@ -204,8 +192,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
   // This is currently tricky via yaml, hence skipping for now. 
   // We can re-enable and improve the test later when we have better way to enable imagescan for testing.
   describe.skip('Imagescan tests', { tags: '@p1'}, () => {
-    qase(112,
-      it("Fleet-112: Test imagescan app without expected semver range does not break fleet controller", { tags: '@fleet-112' }, () => {;
+    it(qase(112, "Fleet-112: Test imagescan app without expected semver range does not break fleet controller"), { tags: '@fleet-112' }, () => {;
         const repoName = 'local-cluster-imagescan-112'
         const repoUrl = 'https://github.com/rancher/fleet-test-data'
         const branch = 'master'
@@ -220,7 +207,6 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.verifyTableRow(0, /Running|Active/, 'fleet-controller')
         cy.deleteAllFleetRepos();
       })
-    )
   });
 
   describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: ['@p1', '@pr-tests'] }, () => {
@@ -259,8 +245,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
 
     privateHelmData.forEach(
       ({qase_id, repoName, path, helmUrlRegex_matching, test_explanation}) => {
-        qase(qase_id,
-          it(`Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`, { tags: `@fleet-${qase_id}` }, () => {;
+        it(qase(qase_id, `Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`), { tags: `@fleet-${qase_id}` }, () => {;
             
             // Adding wait for mitigation of intermittent failures due to slow communication with helm registry 
             // and also to make sure previous test's resources are deleted and not interfering with current test.
@@ -286,13 +271,11 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
             cy.get('.text-error', { timeout: 120000 }).should('contain', 'code: 401');
             cy.deleteAllFleetRepos();
           })
-        )
       })
   });
 
   describe('Test OCI support', { tags: ['@p1', '@pr-tests'] }, () => {
-    qase(60,
-      it("Fleet-60: Test OCI helm chart support on Github Container Registry", { tags: '@fleet-60' }, () => {;
+    it(qase(60, "Fleet-60: Test OCI helm chart support on Github Container Registry"), { tags: '@fleet-60' }, () => {;
         const repoName = 'default-oci-60'
         const repoUrl = 'https://github.com/rancher/fleet-test-data'
         const branch = 'master'
@@ -308,10 +291,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
       })
-    )
   
-    qase(127,
-      it("Fleet-127: Test PRIVATE OCI helm chart support on Github Container Registry", { tags: '@fleet-127' }, () => {;
+    it(qase(127, "Fleet-127: Test PRIVATE OCI helm chart support on Github Container Registry"), { tags: '@fleet-127' }, () => {;
         const repoName = 'default-oci-127'
         const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public'
         const branch = 'main'
@@ -331,7 +312,6 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
       })
-    )  
   });
 
   describe('Test Self-Healing on IMMUTABLE resources when correctDrift is enabled', { tags: ['@p1', '@pr-tests'] }, () => {
@@ -356,8 +336,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
   
     correctDriftTestData.forEach(
       ({qase_id, repoName, resourceType, resourceName, resourceLocation, resourceNamespace, dataToAssert}) => {
-        qase(qase_id,
-          it(`Fleet-${qase_id}: Test IMMUTABLE resource "${resourceType}" will NOT be self-healed when correctDrift is set to true.`, { tags: `@fleet-${qase_id}` }, () => {
+        it(qase(qase_id, `Fleet-${qase_id}: Test IMMUTABLE resource "${resourceType}" will NOT be self-healed when correctDrift is set to true.`), { tags: `@fleet-${qase_id}` }, () => {
             const path = "multiple-paths"
   
             // Add GitRepo by enabling 'correctDrift'
@@ -440,10 +419,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
               cy.deleteAll(false);
             })
           })
-        )
-      }
-    )
   });
+})
 
   describe('Tests with disablePolling', { tags: '@p1' }, () => {
   
@@ -471,9 +448,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
 
     }
 
-    qase(126,
-      it(
-        'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github',
+    it(qase(126, 
+        'Fleet-126: Test when `disablePolling=true` and forcing update Gitrepo will sync latest changes from Github'),
         { tags: '@fleet-126', retries: 1 }, // TODO: Retry added to avoid intermittent failures. Remove once fixed.
         () => {
 
@@ -513,13 +489,10 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
           cy.accesMenuSelection('local', 'Workloads', 'Deployments');
           cy.filterInSearchBox('nginx-test-polling');
           cy.verifyTableRow(0, 'Active', '5/5');
-        }
-      )
-    );
+        });
 
-    qase(124,
-      it(
-        'Fleet-124: Test when `disablePolling=true` Gitrepo will not sync latest changes from Github',
+    it(qase(124, 
+        'Fleet-124: Test when `disablePolling=true` Gitrepo will not sync latest changes from Github'),
         { tags: '@fleet-124' },
         () => {
 
@@ -538,13 +511,10 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
           cy.accesMenuSelection('local', 'Workloads', 'Deployments');
           cy.filterInSearchBox('nginx-test-polling');
           cy.verifyTableRow(0, 'Active', '2/2');
-        }
-      )
-    );
+        });
 
-    qase(125,
-      it(
-        'Fleet-125: Test when `disablePolling=true` and pausing / unpausing Gitrepo will sync latest changes from Github',
+    it(qase(125, 
+        'Fleet-125: Test when `disablePolling=true` and pausing / unpausing Gitrepo will sync latest changes from Github'),
         { tags: '@fleet-125' },
         () => {
 
@@ -591,15 +561,12 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
           cy.accesMenuSelection('local', 'Workloads', 'Deployments');
           cy.filterInSearchBox('nginx-test-polling');
           cy.verifyTableRow(0, 'Active', '5/5');
-        }
-      )
-    );
-  });
+        });
+    });
 
 describe('Test GitRepo Bundle do not show hash mismatch error.', { tags: '@p1'}, () => {
 
-  qase(195,
-    it("Fleet-195: Test GitRepo bundle hash is not mismatch.", { tags: '@fleet-195' }, () => {
+  it(qase(195, "Fleet-195: Test GitRepo bundle hash is not mismatch."), { tags: '@fleet-195' }, () => {
 
       const repoName = "test-bundle-hash-mistmatch"
       const path = "qa-test-apps/bundle-hash-test"
@@ -619,15 +586,13 @@ describe('Test GitRepo Bundle do not show hash mismatch error.', { tags: '@p1'},
       cy.verifyTableRow(0, 'Active', repoName);
 
     })
-  )
 });
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypress.expose('rancher_version')) && !/\/2\.13/.test(Cypress.expose('rancher_version'))) {
 
   describe('Test `dependsON` functionality in Fleet GitRepo', { tags: ['@p1', '@pr-tests'] }, () => {
 
-    qase(207,
-      it("Fleet-207: Test GitRepo with `dependsOn` works as expected.", { tags: '@fleet-207' }, () => {
+    it(qase(207, "Fleet-207: Test GitRepo with `dependsOn` works as expected."), { tags: '@fleet-207' }, () => {
     
         cy.addFleetGitRepo({
           repoName: "root",
@@ -665,12 +630,10 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         // Clicking "Unpause" to ensure button Delete is visible to later delete both repos
         cy.open3dotsMenu('root', 'Unpause');
         cy.wait(1000);
-        cy.deleteAllFleetRepos();      
-      }
-    ));
+        cy.deleteAllFleetRepos();     
+    });
 
-    qase(208,
-      it("Fleet-208: Verify GitRepo with `dependsOn` with invalid states display invalid error.", { tags: '@fleet-208' }, () => {
+    it(qase(208, "Fleet-208: Verify GitRepo with `dependsOn` with invalid states display invalid error."), { tags: '@fleet-208' }, () => {
     
         cy.addFleetGitRepo({
           repoName: "root",
@@ -698,7 +661,8 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.verifyTableRow(0, 'Git Updating', 'leaf-error-state');
         cy.verifyTableRow(0, 'leaf-error-state', '0/0');
         cy.contains('Failed to process bundle: validating fleet.yaml: dependsOn[0].acceptedStates[0]: invalid state "BadState", valid values are: [Ready NotReady Pending OutOfSync Modified WaitApplied ErrApplied]').should('be.visible');
-      }
-    ));
-  });
-}
+    });
+
+    });
+  }
+

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -115,8 +115,6 @@ describe('Test Self-Healing of resource modification when correctDrift option us
     });
   });
 
-
-
 describe('Test Self-Healing of resource modification when correctDrift option used for exisiting GitRepo', { tags: '@p1'}, () => {
   it(qase(77, "Fleet-77: Test MODIFICATION to resources will be self-healed when correctDrift is set to true in existing GitRepo."), { tags: '@fleet-77', retries: 1 }, () => {
       const repoName = "local-cluster-correct-77"
@@ -662,7 +660,6 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.verifyTableRow(0, 'leaf-error-state', '0/0');
         cy.contains('Failed to process bundle: validating fleet.yaml: dependsOn[0].acceptedStates[0]: invalid state "BadState", valid values are: [Ready NotReady Pending OutOfSync Modified WaitApplied ErrApplied]').should('be.visible');
     });
-
-    });
+  });
   }
 

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -49,8 +49,7 @@ beforeEach(() => {
 Cypress.config();
 describe('Test Fleet access with RBAC with custom roles using all verbs for User-Base and Standard User.', { tags: '@rbac' }, () => {
 
-  qase(5,
-    it('Test "User-Base" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Clusters" NOR "Clusters Groups"', { tags: '@fleet-5' }, () => {
+  it(qase(5, 'Test "User-Base" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Clusters" NOR "Clusters Groups"'), { tags: '@fleet-5' }, () => {
 
       const baseUser      = "base-user"
       const customRoleName = "fleetworkspaces-bundles-gitrepos-all-verbs-role"
@@ -87,13 +86,10 @@ describe('Test Fleet access with RBAC with custom roles using all verbs for User
       cy.contains('Clusters').should('not.exist');
       cy.contains('Clusters Groups').should('not.exist');
     })
-  )
-
 });
 
 describe('Test Fleet access with RBAC with custom roles using Standard User', { tags: '@rbac' }, () => {
-  qase(43,
-    it('Test "Standard Base" role user with "list" and "create" verbs for "fleetworkspaces" resource. User can NOT "edit" nor "delete" them', { tags: '@fleet-43' }, () => {
+  it(qase(43, 'Test "Standard Base" role user with "list" and "create" verbs for "fleetworkspaces" resource. User can NOT "edit" nor "delete" them'), { tags: '@fleet-43' }, () => {
       
       const stduser = "std-user-43"
       const customRoleName = "fleetworkspaces-list-and-create-role"
@@ -132,11 +128,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       // Ensuring the user is not able to "edit" or "delete" workspaces.
       cy.open3dotsMenu('fleet-default', 'Delete', true);
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
-    })
+    }
   )
 
-  qase(44,
-    it('Test "Standard Base" role with custom role to "fleetworkspaces" with all verbs except "delete" can "edit" but can NOT "delete" them', { tags: '@fleet-44' }, () => {
+  it(qase(44, 'Test "Standard Base" role with custom role to "fleetworkspaces" with all verbs except "delete" can "edit" but can NOT "delete" them'), { tags: '@fleet-44' }, () => {
       
       const stduser = "std-user-44"
       const customRoleName = "fleetworskspaces-all-but-delete-role"
@@ -176,11 +171,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       // Ensuring the user is not able to "delete" workspaces. 
       cy.continuousDeliveryWorkspacesMenu();
       cy.open3dotsMenu('fleet-default', 'Delete', true);
-    })
+    }
   )
 
-  qase(45,
-    it('Test "Standard-Base" role user with RESOURCE "fleetworkspaces" with ACTIONS "List", "Delete" can "list and delete" but can NOT "edit" them', { tags: '@fleet-45' }, () => {
+  it(qase(45, 'Test "Standard-Base" role user with RESOURCE "fleetworkspaces" with ACTIONS "List", "Delete" can "list and delete" but can NOT "edit" them'), { tags: '@fleet-45' }, () => {
       
       const stduser = "std-user-45"
       const customRoleName = "fleetworkspaces-list-and-delete-role"
@@ -216,11 +210,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       // Ensuring the user is NOT able to "edit" workspaces. 
       cy.continuousDeliveryWorkspacesMenu();
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
-    })
+    }
   )
 
-  qase(42,
-    it('Test "Standard User" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Cluster Registration Tokens" "BundleNamespaceMappings" and "GitRepoRestrictions"', { tags: '@fleet-42' }, () => {
+  it(qase(42, 'Test "Standard User" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Cluster Registration Tokens" "BundleNamespaceMappings" and "GitRepoRestrictions"'), { tags: '@fleet-42' }, () => {
 
       const baseUser      = "base-user"
       const customRoleName = "fleetworkspaces-bundles-gitrepos-all-verbs-role"
@@ -265,7 +258,6 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.contains('GitRepoRestrictions').should('not.exist');
       cy.contains('BundleNamespaceMappings').should('not.exist');
     })
-  )
 });
   
   describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "STANDARD USER"', { tags: '@rbac' }, () => {
@@ -288,8 +280,7 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.checkGitRepoStatus(repoNameDefault, '1 / 1');
     })
     
-  qase(46,
-    it('Fleet-46: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List]', { tags: '@fleet-46' }, () => {
+  it(qase(46, 'Fleet-46: Test "Standard-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List]'), { tags: '@fleet-46' }, () => {
       
       const stduser = "std-user-46"
       
@@ -335,11 +326,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(47,
-    it('Fleet-47: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create]', { tags: '@fleet-47' }, () => {
+  it(qase(47, 'Fleet-47: Test "Standard-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Create]'), { tags: '@fleet-47' }, () => {
       
       const stduser = "std-user-47"     
       
@@ -386,11 +376,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(48,
-    it('Fleet-48: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create, Update, Get]', { tags: '@fleet-48' }, () => {
+  it(qase(48, 'Fleet-48: Test "Standard-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Create, Update, Get]'), { tags: '@fleet-48' }, () => {
       
       const stduser = "std-user-48"
       
@@ -440,11 +429,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.clickButton('Cancel');
       // Can't "Delete"
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(50,
-    it('Fleet-50: Test "Standard-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Delete]', { tags: '@fleet-50' }, () => {
+  it(qase(50, 'Fleet-50: Test "Standard-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Delete]'), { tags: '@fleet-50' }, () => {
       
       const stduser = "std-user-50"
       
@@ -495,8 +483,6 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       // Cant't "Edit"
       cy.open3dotsMenu(repoName, 'Edit Config', true);
     })
-  )
-
 });
 
 describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "USER-BASE" user', { tags: '@rbac' }, () => {
@@ -518,8 +504,7 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
     cy.checkGitRepoStatus(repoNameDefault, '1 / 1');
   })
 
-  qase(13,
-    it('Fleet-13: Test "Base-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List]', { tags: '@fleet-13' }, () => {
+  it(qase(13, 'Fleet-13: Test "Base-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List]'), { tags: '@fleet-13' }, () => {
       
       const baseUser = "base-user-13"
       
@@ -574,11 +559,10 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(14,
-    it('Fleet-14: Test "Base-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create]', { tags: '@fleet-14' }, () => {
+  it(qase(14, 'Fleet-14: Test "Base-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Create]'), { tags: '@fleet-14' }, () => {
       
       const baseUser = "base-user-14"     
       
@@ -626,11 +610,10 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.fleetNamespaceToggle('fleet-local');
       cy.open3dotsMenu(repoName, 'Edit Config', true);
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(15,
-    it('Fleet-15: Test "Base-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Create, Update, Get]', { tags: '@fleet-15' }, () => {
+  it(qase(15, 'Fleet-15: Test "Base-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Create, Update, Get]'), { tags: '@fleet-15' }, () => {
       
       const baseUser = "base-user-15"     
       
@@ -681,11 +664,10 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.clickButton('Cancel');
       // Can't "Delete"
       cy.open3dotsMenu(repoName, 'Delete', true);
-    })
+    }
   )
 
-  qase(16,
-    it('Fleet-16: Test "Base-user" | Custom Role | Fleetworkspaces, Bundles = [ALL] | GitRepos = [List, Delete]', { tags: '@fleet-16' }, () => {
+  it(qase(16, 'Fleet-16: Test "Base-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List, Delete]'), { tags: '@fleet-16' }, () => {
       
       const baseUser = "base-user-16"     
       
@@ -737,13 +719,11 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       // Cant't "Edit"
       cy.open3dotsMenu(repoName, 'Edit Config', true);
     })
-  )
 });
 
 describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "USER-BASE" user', { tags: '@rbac' }, () => {
 
-  qase(10,
-    it('Fleet-10: Test "Base-user" | Custom Role | Fleetworkspaces = [List, Create] | Bundles, Gitrepos = [ALL]', { tags: '@fleet-10' }, () => {
+  it(qase(10, 'Fleet-10: Test "Base-user" | Custom Role | Fleetworkspaces = [List), Create] | Bundles, Gitrepos = [ALL]'), { tags: '@fleet-10' }, () => {
       
       const baseUser = "base-user-10"     
       
@@ -781,11 +761,10 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       // Ensuring the user is not able to "edit" or "delete" workspaces.
       cy.open3dotsMenu('fleet-default', 'Delete', true);
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
-    })
+    }
   )
 
-  qase(11,
-    it('Fleet-11: Test "Base-user" | Custom Role | Fleetworkspaces = [All except Delete] | Bundles, Gitrepos = [ALL]', { tags: '@fleet-11' }, () => {
+  it(qase(11, 'Fleet-11: Test "Base-user" | Custom Role | Fleetworkspaces = [All except Delete] | Bundles), Gitrepos = [ALL]'), { tags: '@fleet-11' }, () => {
       
       const baseUser = "base-user-11"     
       
@@ -824,11 +803,10 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       // Ensuring the user is not able to "delete" workspaces. 
       cy.continuousDeliveryWorkspacesMenu();
       cy.open3dotsMenu('fleet-default', 'Delete', true);
-    })
+    }
   )
 
-  qase(12,
-    it('Fleet-12: Test "Base-user" | Custom Role | Fleetworkspaces = [List, Delete] | Bundles, Gitrepos = [ALL]', { tags: '@fleet-12' }, () => {
+  it(qase(12, 'Fleet-12: Test "Base-user" | Custom Role | Fleetworkspaces = [List), Delete] | Bundles, Gitrepos = [ALL]'), { tags: '@fleet-12' }, () => {
       
       const baseUser = "base-user-12"
       
@@ -864,7 +842,6 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.continuousDeliveryWorkspacesMenu();
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
     })
-  )
 });
 
 

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -14,7 +14,6 @@ limitations under the License.
 
 import 'cypress/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 // General constants
 export const uiPassword    = "rancherpassword"

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import 'cypress/support/commands';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const appName = "nginx-keep";
 export const clusterName = "imported-0";

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -34,9 +34,8 @@ beforeEach(() => {
 
 describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => {
 
-    qase(186,
-        // Cloud downstream cluster provisioning
-        it('Import EC2 cluster into Rancher', () => {
+    // Cloud downstream cluster provisioning
+    it(qase(186, 'Import EC2 cluster into Rancher'), () => {
 
             const cloudProvider = 'Amazon';
             const credentialName = 'qa-fleet-ec2-cloud-cred';
@@ -50,11 +49,8 @@ describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => 
             cy.createCloudCredential(cloudProvider, credentialName, accessKey, secretKey, region);
             cy.createCloudCluster(cloudInstance, clusterName, subnetId);
         })
-    );
 
-    qase(187,
-
-        it('Add gitrepo and deploy app to EC2 cluster', () => {
+    it(qase(187, 'Add gitrepo and deploy app to EC2 cluster'), () => {
             
             const repoName = 'nginx-app';
             const repoUrl = 'https://github.com/rancher/fleet-test-data/';
@@ -66,24 +62,19 @@ describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => 
             cy.wait(45000); // Adding 45 seconds due to slow comunication and size of ec2 cluster
             cy.verifyTableRow(0, 'Active', '4/4');    // 4 clusters means gitrepo was deployed to ec2 cluster
         })
-    );
 
-    qase(188,
-
-        it('Delete EC2 cluster', () => {
+    it(qase(188, 'Delete EC2 cluster'), () => {
 
             const clusterName = 'qa-fleet-ec2-cluster';
 
             cy.deleteDownstreamCluster(clusterName, false);
         })
-    );
 });
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypress.expose('rancher_version'))) {
 
 describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
-  qase(200,
-    it('FLEET-200: Test agent scheduling customization for PDB and PriorityClass', { tags: '@fleet-200' }, () => {
+  it(qase(200, 'FLEET-200: Test agent scheduling customization for PDB and PriorityClass'), { tags: '@fleet-200' }, () => {
       // Go to the cluster and edit it as YAML
       cy.accesMenuSelection('Continuous Delivery', 'Clusters ');
       cy.fleetNamespaceToggle('fleet-local');
@@ -116,13 +107,12 @@ describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
       cy.accesMenuSelection('local', 'More Resources', 'Scheduling');
       cy.contains('PriorityClasses').click();
       cy.verifyTableRow(0, 'fleet-agent', '888');
-    }))
+    })
   });
 };
 
 describe('Test move cluster to newly created workspace and deploy application to it.', { tags: '@special_tests'}, () => {
-  qase(51,
-    it("Fleet-51: Test move cluster to newly created workspace and deploy application to it.", { tags: '@fleet-51' }, () => {
+  it(qase(51, "Fleet-51: Test move cluster to newly created workspace and deploy application to it."), { tags: '@fleet-51' }, () => {
       const dsFirstClusterName = 'imported-0'
       const repoName = 'default-cluster-new-workspace-51'
       const branch = "master"
@@ -173,7 +163,6 @@ describe('Test move cluster to newly created workspace and deploy application to
       cy.filterInSearchBox(newWorkspaceName)
       cy.deleteAll(false);
     })
-  )
 });
 
 // Note: to be executed after the above test cases
@@ -181,8 +170,7 @@ describe('Test move cluster to newly created workspace and deploy application to
 // To be replaced into other spec file when required.
 describe("Global settings related tests", { tags: '@special_tests'}, () => {
   
-    qase(156,
-      it("Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off", { tags: '@fleet-156' }, () => {
+    it(qase(156, "Fleet-156: Test gitrepoJobsCleanup is disabled when continuous-delivery feature is off"), { tags: '@fleet-156' }, () => {
 
         // Verify is gitrepoJobsCleanup is enabled by default.
         cy.accesMenuSelection('local', 'Workloads', 'CronJobs');
@@ -216,5 +204,4 @@ describe("Global settings related tests", { tags: '@special_tests'}, () => {
         cy.verifyTableRow(0, 'Active', 'fleet-cleanup-gitrepo-jobs');
 
       })
-    )
 });

--- a/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
@@ -13,7 +13,6 @@ limitations under the License.
 */
 
 import 'cypress/support/commands';
-import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 export const branch = "master";
 export let upgrade = Cypress.expose('upgrade') === 'true'

--- a/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
@@ -49,7 +49,6 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@upgra
       cy.checkGitRepoStatus(repoName, '1 / 1');
       cy.checkApplicationStatus(appName, clusterName);
     })
-  );
 });
 
 describe('Test Fleet deployment on PUBLIC repos',  { tags: '@upgrade' }, () => {
@@ -77,7 +76,6 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@upgrade' }, () => {
       cy.verifyTableRow(3, 'Service', 'redis-master');
       cy.verifyTableRow(5, 'Service', 'redis-slave');
     })
-  );
 });
 
 describe('Test gitrepos with cabundle', { tags: '@upgrade' }, () => {
@@ -105,7 +103,6 @@ describe('Test gitrepos with cabundle', { tags: '@upgrade' }, () => {
       cy.filterInSearchBox(repoName+'-cabundle');
       cy.contains('There are no rows which match your search query.').should('be.visible');
     })
-  );
 });
 
 describe('Test Crontab for Fleet job cleanup is present',  { tags: '@upgrade' }, () => {
@@ -122,7 +119,6 @@ describe('Test Crontab for Fleet job cleanup is present',  { tags: '@upgrade' },
       // Check Crontab schedule is '@daily'
       cy.verifyTableRow(0, 'fleet-cleanup-gitrepo-jobs', '@daily');
     })
-  );
 });
 
 describe('Test "fleet-agent" image version on each downstream cluster',  { tags: '@upgrade' }, () => {

--- a/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade_fleet.spec.ts
@@ -24,8 +24,7 @@ beforeEach(() => {
 
 Cypress.config();
 describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@upgrade' }, () => {
-  qase(157,
-    it(`FLEET-157: Test to install "NGINX" app using "SSH" auth on "GitLab" PRIVATE repository`, { tags: '@fleet-157', retries: 1 }, () => {
+  it(qase(157, `FLEET-157: Test to install "NGINX" app using "SSH" auth on "GitLab" PRIVATE repository`), { tags: '@fleet-157', retries: 1 }, () => {
       const repoName = 'default-cluster-fleet-157'
       const gitAuthType = "ssh"
       const userOrPublicKey = Cypress.expose("rsa_public_key_qa")
@@ -54,8 +53,7 @@ describe('Test Fleet deployment on PRIVATE repos with SSH auth', { tags: '@upgra
 });
 
 describe('Test Fleet deployment on PUBLIC repos',  { tags: '@upgrade' }, () => {
-  qase(158,
-    it('FLEET-158: Deploy application to local cluster', { tags: '@fleet-158' }, () => {
+  it(qase(158, 'FLEET-158: Deploy application to local cluster'), { tags: '@fleet-158' }, () => {
       const path = "simple"
       const repoUrl = 'https://github.com/rancher/fleet-examples'
       const repoName = "local-cluster-fleet-158"
@@ -83,8 +81,7 @@ describe('Test Fleet deployment on PUBLIC repos',  { tags: '@upgrade' }, () => {
 });
 
 describe('Test gitrepos with cabundle', { tags: '@upgrade' }, () => {
-  qase(159,
-    it("Fleet-159 Test cabundle secrets are not created without TLS certificate", { tags: '@fleet-159' }, () => {;
+  it(qase(159, "Fleet-159 Test cabundle secrets are not created without TLS certificate"), { tags: '@fleet-159' }, () => {;
       const repoName = 'default-159-test-cabundle-secrets-not-created'
       const path = "qa-test-apps/nginx-app"
       const repoUrl = "https://github.com/rancher/fleet-test-data/"
@@ -112,8 +109,7 @@ describe('Test gitrepos with cabundle', { tags: '@upgrade' }, () => {
 });
 
 describe('Test Crontab for Fleet job cleanup is present',  { tags: '@upgrade' }, () => {
-  qase(162,
-    it('FLEET-162: Test Crontab for Fleet job cleanup is present', { tags: '@fleet-162' }, () => {
+  it(qase(162, 'FLEET-162: Test Crontab for Fleet job cleanup is present'), { tags: '@fleet-162' }, () => {
       // This test doesnot require upgrade flag as it not creating anything,
       // only checking the existance of Crontab for Fleet cleanup job.
 
@@ -130,8 +126,7 @@ describe('Test Crontab for Fleet job cleanup is present',  { tags: '@upgrade' },
 });
 
 describe('Test "fleet-agent" image version on each downstream cluster',  { tags: '@upgrade' }, () => {
-  qase(163,
-    it('FLEET-163: Test "fleet-agent" image version on each downstream cluster after upgrade ', { tags: '@fleet-163' }, () => {
+  it(qase(163, 'FLEET-163: Test "fleet-agent" image version on each downstream cluster after upgrade '), { tags: '@fleet-163' }, () => {
       const dsAllClusterList = ['imported-0', 'imported-1', 'imported-2']
       cy.log("===========================");
       cy.log("Cluster Upgraded: " + upgrade);
@@ -176,12 +171,10 @@ describe('Test "fleet-agent" image version on each downstream cluster',  { tags:
         cy.log("This test has to run After Upgrade only")
       }
     })
-  );
 });
 
 describe('Test Upgrade Kubernetes version of imported cluster support for fleet',  { tags: '@k8supgrade' }, () => {
-  qase(90,
-    it('FLEET-90: Test Upgrade Kubernetes version of imported cluster support for fleet', { tags: '@fleet-90' }, () => {
+  it(qase(90, 'FLEET-90: Test Upgrade Kubernetes version of imported cluster support for fleet'), { tags: '@fleet-90' }, () => {
       const dsAllClusterList = ['imported-0','imported-1', 'imported-2']
       if (upgrade) {
         cy.log("K8s Version for all downstream cluster upgraded to given K8s version.")
@@ -193,5 +186,4 @@ describe('Test Upgrade Kubernetes version of imported cluster support for fleet'
         })
       }
     })
-  );
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,7 +33,7 @@
     "cypress-mochawesome-reporter": "^4.0.2",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-plugin-tab": "^2.0.0",
-    "cypress-qase-reporter": "^1.4.3",
+    "cypress-qase-reporter": "^3.0.3",
     "dotenv": "^17.3.1",
     "typescript": "^5.9.3"
   },

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,7 +33,7 @@
     "cypress-mochawesome-reporter": "^4.0.2",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-plugin-tab": "^2.0.0",
-    "cypress-qase-reporter": "^3.0.3",
+    "cypress-qase-reporter": "^3.6.0",
     "dotenv": "^17.3.1",
     "typescript": "^5.9.3"
   },

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -9,8 +9,10 @@ npm install
 docker run --init -v $PWD:/workdir -w /workdir              \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
     -e QASE_API_TOKEN=$QASE_API_TOKEN                       \
-    -e QASE_REPORT=$QASE_REPORT                             \
-    -e QASE_RUN_ID=$QASE_RUN_ID                             \
+    -e QASE_MODE=$QASE_MODE                                 \
+    -e QASE_TESTOPS_RUN_TITLE="$QASE_TESTOPS_RUN_TITLE"     \
+    -e QASE_TESTOPS_RUN_DESCRIPTION="$QASE_TESTOPS_RUN_DESCRIPTION" \
+    -e QASE_TESTOPS_RUN_ID=$QASE_TESTOPS_RUN_ID             \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \


### PR DESCRIPTION

Fixing  QASE report again after update to latest version.

Done among many things:
- Updated QASE to new [qase-reporter](https://www.npmjs.com/package/cypress-qase-reporter?activeTab=readme) standard version `3.6.0`. This includes also updating a lot of variables `QASE_TESTOPS` everywhere.
- Created new dispatch `Report to QASE` (set to true by default)
- Updated all test nomenclature by embedding `qase` whitin`it` block.
- Ensuring report is correctly generated
- Removing old commands from `Makefile`
- Updated workflows on all lines 2.11 onwards

---
Screenshots:

New counter + tag identification per run:

<img width="1439" height="1136" alt="image" src="https://github.com/user-attachments/assets/d06807d5-8227-40fc-834c-1c0401278dbf" />

New `Report to QASE` dispatch on ci (automatically selected to true:

<img width="1413" height="908" alt="image" src="https://github.com/user-attachments/assets/7eaf03bf-53f2-4cdd-b2ef-d7765e38a4e3" />



---

Tests:

`2.14`

- [p0](https://github.com/rancher/fleet-e2e/actions/runs/25150548427) | [QASE link ](https://app.qase.io/run/FLEET/dashboard/4948)
- [p1](https://github.com/rancher/fleet-e2e/actions/runs/25150559777) | [QASE link](https://app.qase.io/run/FLEET/dashboard/4946)
- [p1_2](https://github.com/rancher/fleet-e2e/actions/runs/25155083305) | [QASE link](https://app.qase.io/run/FLEET/dashboard/4951)
- [rbac](https://github.com/rancher/fleet-e2e/actions/runs/25150570481) | [QASE link](https://app.qase.io/run/FLEET/dashboard/4947)
- [special + cloud](https://github.com/rancher/fleet-e2e/actions/runs/25150602824) | [QASE link](https://app.qase.io/run/FLEET/dashboard/4949)
- [hardening](https://github.com/rancher/fleet-e2e/actions/runs/25150620964) | [QASE link](https://app.qase.io/run/FLEET/dashboard/4950)

