### PR TITLE
Update test for Private Helm Repository to check for 401 error code

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -207,7 +207,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       })
   });
 
-  describe.only('Private Helm Repository tests (helmRepoURLRegex)', { tags: ['@p1', '@pr-tests'] }, () => {
+  describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: ['@p1', '@pr-tests'] }, () => {
 
     const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'
     const branch = 'main'

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -207,7 +207,7 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
       })
   });
 
-  describe('Private Helm Repository tests (helmRepoURLRegex)', { tags: ['@p1', '@pr-tests'] }, () => {
+  describe.only('Private Helm Repository tests (helmRepoURLRegex)', { tags: ['@p1', '@pr-tests'] }, () => {
 
     const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public.git'
     const branch = 'main'
@@ -266,7 +266,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
             helmUrlRegex = '1234.*'
             cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex, local: true });
             cy.clickButton('Create');
-            cy.get('.text-error', { timeout: 120000 }).should('contain', 'code: 401');
+            cy.get('.text-error', { timeout: 120000 }).should('contain', '401');
+
             cy.deleteAllFleetRepos();
           })
       })


### PR DESCRIPTION
### Issue

For some reason in the outcome of test 65 in fleet 0.16 there is a new outcome. Instead of `code: 401` there is `status 401`

<img width="2517" height="1189" alt="2026-May- 5_18-45" src="https://github.com/user-attachments/assets/3f7a47f0-2fb6-417f-ab07-b0928bbc2718" />

<img width="1205" height="800" alt="image" src="https://github.com/user-attachments/assets/72924d4f-539c-410e-a363-68ca0f6faa92" />


A simple update on the text, solves the issue on test 65 in 2.15:

<img width="2517" height="1189" alt="2026-May- 5_18-54" src="https://github.com/user-attachments/assets/201f6d90-4ed8-4209-995b-94add3e19788" />