### PR TITLE
Fleetqa/4995 update ci to test webhook with ghcli

### DIFF
--- a/.github/scripts/install-git-helm-4.sh
+++ b/.github/scripts/install-git-helm-4.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script is used to install git and helm 4.
+# This script is used to install git, helm 4, and GitHub CLI.
 
 set -euo pipefail
 
@@ -11,6 +11,18 @@ HELM_SUM_amd64="02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
 
 # Install git
 sudo zypper -n install --no-recommends git
+
+# Install GitHub CLI (gh)
+echo "Installing GitHub CLI..."
+if ! command -v gh &> /dev/null; then
+  # Add official GitHub CLI repository for openSUSE/SLES
+  sudo zypper -n addrepo https://cli.github.com/packages/rpm/gh-cli.repo
+  sudo zypper -n --gpg-auto-import-keys refresh
+  sudo zypper -n install --no-recommends gh
+  echo "GitHub CLI installed: $(gh --version | head -n1)"
+else
+  echo "GitHub CLI already installed: $(gh --version | head -n1)"
+fi
 
 # Download Helm
 curl -sSfL \

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -223,7 +223,7 @@ jobs:
         run: echo "/usr/local/bin/" >> ${GITHUB_PATH}
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install latest helm-4 on runner
+      - name: Install git, helm-4, and gh CLI on runner
         run: |
           pwd
           ls -a

--- a/tests/assets/webhook-tests/webhook_setup.sh
+++ b/tests/assets/webhook-tests/webhook_setup.sh
@@ -30,53 +30,15 @@ sed -i "s/{{EXTERNAL_IP}}/${EXTERNAL_IP}/g" assets/webhook-tests/webhook_ingress
 echo "Current directory: $(pwd)"
 echo "PATH: $PATH"
 
-# Install gh CLI if not available
+# Verify gh CLI is available (should be mounted from host)
 if ! command -v gh &> /dev/null; then
-  echo "gh CLI not found, installing..."
-
-  # Detect OS and install accordingly
-  if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    case "$ID" in
-      opensuse*|sles)
-        echo "Installing gh CLI on openSUSE/SLES..."
-        # Add official GitHub CLI repository for openSUSE/SLES
-        # Using official repo with GPG signature verification via zypper
-        sudo zypper -n addrepo https://cli.github.com/packages/rpm/gh-cli.repo
-        sudo zypper -n --gpg-auto-import-keys refresh
-        sudo zypper -n install --no-recommends gh
-        ;;
-      ubuntu|debian)
-        echo "Installing gh CLI on Ubuntu/Debian..."
-        # Using official GitHub CLI repository with GPG keyring verification
-        # Using wget instead of curl for better compatibility in minimal environments
-        wget --quiet -O - https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt-get update
-        sudo apt-get install -y gh
-        ;;
-      *)
-        echo "Error: Unsupported OS '$ID' for automatic gh CLI installation"
-        echo "Please install gh CLI manually from: https://github.com/cli/cli/releases"
-        echo "Or use a supported OS (openSUSE, SLES, Ubuntu, Debian)"
-        exit 1
-        ;;
-    esac
-  else
-    echo "Error: Cannot detect OS to install gh CLI"
-    echo "Please install gh CLI manually from: https://github.com/cli/cli/releases"
-    exit 1
-  fi
-
-  # Verify installation
-  if ! command -v gh &> /dev/null; then
-    echo "Error: gh CLI installation failed"
-    exit 1
-  fi
-
-  echo "gh CLI installed successfully (version: $(gh --version | head -n1))"
+  echo "Error: gh CLI not found"
+  echo "gh CLI should be installed on the host and mounted into the container"
+  echo "Please ensure gh is installed on the GCP runner"
+  exit 1
 fi
+
+echo "Using gh CLI: $(gh --version | head -n1)"
 
 # Set GH_TOKEN from GH_PRIVATE_PWD for gh CLI authentication
 # This avoids passing tokens in command-line arguments

