### PR TITLE
Fleetqa/improve artifact and qase upload logic

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -449,7 +449,7 @@ jobs:
           name: webhook-setup-log-${{ inputs.cluster_name }}
           path: tests/assets/webhook-tests/webhook_setup.log
       - name: Add summary
-        if: ${{ failure() || cancelled() }}
+        if: ${{ always() }}
         run: |
           echo "## General information" >> ${GITHUB_STEP_SUMMARY}
           echo -e "***${{ inputs.test_description }}***\n" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -465,10 +465,10 @@ jobs:
           echo "### Kubernetes" >> ${GITHUB_STEP_SUMMARY}
           echo "K3s version for Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
           echo "K3d version for downstream cluster: ${{ env.INSTALL_K3S_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
-          if ${{ inputs.hardening != '' }}; then
+          if [[ -n "${{ inputs.hardening }}" ]]; then
             echo "Version for HARDENING upstream cluster: ${{ env.INSTALL_HARDENED_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
           fi
-          if ${{ inputs.rancher_upgrade != '' }}; then
+          if [[ -n "${{ inputs.rancher_upgrade }}" ]]; then
             echo "### Rancher Manager Upgrade Information" >> ${GITHUB_STEP_SUMMARY}
             echo "Rancher Manager Installed Version: ${{ steps.component.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Rancher Manager Upgraded Version: ${{ steps.upgraded_component.outputs.rm_upgraded_version }}" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -321,7 +321,7 @@ jobs:
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cypress-screenshots-basics-${{ inputs.cluster_name }}
@@ -330,7 +330,7 @@ jobs:
           if-no-files-found: ignore
       - name: Upload Cypress videos (Basics)
         # Test run video is always captured, so this action uses "always()" condition
-        if: always()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cypress-videos-basics-${{ inputs.cluster_name }}
@@ -449,7 +449,7 @@ jobs:
           name: webhook-setup-log-${{ inputs.cluster_name }}
           path: tests/assets/webhook-tests/webhook_setup.log
       - name: Add summary
-        if: ${{ always() }}
+        if: ${{ failure() || cancelled() }}
         run: |
           echo "## General information" >> ${GITHUB_STEP_SUMMARY}
           echo -e "***${{ inputs.test_description }}***\n" >> ${GITHUB_STEP_SUMMARY}
@@ -524,6 +524,8 @@ jobs:
               --url https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete \
               -H "Token: ${{ secrets.qase_api_token }}" \
               -H 'accept: application/json'
+            echo -e "\n### QASE Report" >> ${GITHUB_STEP_SUMMARY}
+            echo "View the detailed report [here](https://app.qase.io/run/FLEET/dashboard/${RUN_ID})" >> ${GITHUB_STEP_SUMMARY}
           fi
           echo "QASE run $RUN_ID marked as Completed" >> ${GITHUB_STEP_SUMMARY}
           


### PR DESCRIPTION
Enhanced the logic after qase rework:

- Artifacts are now only uploaded when test fails
- Report is always displayed
- Refactor on reporting part in Hardening to avoid possible issues.

Tests:

- [Case 1:](https://github.com/rancher/fleet-e2e/actions/runs/25369509764) Single test failure -> Report on CI and QASE  generated + Artifact uploaded
- [Case 2:](https://github.com/rancher/fleet-e2e/actions/runs/25369534428) Single test success -> Report on CI and QASE  generated (but no artifact uploaded)
- [Case 3](https://github.com/rancher/fleet-e2e/actions/runs/25369525860) -> Test interrupted -> Report on CI generated, artifact generated,  QASE generated (on the completed test only, in this case login, but not p0; this is ok behavior)