### PR TITLE
Add kubectl command execution support for cluster labeling in clusterGroup related tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -439,7 +439,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
   beforeEach('Remove labels from all clusters.', () => {
     // Remove labels from the clusters.
-    cy.accesMenuSelection('local');
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -21,9 +21,12 @@ export const repoUrl = "https://github.com/rancher/fleet-test-data/"
 export const bannerMessageToAssert = /Matches 2 of 3 existing clusters, including "imported-\d"/
 export const key = 'key_env'
 export const value = 'value_testing'
+export const new_key = 'key_third_cluster'
+export const new_value = 'value_third_cluster'
 export const clusterGroupName = 'cluster-group-env-prod'
 export const dsAllClusterList = ['imported-0', 'imported-1', 'imported-2']
 export const dsFirstClusterName = dsAllClusterList[0]
+export const dsSecondClusterName = dsAllClusterList[1]
 export const dsFirstTwoClusterList = dsAllClusterList.slice(0, 2)
 export const dsThirdClusterName = dsAllClusterList[2]
 export const NoAppBundleOrGitRepoPresentMessages = ['No repositories have been added', 'No App Bundles have been created']
@@ -32,6 +35,23 @@ export const supported_versions_212_and_above = [
   /^(prime|prime-optimus|prime-optimus-alpha|prime-alpha|prime-rc|alpha)\/2\.(1[2-9]|[2-9]\d+)(\..*)?$/,
   /^head\/2\.(1[2-9])$/
 ];
+export const labelFirstTwoImportedClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io \
+  -l 'management.cattle.io/cluster-display-name in (${dsFirstTwoClusterList.join(',')})' ${key}=${value} {enter}`
+export const removeLabelFirstTwoImportedClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name in (${dsFirstTwoClusterList.join(',')})' ${key}- {enter}`
+export const labelThirdImportedCluster = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name=${dsThirdClusterName}' ${key}=${value} {enter}`
+export const removeLabelThirdImportedCluster = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name=${dsThirdClusterName}' ${key}- {enter}`
+export const removeLabelSecondImportedCluster = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name=${dsSecondClusterName}' ${key}- {enter}`
+
+export const newLabelThirdImportedCluster = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name=${dsThirdClusterName}' ${new_key}=${new_value} {enter}`
+export const removeNewLabelThirdImportedCluster = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name=${dsThirdClusterName}' ${new_key}- {enter}`
+export const removeLabelFromAllClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name in (${dsAllClusterList.join(',')})' ${key}- ${new_key}- {enter}`
 
 beforeEach(() => {
   cy.session('admin', () => {
@@ -153,14 +173,6 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
 
   beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
     cy.deleteAllFleetRepos();
-    // Remove labels from the clusters.
-    dsAllClusterList.forEach(
-      (dsCluster) => {
-        // Adding wait to load page correctly to avoid interference with hamburger-menu.
-        cy.wait(500);
-        cy.removeClusterLabels(dsCluster, key, value);
-      }
-    )
     cy.deleteClusterGroups();
   })
 
@@ -182,18 +194,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
             repoName = "default-single-app-cluster-group"
           }
 
-          cy.continuousDeliveryMenuSelection();
-          cy.clickNavMenu(['Clusters']);
-          cy.contains('.title', 'Clusters').should('be.visible');
-
-          // Assign label to the first 2 clusters i.e. imported-0 and imported-1
-          dsFirstTwoClusterList.forEach(
-            (dsCluster) => {
-              cy.assignClusterLabel(dsCluster, key, value);
-            }
-          )
+          // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+          cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
           // Create group of cluster consists of same label.
+          cy.continuousDeliveryMenuSelection();
           cy.clickNavMenu(['Cluster Groups']);
           cy.contains('.title', 'Cluster Groups').should('be.visible');
           cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
@@ -230,7 +235,7 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
             cy.fleetNamespaceToggle('fleet-default');
 
             // Add label to the third cluster i.e. imported-2
-            cy.assignClusterLabel(dsThirdClusterName, key, value);
+            cy.executeKubectlCommand(labelThirdImportedCluster);
 
             // Check existing clusterGroup for third cluster (imported-2) is added.
             if (!(supported_versions_212_and_above.some(r => r.test(rancherVersion)))) {
@@ -243,18 +248,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
             // Remove label from the third cluster i.e. imported-2
             cy.wait(500);
             cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-            cy.removeClusterLabels(dsThirdClusterName, key, value);
+            cy.executeKubectlCommand(removeLabelThirdImportedCluster);
           }
 
-          // Remove labels from the All 3 clusters.
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          dsAllClusterList.forEach(
-            (dsCluster) => {
-              // Adding wait to load page correctly to avoid interference with hamburger-menu.
-              cy.wait(500);
-              cy.removeClusterLabels(dsCluster, key, value);
-            }
-          )
+          // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+          cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
           cy.deleteClusterGroups();
         })
     }