--- a/tests/assets/webhook-tests/webhook_setup.sh
+++ b/tests/assets/webhook-tests/webhook_setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -exo pipefail
+set -eo pipefail
 
-# Redirect all output to a log file
+# Redirect all output to a log file (excluding sensitive commands)
 exec > >(tee -i $PWD/assets/webhook-tests/webhook_setup.log)
 exec 2>&1
 
@@ -10,8 +10,11 @@ exec 2>&1
 export REPO_OWNER="fleetqa"
 export REPO_NAME="webhook-github-test"
 export SECRET_VALUE="webhooksecretvalue"
+
 # Get the external IP of the Google Cloud instance
-export EXTERNAL_IP=$(wget --quiet --header="Metadata-Flavor: Google" -O - http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip) 
+# Using wget as curl may not be available in minimal GCP environments
+export EXTERNAL_IP=$(wget --quiet --header="Metadata-Flavor: Google" -O - \
+  http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
 echo "External IP: ${EXTERNAL_IP}"
 
 # Confirm the external IP is not empty
@@ -27,26 +30,98 @@ sed -i "s/{{EXTERNAL_IP}}/${EXTERNAL_IP}/g" assets/webhook-tests/webhook_ingress
 echo "Current directory: $(pwd)"
 echo "PATH: $PATH"
 
-# Delete any previous webhook
-# 1 - Get all webhooks
-webhooks=$(wget --quiet --header="Authorization: Bearer ${GH_PRIVATE_PWD}" \
- -O - https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/hooks)
+# Install gh CLI if not available
+if ! command -v gh &> /dev/null; then
+  echo "gh CLI not found, installing..."
 
-# 2- Extract webhook IDs and delete each one
-echo "$webhooks" | grep -o '"id": *[0-9]*' | awk -F ': ' '{print $2}' | while read webhook_id; do
-  echo "Deleting webhook ID: $webhook_id"
-  wget --quiet --method=DELETE --header="Authorization: Bearer ${GH_PRIVATE_PWD}" \
-  -O - https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/hooks/${webhook_id}
+  # Detect OS and install accordingly
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+      opensuse*|sles)
+        echo "Installing gh CLI on openSUSE/SLES..."
+        # Add official GitHub CLI repository for openSUSE/SLES
+        # Using official repo with GPG signature verification via zypper
+        sudo zypper -n addrepo https://cli.github.com/packages/rpm/gh-cli.repo
+        sudo zypper -n --gpg-auto-import-keys refresh
+        sudo zypper -n install --no-recommends gh
+        ;;
+      ubuntu|debian)
+        echo "Installing gh CLI on Ubuntu/Debian..."
+        # Using official GitHub CLI repository with GPG keyring verification
+        # Using wget instead of curl for better compatibility in minimal environments
+        wget --quiet -O - https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt-get update
+        sudo apt-get install -y gh
+        ;;
+      *)
+        echo "Error: Unsupported OS '$ID' for automatic gh CLI installation"
+        echo "Please install gh CLI manually from: https://github.com/cli/cli/releases"
+        echo "Or use a supported OS (openSUSE, SLES, Ubuntu, Debian)"
+        exit 1
+        ;;
+    esac
+  else
+    echo "Error: Cannot detect OS to install gh CLI"
+    echo "Please install gh CLI manually from: https://github.com/cli/cli/releases"
+    exit 1
+  fi
+
+  # Verify installation
+  if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI installation failed"
+    exit 1
+  fi
+
+  echo "gh CLI installed successfully (version: $(gh --version | head -n1))"
+fi
+
+# Set GH_TOKEN from GH_PRIVATE_PWD for gh CLI authentication
+# This avoids passing tokens in command-line arguments
+# Handle both uppercase (from workflow) and lowercase (from Cypress) variable names
+if [ -n "${GH_PRIVATE_PWD}" ]; then
+  export GH_TOKEN="${GH_PRIVATE_PWD}"
+elif [ -n "${gh_private_pwd}" ]; then
+  export GH_TOKEN="${gh_private_pwd}"
+else
+  echo "Error: GH_PRIVATE_PWD or gh_private_pwd environment variable not set"
+  exit 1
+fi
+
+# Verify gh CLI authentication
+if ! gh auth status &> /dev/null; then
+  echo "Error: gh CLI authentication failed"
+  exit 1
+fi
+
+echo "Successfully authenticated with GitHub CLI"
+
+# Delete any previous webhooks using gh CLI
+echo "Deleting existing webhooks..."
+gh api "repos/${REPO_OWNER}/${REPO_NAME}/hooks" --jq '.[].id' | while read -r webhook_id; do
+  if [ -n "$webhook_id" ]; then
+    echo "Deleting webhook ID: $webhook_id"
+    gh api --method DELETE "repos/${REPO_OWNER}/${REPO_NAME}/hooks/$webhook_id"
+  fi
 done
 
 echo "All webhooks deleted."
 
 sleep 3 # Adding a bit of sleep to get things to settle
 
