### PR TITLE
Refactor GitRepo state tests to include cleanup and clarify diff usage in fleet.yaml

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1568,9 +1568,13 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
     })
 });
 
-describe('Test GitRepo shows Active state for missing resources when `diff` used in `fleet.yaml`', { tags: '@p1_2' }, () => {
+describe('Test GitRepo state for missing resources with and without `diff` used in `fleet.yaml`', { tags: '@p1_2' }, () => {
 
-  it(qase(179, `FLEET-179: Test GitRepo shows Active state for missing resources when 'diff' used in 'fleet.yaml'`), { tags: '@fleet-179'}, () => {
+  beforeEach('Cleanup leftover GitRepo if any.', () => {
+    cy.deleteAllFleetRepos();
+  });
+
+  it(qase(179, `FLEET-179: Test GitRepo shows 'Modified' state for missing resources without using 'diff' in 'fleet.yaml'`), { tags: '@fleet-179'}, () => {
       const repoName = 'ds-cluster-fleet-179'
       const pathWithoutDiff = 'qa-test-apps/ignore-missing-resources/without-diff'
 
@@ -1582,18 +1586,21 @@ describe('Test GitRepo shows Active state for missing resources when `diff` used
       cy.verifyTableRow(0, 'Modified', repoName);
       cy.checkGitRepoStatus(repoName, '0 / 1', '3 / 6', { repoStatus: 'Modified' });
 
-      // Update Path which has diff mentioned in the fleet.yaml
-      // On both Path data is same the only difference is diff part.
+})
+
+  it(qase(339, `FLEET-339: Test GitRepo shows 'Active' state for missing resources when using 'diff' in 'fleet.yaml'`), { tags: '@fleet-339'}, () => {
+      const repoName = 'ds-cluster-fleet-339'
       const pathWithDiff = 'qa-test-apps/ignore-missing-resources/with-diff'
 
-      cy.addFleetGitRepo({ repoName, path: pathWithDiff, fleetNamespace: 'fleet-default', editConfig: true });
-      cy.clickButton('Save');
+      // Create GitRepo with diff which will ignore missing resources.
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.continuousDeliveryMenuSelection()
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path: pathWithDiff });
+      cy.clickButton('Create');
       cy.verifyTableRow(0, 'Active', repoName);
       cy.checkGitRepoStatus(repoName, '1 / 1', '6 / 6');
 
-      // Delete GitRepo
-      cy.deleteAllFleetRepos();
-    })
+  })
 })
 
 describe('Test bundle deploy with overrideTargets by label availability on clusters.', { tags: '@p1_2'}, () => {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1570,10 +1570,6 @@ describe('Test helm chart dependency download with `disableDependencyUpdate: tru
 
 describe('Test GitRepo state for missing resources with and without `diff` used in `fleet.yaml`', { tags: '@p1_2' }, () => {
 
-  beforeEach('Cleanup leftover GitRepo if any.', () => {
-    cy.deleteAllFleetRepos();
-  });
-
   it(qase(179, `FLEET-179: Test GitRepo shows 'Modified' state for missing resources without using 'diff' in 'fleet.yaml'`), { tags: '@fleet-179'}, () => {
       const repoName = 'ds-cluster-fleet-179'
       const pathWithoutDiff = 'qa-test-apps/ignore-missing-resources/without-diff'


### PR DESCRIPTION
### Problem
- Currently, Fleet-179 test implementation:
  - Creates a GitRepo with fleet.yaml which doesn't contains `diff` section.
  - This results GitRepo state in `Modified` state.
  - After updating GitRepo path by pointing to fleet.yaml containing `diff` section.
  - GitRepo changes it's state from `Modified` to `Active`.

Sometimes GitRepo takes ample amount of time to reconcile and consume newly 

### Solution
- Separate checks in 2 tests.