@@ -264,17 +262,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       const repoName = 'default-single-app-cluster-group-26'
       const path2 = 'multiple-paths/config'
 
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      cy.contains('.title', 'Clusters').should('be.visible');
-
-      // Assign label to the first 2 clusters i.e. imported-0 and imported-1
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          cy.assignClusterLabel(dsCluster, key, value);
-        }
-      )
+      // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
       // Create group of cluster consists of same label.
+      cy.continuousDeliveryMenuSelection();
       cy.clickNavMenu(['Cluster Groups']);
       cy.contains('.title', 'Cluster Groups').should('be.visible');
       cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
@@ -310,16 +302,9 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
         cy.get('td.col-link-detail > span').contains("mp-app-config").click();
       })
 
-      // Remove labels from the clusters i.e. imported-0 and imported-1
-      cy.wait(1000);
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          // Adding wait to load page correctly to avoid interference with hamburger-menu.
-          cy.wait(500);
-          cy.removeClusterLabels(dsCluster, key, value);
-        }
-      )
+      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
+      cy.deleteClusterGroups();
     }
   )
   
@@ -331,19 +316,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
         repoName = "default-single-app-cluster-group"
       }
 
-      const dsSecondClusterName = dsAllClusterList[1]
-
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      cy.contains('.title', 'Clusters').should('be.visible');
-
-      // Assign label to the clusters 
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          cy.assignClusterLabel(dsCluster, key, value);
-        }
-      )
+      // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
       // Create group of cluster consists of same label.
+      cy.continuousDeliveryMenuSelection();
       cy.clickNavMenu(['Cluster Groups']);
       cy.contains('.title', 'Cluster Groups').should('be.visible');
       cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
@@ -382,18 +359,8 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       // Check application is absent i.e. removed from second cluster i.e. imported-1
       cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);
 
-      // Check application is available on first cluster i.e. imported-0
-
-      // Remove labels from the clusters.
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          // Adding wait to load page correctly to avoid interference with hamburger-menu.
-          cy.wait(500);
-          cy.removeClusterLabels(dsCluster, key, value);
-        }
-      )
-      // Delete clusterGroups.
+      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       cy.deleteClusterGroups();
     }
   )
@@ -404,21 +371,13 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
   else {
     it(qase(29, "Fleet-29: Test install app to new set of clusters from old set of clusters using 'clusterGroup'"), { tags: '@fleet-29' }, () => {
       const repoName = 'default-single-app-cluster-group-29'
-      const new_key = 'key_third_cluster'
-      const new_value = 'value_third_cluster'
       const newClusterGroupName = 'cluster-group-env-third-cluster'
 
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      cy.contains('.title', 'Clusters').should('be.visible');
-
-      // Check application status on both clusters i.e. imported-0 and imported-1
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          cy.assignClusterLabel(dsCluster, key, value);
-        }
-      )
+      // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
       // Create group of cluster consists of same label.
+      cy.continuousDeliveryMenuSelection();
       cy.clickNavMenu(['Cluster Groups']);
       cy.contains('.title', 'Cluster Groups').should('be.visible');
       cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
@@ -433,11 +392,7 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
         cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
       })
 
-      // Add label to the third cluster
-      cy.continuousDeliveryMenuSelection();
-      cy.clickNavMenu(['Clusters']);
-      cy.contains('.title', 'Clusters').should('be.visible');
-      cy.assignClusterLabel(dsThirdClusterName, new_key, new_value);
+      cy.executeKubectlCommand(newLabelThirdImportedCluster);
 
       // Create another clusterGroup using third cluster.
       const newBannerMessageToAssert = /Matches 1 of 3 existing clusters: "imported-\d"/
@@ -461,18 +416,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
         }
       )
 
-      // Remove labels from the clusters i.e. imported-0 and imported-1
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          // Adding wait to load page correctly to avoid interference with hamburger-menu.
-          cy.wait(500);
-          cy.removeClusterLabels(dsCluster, key, value);
-        }
-      )
+      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
 
       // Remove labels from third cluster i.e. imported-2
-      cy.removeClusterLabels(dsThirdClusterName, new_key, new_value);
+      cy.executeKubectlCommand(removeLabelThirdImportedCluster);
 
       // Delete clusterGroups.
       cy.deleteClusterGroups();
@@ -481,19 +429,11 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
 });
 
 describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_2'}, () => {
-  const key = 'key_env'
-  const value = 'value_testing'
   let gitRepoFile
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
     // Remove labels from the clusters.