-# Create new adhock webhook with the specific Google External IP
-wget --quiet \
-     --method=POST \
-     --header="Authorization: Bearer ${GH_PRIVATE_PWD}" \
-     --header="Content-Type: application/json" \
-     --body-data='{"name":"web","active":true,"events":["push"],"config":{"url":"https://'"${EXTERNAL_IP}"'.nip.io/","content_type":"json","secret":"'"${SECRET_VALUE}"'","insecure_ssl":"1"}}' \
-     -O - https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/hooks
+# Create new webhook with the specific Google External IP using gh CLI
+echo "Creating new webhook..."
+gh api \
+  --method POST \
+  "repos/${REPO_OWNER}/${REPO_NAME}/hooks" \
+  -f name='web' \
+  -F active=true \
+  -f events[]='push' \
+  -f config[url]="https://${EXTERNAL_IP}.nip.io/" \
+  -f config[content_type]='json' \
+  -f config[secret]="${SECRET_VALUE}" \
+  -f config[insecure_ssl]='1'
+
+echo "Webhook created successfully"

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -9,7 +9,7 @@ npm install
 # Mount gh CLI from host if available for webhook tests
 GH_MOUNT=""
 if command -v gh &> /dev/null; then
-  GH_PATH=$(which gh)
+  GH_PATH=$(command -v gh)
   GH_MOUNT="-v ${GH_PATH}:/usr/local/bin/gh:ro"
   echo "Mounting gh CLI from host: ${GH_PATH}"
 fi

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -6,7 +6,15 @@ set -evx
 npm install
 
 # Start Cypress tests with docker
-docker run --init -v $PWD:/workdir -w /workdir              \
+# Mount gh CLI from host if available for webhook tests
+GH_MOUNT=""
+if command -v gh &> /dev/null; then
+  GH_PATH=$(which gh)
+  GH_MOUNT="-v ${GH_PATH}:/usr/local/bin/gh:ro"
+  echo "Mounting gh CLI from host: ${GH_PATH}"
+fi
+
+docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
     -e QASE_API_TOKEN=$QASE_API_TOKEN                       \
     -e QASE_MODE=$QASE_MODE                                 \


### PR DESCRIPTION
Ref: https://github.com/rancher/fleet/issues/4995
Follow up on: https://github.com/rancher/rancher-security/issues/1797#issuecomment-4258725039

Updated CI to use ghcli in our webhook tests as recommended here.

---

Test passing on CI:

- [2.12](https://github.com/rancher/fleet-e2e/actions/runs/25556020841/job/75015237544#step:10:342)
- [2.13](https://github.com/rancher/fleet-e2e/actions/runs/25556120015/job/75015587485?pr=516#step:10:368) (on this pr)
- [2.14](https://github.com/rancher/fleet-e2e/actions/runs/25555459759/job/75013309273#step:10:415)

<img width="1026" height="156" alt="image" src="https://github.com/user-attachments/assets/f6a0a02a-9eb0-46cb-96dc-ebf9e99db7b8" />