-    dsAllClusterList.forEach(
-      (dsCluster) => {
-        // Adding wait to load page correctly to avoid interference with hamburger-menu.
-        cy.wait(500);
-        cy.removeClusterLabels(dsCluster, key, value);
-      }
-    )
+    cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
   const clusterSelector: testData[] = [
@@ -523,12 +463,8 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         cy.continuousDeliveryMenuSelection();
         cy.clickNavMenu(['Clusters']);
         cy.contains('.title', 'Clusters').should('be.visible');
-        // Assign label to the clusters 
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            cy.assignClusterLabel(dsCluster, key, value);
-          }
-        )
+        // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         // Get GitRepo YAML file according to test.
         if (qase_id === 9 || qase_id === 20) {
@@ -565,20 +501,15 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
         // Add same label on third cluster
         if (qase_id === 20) {
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.contains('.title', 'Clusters').should('be.visible');
-
           // Add label to the third cluster
-          cy.assignClusterLabel(dsThirdClusterName, key, value);
+          cy.executeKubectlCommand(labelThirdImportedCluster);
 
           // Check application deployed to third cluster
           cy.wait(500);
           cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
 
-          // Remove label from the third cluster.
-          cy.wait(500);
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.removeClusterLabels(dsThirdClusterName, key, value);
+          // Remove label from the third cluster i.e. imported-2 using kubectl command in terminal.
+          cy.executeKubectlCommand(removeLabelThirdImportedCluster);
         }
 
         // Check another application on each cluster.
@@ -596,32 +527,19 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
           })
         }
 
-        // Remove labels from the clusters.
-        cy.wait(5000);
-        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            // Adding wait to load page correctly to avoid interference with hamburger-menu.
-            cy.wait(500);
-            cy.removeClusterLabels(dsCluster, key, value);
-          }
-        )
+        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })
 
   it(qase(19, "Fleet-19: Test remove label from cluster-2 to remove application from it when application deployed using clusterSelector(matchLabels)"), { tags: '@fleet-19' }, () => {
-      const dsSecondClusterName = dsAllClusterList[1]
       gitRepoFile = 'assets/git-repo-multiple-app-cluster-selector.yaml'
 
       cy.accesMenuSelection('Continuous Delivery', 'Clusters');
       cy.contains('.title', 'Clusters').should('be.visible');
 
-      // Assign label to the clusters 
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          cy.assignClusterLabel(dsCluster, key, value);
-        }
-      )
+      // Assign label to the clusters using kubectl command in terminal.
+      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
       // Create a GitRepo targeting cluster group created from YAML.
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
@@ -648,7 +566,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
       //Toggle Fleet namespace on cluster page to `fleet-default` if not being selected already.
       cy.fleetNamespaceToggle('fleet-default');
 
-      cy.removeClusterLabels(dsSecondClusterName, key, value);
+      cy.executeKubectlCommand(removeLabelSecondImportedCluster);
 
       // Check application is absent i.e. removed from second cluster i.e. imported-1
       cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);
@@ -656,15 +574,8 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
       // Check application is available on first cluster i.e. imported-0
       cy.checkApplicationStatus(appName, dsFirstClusterName, 'All Namespaces');
 
-      // Remove labels from the clusters.
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      dsFirstTwoClusterList.forEach(
-        (dsCluster) => {
-          // Adding wait to load page correctly to avoid interference with hamburger-menu.
-          cy.wait(500);
-          cy.removeClusterLabels(dsCluster, key, value);
-        }
-      )
+      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
     }
   )
   it(qase(22, "Fleet-22: Test install app to new set of clusters from old set of clusters"), { tags: '@fleet-22' }, () => {
@@ -681,12 +592,8 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         cy.contains('.title', 'Clusters').should('be.visible');
 
-        // Assign label to the clusters 
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            cy.assignClusterLabel(dsCluster, key, value);
-          }
-        )
+        // Assign label to the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         // Create a GitRepo targeting cluster selector created from YAML.
         if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
@@ -709,7 +616,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         // Add label to the third cluster
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         cy.contains('.title', 'Clusters').should('be.visible');
-        cy.assignClusterLabel(dsThirdClusterName, new_key, new_value);
+        cy.executeKubectlCommand(labelThirdImportedCluster);
 
         // Update GitRepo with newly created clusterGroup.
         cy.addFleetGitRepo({ repoName, deployToTarget: "Advanced", fleetNamespace: 'fleet-default', editConfig: true });
@@ -727,18 +634,11 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
           }
         )
 
-        // Remove labels from the clusters i.e. imported-0 and imported-1
-        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            // Adding wait to load page correctly to avoid interference with hamburger-menu.
-            cy.wait(500);
-            cy.removeClusterLabels(dsCluster, key, value);
-          }
-        )
+        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
 
-        // Remove labels from third cluster i.e. imported-2
-        cy.removeClusterLabels(dsThirdClusterName, new_key, new_value);
+        // Remove labels from third cluster i.e. imported-2 using kubectl command in terminal.
+        cy.executeKubectlCommand(removeLabelThirdImportedCluster);
       }
     })
 });
@@ -750,16 +650,8 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
     cy.deleteAllFleetRepos();
-    // Remove labels from the clusters.
-    dsAllClusterList.forEach(
-      (dsCluster) => {
-        // Adding wait to load page correctly to avoid interference with hamburger-menu.
-        cy.wait(500);
-        cy.removeClusterLabels(dsCluster, key, value);
-      }
-    )
-
     cy.deleteClusterGroups();
+    cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
   const clusterSelector: testData[] = [
@@ -790,14 +682,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
         cy.contains('.title', 'Clusters').should('be.visible');
 
         // Assign label to the first 2 clusters i.e. imported-0 and imported-1
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            cy.assignClusterLabel(dsCluster, key, value);
-          }
-        )
-
-        // Adding explicit wait here till the labels are reflected on Clusters.
-        cy.wait(5000);
+        cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         // Create group of cluster consists of same label.
         cy.clickNavMenu(['Cluster Groups']);
@@ -845,18 +730,15 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
           cy.accesMenuSelection('Continuous Delivery', 'Clusters');
           cy.contains('.title', 'Clusters').should('be.visible');
 
-          // Add label to the third cluster i.e. imported-2
-          cy.assignClusterLabel(dsThirdClusterName, key, value);
+          // Add label to the third cluster i.e. imported-2 using kubectl command in terminal.
+          cy.executeKubectlCommand(labelThirdImportedCluster);
 
           // Check application deployed to third cluster(imported-2)
           // Along with other 2 clusters (imported-0 and imported-1).
           cy.wait(500);
           cy.checkApplicationStatus(appName, dsThirdClusterName, 'All Namespaces');
 
-          // Remove label from the third cluster.
-          cy.wait(500);
-          cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-          cy.removeClusterLabels(dsThirdClusterName, key, value);
+          cy.executeKubectlCommand(removeLabelThirdImportedCluster);
         }
 
         // Check another application on each cluster.
@@ -874,16 +756,8 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
           })
         }
 
-        // Remove labels from the clusters.
-        cy.wait(1000);
-        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-        dsFirstTwoClusterList.forEach(
-          (dsCluster) => {
-            // Adding wait to load page correctly to avoid interference with hamburger-menu.
-            cy.wait(500);
-            cy.removeClusterLabels(dsCluster, key, value);
-          }
-        )
+        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })
 });

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -171,7 +171,7 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
 describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
   let repoName
 
-  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+  beforeEach('Cleanup leftover cluster groups and labels etc. if any.', () => {
     cy.executeKubectlCommand(removeClusterGroupCommand);
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
@@ -623,8 +623,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
   const clusterGroupLabelValue = 'cluster_group_selector_test'
   let clusterGroupSelectorFile
 
-  beforeEach('Cleanup leftover GitRepo if any.', () => {
-    cy.deleteAllFleetRepos();
+  beforeEach('Cleanup leftover cluster groups and labels if any.', () => {
     cy.executeKubectlCommand(removeClusterGroupCommand);
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -52,6 +52,7 @@ export const removeNewLabelThirdImportedCluster = `kubectl label -n fleet-defaul
     'management.cattle.io/cluster-display-name=${dsThirdClusterName}' ${new_key}- {enter}`
 export const removeLabelFromAllClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
     'management.cattle.io/cluster-display-name in (${dsAllClusterList.join(',')})' ${key}- ${new_key}- {enter}`
+export const removeClusterGroupCommand = `kubectl delete clustergroups.fleet.cattle.io ${clusterGroupName} -n fleet-default {enter}`
 
 beforeEach(() => {
   cy.session('admin', () => {
@@ -170,9 +171,9 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
 describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
   let repoName
 
-  beforeEach('Cleanup leftover GitRepo, ClusterGroup etc. if any.', () => {
-    cy.deleteAllFleetRepos();
-    cy.deleteClusterGroups();
+  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+    cy.executeKubectlCommand(removeClusterGroupCommand);
+    cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
   const clusterGroup: testData[] = [
@@ -249,10 +250,6 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
             cy.accesMenuSelection('Continuous Delivery', 'Clusters');
             cy.executeKubectlCommand(removeLabelThirdImportedCluster);
           }
-
-          // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-          cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-          cy.deleteClusterGroups();
         })
     }
   )
@@ -305,10 +302,6 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
 
       // Check application is absent i.e. removed from second cluster i.e. imported-1
       cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);
-
-      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-      cy.deleteClusterGroups();
     }
   )
 
@@ -362,23 +355,15 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
           cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces', false);
         }
       )
-
-      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-
-      // Remove labels from third cluster i.e. imported-2
-      cy.executeKubectlCommand(removeLabelThirdImportedCluster);
-
-      // Delete clusterGroups.
-      cy.deleteClusterGroups();
     })
   }
 });
 
 describe('Test multiple applications deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
 
-  beforeEach('Cleanup leftover GitRepo if any.', () => {
-    cy.deleteAllFleetRepos();
+  beforeEach('Cleanup leftover clusterGroups or labels if any.', () => {
+    cy.executeKubectlCommand(removeClusterGroupCommand);
+    cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
   it(qase(26, "Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'"), { tags: '@fleet-26' }, () => {
@@ -425,11 +410,6 @@ describe('Test multiple applications deployment based on clusterGroup', { tags: 
         cy.filterInSearchBox("mp-app-config");
         cy.get('td.col-link-detail > span').contains("mp-app-config").click();
       })
-
-      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.wait(1000);
-      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-      cy.deleteClusterGroups();
     }
   )
 });
@@ -438,7 +418,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   let gitRepoFile
 
   beforeEach('Remove labels from all clusters.', () => {
-    // Remove labels from the clusters.
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
@@ -534,10 +513,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
             cy.get('td.col-link-detail > span').contains("mp-app-config").click();
           })
         }
-
-        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-        cy.accesMenuSelection('local');
-        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })
 
@@ -583,9 +558,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
       // Check application is available on first cluster i.e. imported-0
       cy.checkApplicationStatus(appName, dsFirstClusterName, 'All Namespaces');
-
-      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
     }
   )
   it(qase(22, "Fleet-22: Test install app to new set of clusters from old set of clusters"), { tags: '@fleet-22' }, () => {
@@ -642,12 +614,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
             cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces', false);
           }
         )
-
-        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-
-        // Remove labels from third cluster i.e. imported-2 using kubectl command in terminal.
-        cy.executeKubectlCommand(removeLabelThirdImportedCluster);
       }
     })
 });
@@ -659,7 +625,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
     cy.deleteAllFleetRepos();
-    cy.deleteClusterGroups();
+    cy.executeKubectlCommand(removeClusterGroupCommand);
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
@@ -764,10 +730,6 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
             cy.get('td.col-link-detail > span').contains("mp-app-config").click();
           })
         }
-
-        // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-        cy.wait(1000);
-        cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })
 });

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -170,7 +170,7 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
 describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
   let repoName
 
-  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+  beforeEach('Cleanup leftover GitRepo, ClusterGroup etc. if any.', () => {
     cy.deleteAllFleetRepos();
     cy.deleteClusterGroups();
   })
@@ -377,7 +377,7 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
 
 describe('Test multiple applications deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
 
-  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+  beforeEach('Cleanup leftover GitRepo if any.', () => {
     cy.deleteAllFleetRepos();
   })
 
@@ -436,9 +436,9 @@ describe('Test multiple applications deployment based on clusterGroup', { tags: 
 describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_2'}, () => {
   let gitRepoFile
 
-  beforeEach('Cleanup leftover GitRepo if any.', () => {
-
+  beforeEach('Remove labels from all clusters.', () => {
     // Remove labels from the clusters.
+    cy.accesMenuSelection('local');
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
 
@@ -466,6 +466,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
     it(qase(qase_id, `Fleet-${qase_id}: Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`), { tags: `@fleet-${qase_id}` }, () => {
         // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.accesMenuSelection('local');
         cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         cy.continuousDeliveryMenuSelection();
@@ -534,6 +535,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         }
 
         // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.accesMenuSelection('local');
         cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })
@@ -541,11 +543,11 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   it(qase(19, "Fleet-19: Test remove label from cluster-2 to remove application from it when application deployed using clusterSelector(matchLabels)"), { tags: '@fleet-19' }, () => {
       gitRepoFile = 'assets/git-repo-multiple-app-cluster-selector.yaml'
 
-      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-      cy.contains('.title', 'Clusters').should('be.visible');
-
       // Assign label to the clusters using kubectl command in terminal.
       cy.executeKubectlCommand(labelFirstTwoImportedClusters);
+
+      cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+      cy.contains('.title', 'Clusters').should('be.visible');
 
       // Create a GitRepo targeting cluster group created from YAML.
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -430,6 +430,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
   let gitRepoFile
 
   beforeEach('Cleanup leftover GitRepo if any.', () => {
+
     // Remove labels from the clusters.
     cy.executeKubectlCommand(removeLabelFromAllClusters);
   })
@@ -582,8 +583,6 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
       }
       else {
         const repoName = 'default-multiple-apps-cluster-selector'
-        const new_key = 'key_third_cluster'
-        const new_value = 'value_third_cluster'
 
         gitRepoFile = 'assets/git-repo-multiple-app-cluster-selector.yaml'
 

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -426,6 +426,7 @@ describe('Test multiple applications deployment based on clusterGroup', { tags: 
       })
 
       // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.wait(1000);
       cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       cy.deleteClusterGroups();
     }
@@ -464,12 +465,12 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
     it(qase(qase_id, `Fleet-${qase_id}: Test install ${test_explanation} using clusterSelector(matchLabels) in GitRepo`), { tags: `@fleet-${qase_id}` }, () => {
+        // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         cy.continuousDeliveryMenuSelection();
         cy.clickNavMenu(['Clusters']);
         cy.contains('.title', 'Clusters').should('be.visible');
-        // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-        cy.executeKubectlCommand(labelFirstTwoImportedClusters);
 
         // Get GitRepo YAML file according to test.
         if (qase_id === 9 || qase_id === 20) {
@@ -592,11 +593,11 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
         gitRepoFile = 'assets/git-repo-multiple-app-cluster-selector.yaml'
 
-        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-        cy.contains('.title', 'Clusters').should('be.visible');
-
         // Assign label to the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
         cy.executeKubectlCommand(labelFirstTwoImportedClusters);
+
+        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+        cy.contains('.title', 'Clusters').should('be.visible');
 
         // Create a GitRepo targeting cluster selector created from YAML.
         if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
@@ -681,11 +682,11 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
   clusterSelector.forEach(({ qase_id, app, test_explanation, bundle_count }) => {
     it(qase(qase_id, `Fleet-${qase_id}: Test install ${test_explanation}  cluster using "clusterGroupSelector"`), { tags: `@fleet-${qase_id}` }, () => {
 
-        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-        cy.contains('.title', 'Clusters').should('be.visible');
-
         // Assign label to the first 2 clusters i.e. imported-0 and imported-1
         cy.executeKubectlCommand(labelFirstTwoImportedClusters);
+
+        cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+        cy.contains('.title', 'Clusters').should('be.visible');
 
         // Create group of cluster consists of same label.
         cy.clickNavMenu(['Cluster Groups']);
@@ -760,6 +761,7 @@ describe("Test Application deployment based on 'clusterGroupSelector'", { tags: 
         }
 
         // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+        cy.wait(1000);
         cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
       })
   })

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1205,19 +1205,13 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
 
   const key = "key_resources"
   const value = "deploy_true"
+  const addDeployLabelToAllClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name in (${dsAllClusterList.join(',')})' ${key}=${value} {enter}`
+  const removeDeployLabelFromAllClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+    'management.cattle.io/cluster-display-name in (${dsAllClusterList.join(',')})' ${key}- {enter}`
 
   beforeEach('Cleanup leftover Cluster labels if any.', () => {
-    cy.login();
-    cy.visit('/');
-    // Remove labels from the clusters.
-    cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-    dsAllClusterList.forEach(
-      (dsCluster) => {
-        // Adding wait to load page correctly to avoid interference with hamburger-menu.
-        cy.wait(500);
-        cy.removeClusterLabels(dsCluster, key, value);
-      }
-    )
+    cy.executeKubectlCommand(removeDeployLabelFromAllClusters);
   })
 
   it(qase(88, "Fleet-88: Test bundle did not get deployed when 'doNotDeploy' value set to `true` option is used in the 'fleet.yaml' file."), { tags: '@fleet-88' }, () => {
@@ -1230,12 +1224,9 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
         gitRepoWord = "GitRepo"
       }
 
-      // Assign label (similar to label mentioned in fleet.yaml file.) to All the clusters
-      dsAllClusterList.forEach(
-        (dsCluster) => {
-          cy.assignClusterLabel(dsCluster, key, value);
-        }
-      )
+      // Assign label (similar to label mentioned in fleet.yaml file.) to all the clusters
+      // i.e. imported-0, imported-1 and imported-2 using kubectl command in terminal.
+      cy.executeKubectlCommand(addDeployLabelToAllClusters);
 
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
@@ -1253,9 +1244,6 @@ describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.'
           cy.checkApplicationStatus("nginx-donot-deploy", dsCluster, 'All Namespaces', false);
         }
       )
-
-      cy.deleteAllFleetRepos();
-
     })
 });
 
@@ -1277,9 +1265,6 @@ describe('Test Fleet `doNotDeploy: false` will deploy resources to all clusters.
           cy.checkApplicationStatus("nginx-donot-deploy", dsCluster, 'All Namespaces');
         }
       )
-
-      cy.deleteAllFleetRepos();
-
     })
 });
 

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -168,7 +168,6 @@ describe('Test GitRepo Bundle name validation and max character trimming behavio
 });
 
 describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
-  const value = 'value_prod'
   let repoName
 
   beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
@@ -352,9 +351,8 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       cy.accesMenuSelection('Continuous Delivery', 'Clusters');
       cy.contains('.title', 'Clusters').should('be.visible');
 
-      // Remove label from the Second cluster i.e. imported-1
-      cy.wait(500);
-      cy.removeClusterLabels(dsSecondClusterName, key, value);
+      // Remove label from the Second cluster i.e. imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelSecondImportedCluster);
 
       // Check application is absent i.e. removed from second cluster i.e. imported-1
       cy.checkApplicationStatus(appName, dsSecondClusterName, 'All Namespaces', false);

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -392,6 +392,7 @@ describe('Test multiple applications deployment based on clusterGroup', { tags: 
       cy.continuousDeliveryMenuSelection();
       cy.clickNavMenu(['Cluster Groups']);
       cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.fleetNamespaceToggle('fleet-default');
       cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
 
       // Create a GitRepo targeting cluster group created.
@@ -472,6 +473,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
         cy.continuousDeliveryMenuSelection();
         cy.clickNavMenu(['Clusters']);
         cy.contains('.title', 'Clusters').should('be.visible');
+        cy.fleetNamespaceToggle('fleet-default');
 
         // Get GitRepo YAML file according to test.
         if (qase_id === 9 || qase_id === 20) {
@@ -548,6 +550,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
       cy.accesMenuSelection('Continuous Delivery', 'Clusters');
       cy.contains('.title', 'Clusters').should('be.visible');
+      cy.fleetNamespaceToggle('fleet-default');
 
       // Create a GitRepo targeting cluster group created from YAML.
       if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
@@ -600,6 +603,7 @@ describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_
 
         cy.accesMenuSelection('Continuous Delivery', 'Clusters');
         cy.contains('.title', 'Clusters').should('be.visible');
+        cy.fleetNamespaceToggle('fleet-default');
 
         // Create a GitRepo targeting cluster selector created from YAML.
         if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -257,57 +257,6 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
     }
   )
 
-  it(qase(26, "Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'"), { tags: '@fleet-26' }, () => {
-      const repoName = 'default-single-app-cluster-group-26'
-      const path2 = 'multiple-paths/config'
-
-      // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
-
-      // Create group of cluster consists of same label.
-      cy.continuousDeliveryMenuSelection();
-      cy.clickNavMenu(['Cluster Groups']);
-      cy.contains('.title', 'Cluster Groups').should('be.visible');
-      cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
-
-      // Create a GitRepo targeting cluster group created.
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.clickNavMenu(['Resources']);
-        cy.clickNavMenu(['Git Repos']);
-        cy.wait(1000);
-        cy.clickButton('Add Repository');
-        cy.wait(1000);
-        cy.clickButton('Edit as YAML');
-        cy.addYamlFile('assets/cluster-group-tests/clusterGroupMultipleApps.yaml');
-      }
-      else {
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, path2, deployToTarget: clusterGroupName });
-      }
-      cy.clickButton('Create');
-      cy.checkGitRepoStatus(repoName, '2 / 2');
-
-      // Check first application status on both clusters i.e. imported-0 and imported-1
-      dsFirstTwoClusterList.forEach((dsCluster) => {
-        cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-      })
-
-      dsFirstTwoClusterList.forEach((dsCluster) => {
-        // Check second application status on both clusters i.e. imported-0 and imported-1
-        // Adding wait to load page correctly to avoid interference with hamburger-menu.
-        cy.wait(500);
-        cy.accesMenuSelection(dsCluster, "Storage", "ConfigMaps");
-        cy.nameSpaceMenuToggle("test-fleet-mp-config");
-        cy.filterInSearchBox("mp-app-config");
-        cy.get('td.col-link-detail > span').contains("mp-app-config").click();
-      })
-
-      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
-      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
-      cy.deleteClusterGroups();
-    }
-  )
-  
-
   it(qase(28, "Fleet-28: Test remove existing application from cluster-2 by removing it from an existing 'clusterGroup'"), { tags: '@fleet-28' }, () => {
       let repoName
       repoName = 'default-single-app-cluster-group-28'
@@ -424,6 +373,63 @@ describe('Test application deployment based on clusterGroup', { tags: ['@p1_2', 
       cy.deleteClusterGroups();
     })
   }
+});
+
+describe('Test multiple applications deployment based on clusterGroup', { tags: ['@p1_2', '@pr-tests'] }, () => {
+
+  beforeEach('Cleanup leftover GitRepo, ClusterGroup or label etc. if any.', () => {
+    cy.deleteAllFleetRepos();
+  })
+
+  it(qase(26, "Fleet-26: Test install multiple applications to the all defined clusters in the 'clusterGroup'"), { tags: '@fleet-26' }, () => {
+      const repoName = 'default-single-app-cluster-group-26'
+      const path2 = 'multiple-paths/config'
+
+      // Assign label to the first 2 clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(labelFirstTwoImportedClusters);
+
+      // Create group of cluster consists of same label.
+      cy.continuousDeliveryMenuSelection();
+      cy.clickNavMenu(['Cluster Groups']);
+      cy.contains('.title', 'Cluster Groups').should('be.visible');
+      cy.createClusterGroup(clusterGroupName, key, value, bannerMessageToAssert);
+
+      // Create a GitRepo targeting cluster group created.
+      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
+        cy.clickNavMenu(['Resources']);
+        cy.clickNavMenu(['Git Repos']);
+        cy.wait(1000);
+        cy.clickButton('Add Repository');
+        cy.wait(1000);
+        cy.clickButton('Edit as YAML');
+        cy.addYamlFile('assets/cluster-group-tests/clusterGroupMultipleApps.yaml');
+      }
+      else {
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, path2, deployToTarget: clusterGroupName });
+      }
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '2 / 2');
+
+      // Check first application status on both clusters i.e. imported-0 and imported-1
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
+      })
+
+      dsFirstTwoClusterList.forEach((dsCluster) => {
+        // Check second application status on both clusters i.e. imported-0 and imported-1
+        // Adding wait to load page correctly to avoid interference with hamburger-menu.
+        cy.wait(500);
+        cy.accesMenuSelection(dsCluster, "Storage", "ConfigMaps");
+        cy.nameSpaceMenuToggle("test-fleet-mp-config");
+        cy.filterInSearchBox("mp-app-config");
+        cy.get('td.col-link-detail > span').contains("mp-app-config").click();
+      })
+
+      // Remove labels from the clusters i.e. imported-0 and imported-1 using kubectl command in terminal.
+      cy.executeKubectlCommand(removeLabelFirstTwoImportedClusters);
+      cy.deleteClusterGroups();
+    }
+  )
 });
 
 describe("Test Application deployment based on 'clusterSelector'", { tags: '@p1_2'}, () => {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -419,20 +419,8 @@ Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2,
 // Namespace Toggle
 Cypress.Commands.add('nameSpaceMenuToggle', (namespaceName) => {
   cy.get('.top > .ns-filter').should('be.visible');
-
-  // For some reason I don't understand, click force doesn't work
-  // in 2.10 an onwards, but it is mandatory for earlier versions
-  // To be improved in the future
-  const old_versions = ["latest/devel/2.7", "latest/devel/2.8", "latest/devel/2.9"];
-
-  if (old_versions.includes(rancherVersion)) {
-    cy.log('Rancher version is: ' + rancherVersion , 'Clicking WITH force:true');
-    cy.get('.top > .ns-filter').click({ force: true });
-  }
-  else  {
-    cy.log('Rancher version is: ' + rancherVersion, 'Clicking WITHOUT force:true');
-    cy.get('.top > .ns-filter').click();
-  }
+  cy.log('Rancher version is: ' + rancherVersion, 'Clicking WITHOUT force:true');
+  cy.get('.top > .ns-filter').click();
   cy.get('div.ns-item').contains(namespaceName).scrollIntoView()
   cy.get('div.ns-item').contains(namespaceName).click()
   cy.get('div.ns-dropdown.ns-open > i.icon.icon-chevron-up').click({ force: true });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -1330,9 +1330,9 @@ Cypress.Commands.add('deleteDownstreamCluster', (clusterName, deleteOption=false
   }
 );
 
-Cypress.Commands.add('executeKubectlCommand', (labelCommand) => {
+Cypress.Commands.add('executeKubectlCommand', (labelCommand, clusterName='local') => {
   // Open local terminal in Rancher UI
-  cy.accesMenuSelection('local');
+  cy.accesMenuSelection(clusterName);
   cy.get('#btn-kubectl').click();
   cy.contains('Connected').should('be.visible');
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -1341,3 +1341,18 @@ Cypress.Commands.add('deleteDownstreamCluster', (clusterName, deleteOption=false
 
   }
 );
+
+Cypress.Commands.add('executeKubectlCommand', (labelCommand) => {
+  // Open local terminal in Rancher UI
+  cy.accesMenuSelection('local');
+  cy.get('#btn-kubectl').click();
+  cy.contains('Connected').should('be.visible');
+
+  // Simulate typing the kubectl command to assign label to the cluster in the terminal
+  cy.typeIntoCanvasTermnal(labelCommand);
+  cy.wait(500);
+
+  // Close local terminal
+  cy.get('i.closer.icon').click();
+  }
+);

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -82,7 +82,7 @@ declare global {
       deleteDownstreamCluster(clusterName: string, deleteOption?: boolean): Chainable<Element>;
       addHelmOp(fleetNamespace: string?, repoName: string, repoUrl: string, chart: string, version?: string, values?: string, deployTo?: string, serviceAccountName?: string, targetNamespace?: string, helmAuth?: string): Chainable<Element>;
       addFleetRepoFromYaml(yamlFilePath: string, fleetNamespace?: string): Chainable<Element>;
-      
+      executeKubectlCommand(labelCommand: string): Chainable<Element>;
     }
   }
 }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -82,7 +82,7 @@ declare global {
       deleteDownstreamCluster(clusterName: string, deleteOption?: boolean): Chainable<Element>;
       addHelmOp(fleetNamespace: string?, repoName: string, repoUrl: string, chart: string, version?: string, values?: string, deployTo?: string, serviceAccountName?: string, targetNamespace?: string, helmAuth?: string): Chainable<Element>;
       addFleetRepoFromYaml(yamlFilePath: string, fleetNamespace?: string): Chainable<Element>;
-      executeKubectlCommand(labelCommand: string): Chainable<Element>;
+      executeKubectlCommand(labelCommand: string,clusterName?: string): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
- Update assigning of labels to the cluster via kubectl way.
- This will reduce the extra traversal between clusters for assignment and removal of cluster labels.