### PR TITLE
Refactor GitRepo bundle creation tests to improve clarity and consolidate assertions

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -947,22 +947,13 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
       cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
       cy.continuousDeliveryBundlesMenu();
 
-      // Verify all expected bundles with Active state in a single query
-      cy.get('table tbody tr').should(($rows) => {
-        const rowTexts = $rows.toArray().map(row => row.textContent);
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-driven-helm')
-        ), 'test-bundle-driven-helm should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-driven-kustomize')
-        ), 'test-bundle-driven-kustomize should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-driven-simple')
-        ), 'test-bundle-driven-simple should be Active').to.be.true;
-      });
+      // Verify all expected bundles
+      cy.filterInSearchBox('test-bundle-driven-helm');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-driven-helm');
+      cy.filterInSearchBox('test-bundle-driven-kustomize');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-driven-kustomize');
+      cy.filterInSearchBox('test-bundle-driven-simple');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-driven-simple');
     });
 
     it(qase(181, "FLEET-181: Test GitRepo creates bundles specified under bundles: with option: field"), { tags: '@fleet-181' }, () => {
@@ -981,26 +972,15 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
       cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
       cy.continuousDeliveryBundlesMenu();
 
-      // Verify all expected bundles with Active state in a single query
-      cy.get('table tbody tr').should(($rows) => {
-        const rowTexts = $rows.toArray().map(row => row.textContent);
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-helm')
-        ), 'test-bundle-dev-prod-driven-helm should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-kustomize-dev')
-        ), 'test-bundle-dev-prod-driven-kustomize-dev should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-kustomize-prod')
-        ), 'test-bundle-dev-prod-driven-kustomize-prod should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-simple')
-        ), 'test-bundle-dev-prod-driven-simple should be Active').to.be.true;
-      });
+      // Verify all expected bundles
+      cy.filterInSearchBox('test-bundle-dev-prod-driven-helm');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-prod-driven-helm');
+      cy.filterInSearchBox('test-bundle-dev-prod-driven-kustomize-dev');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-prod-driven-kustomize-dev');
+      cy.filterInSearchBox('test-bundle-dev-prod-driven-kustomize-prod');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-prod-driven-kustomize-prod');
+      cy.filterInSearchBox('test-bundle-dev-prod-driven-simple');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-prod-driven-simple');
     });
 
     it(qase(182, "FLEET-182: Test update GitRepo by removing prod.yaml from option and verify that prod bundle should not be created."), { tags: '@fleet-182' }, () => {
@@ -1019,22 +999,13 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
       cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
       cy.continuousDeliveryBundlesMenu();
 
-      // Verify all expected bundles with Active state in a single query
-      cy.get('table tbody tr').should(($rows) => {
-        const rowTexts = $rows.toArray().map(row => row.textContent);
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-driven-helm')
-        ), 'test-bundle-dev-driven-helm should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-driven-kustomize-dev')
-        ), 'test-bundle-dev-driven-kustomize-dev should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-driven-simple')
-        ), 'test-bundle-dev-driven-simple should be Active').to.be.true;
-      });
+      // Verify all expected bundles
+      cy.filterInSearchBox('test-bundle-dev-driven-helm');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-driven-helm');
+      cy.filterInSearchBox('test-bundle-dev-driven-kustomize-dev');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-driven-kustomize-dev');
+      cy.filterInSearchBox('test-bundle-dev-driven-simple');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-driven-simple');
     });
 
     it(qase(183, "FLEET-183: Test update GitRepo by adding test.yaml under option and verify that prod bundle should not be created."), { tags: '@fleet-183' }, () => {
@@ -1053,26 +1024,15 @@ describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
       cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
       cy.continuousDeliveryBundlesMenu();
 
-      // Verify all expected bundles with Active state in a single query
-      cy.get('table tbody tr').should(($rows) => {
-        const rowTexts = $rows.toArray().map(row => row.textContent);
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-test-driven-helm')
-        ), 'test-bundle-dev-test-driven-helm should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-test-driven-kustomize-dev')
-        ), 'test-bundle-dev-test-driven-kustomize-dev should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-test-driven-kustomize-test')
-        ), 'test-bundle-dev-test-driven-kustomize-test should be Active').to.be.true;
-
-        expect(rowTexts.some(text =>
-          text.includes('Active') && text.includes('test-bundle-dev-test-driven-simple')
-        ), 'test-bundle-dev-test-driven-simple should be Active').to.be.true;
-      });
+      // Verify all expected bundles
+      cy.filterInSearchBox('test-bundle-dev-test-driven-helm');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-test-driven-helm');
+      cy.filterInSearchBox('test-bundle-dev-test-driven-kustomize-dev');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-test-driven-kustomize-dev');
+      cy.filterInSearchBox('test-bundle-dev-test-driven-kustomize-test');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-test-driven-kustomize-test');
+      cy.filterInSearchBox('test-bundle-dev-test-driven-simple');
+      cy.verifyTableRow(0, 'Active', 'test-bundle-dev-test-driven-simple');
     });
   }
 });

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -929,88 +929,149 @@ describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
 });
 
 describe('Create specified bundles from GitRepo', { tags: '@p1_2' }, () => {
-  const repoTestData: testData[] = [
-    {
-      qase_id: 180,
-      test_name: 'Test GitRepo creates bundles specified under bundles: without option: field',
-      repoName: 'test-bundle',
-      gitrepo_file: 'assets/gitrepo-bundle-create-tests/180-gitrepo-create-bundle.yaml',
-      bundle_count: '3 / 3',
-      resource_count: '12 / 12',
-      expectedBundles: [
-        "test-bundle-driven-helm",
-        "test-bundle-driven-kustomize",
-        "test-bundle-driven-simple",
-      ],
-    },
-    {
-      qase_id: 181,
-      test_name: 'Test GitRepo creates bundles specified under bundles: with option: field',
-      repoName: 'test-bundle-dev-prod',
-      gitrepo_file: 'assets/gitrepo-bundle-create-tests/181-gitrepo-create-dev-prod-bundle.yaml',
-      bundle_count: '4 / 4',
-      resource_count: '15 / 15',
-      expectedBundles: [
-        "test-bundle-dev-prod-driven-helm",
-        "test-bundle-dev-prod-driven-kustomize-dev",
-        "test-bundle-dev-prod-driven-kustomize-prod",
-        "test-bundle-dev-prod-driven-simple",
-      ],
-    },
-    {
-      qase_id: 182,
-      test_name: 'Test update GitRepo by removing prod.yaml from option and verify that prod bundle should not be created.',
-      repoName: 'test-bundle-dev',
-      gitrepo_file: 'assets/gitrepo-bundle-create-tests/182-gitrepo-create-dev-bundle.yaml',
-      bundle_count: '3 / 3',
-      resource_count: '12 / 12',
-      expectedBundles: [
-        "test-bundle-dev-driven-helm",
-        "test-bundle-dev-driven-kustomize-dev",
-        "test-bundle-dev-driven-simple",
-      ],
-    },
-    {
-      qase_id: 183,
-      test_name: 'Test update GitRepo by adding test.yaml under option and verify that prod bundle should not be created.',
-      repoName: 'test-bundle-dev-test',
-      gitrepo_file: 'assets/gitrepo-bundle-create-tests/183-gitrepo-create-dev-test-bundle.yaml',
-      bundle_count: '4 / 4',
-      resource_count: '15 / 15',
-      expectedBundles: [
-        "test-bundle-dev-test-driven-helm",
-        "test-bundle-dev-test-driven-kustomize-dev",
-        "test-bundle-dev-test-driven-kustomize-test",
-        "test-bundle-dev-test-driven-simple",
-      ],
-    },
-  ]
 
   if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-    beforeEach('Cleanup leftover GitRepo', () => {
-      cy.login();
-      cy.visit('/');
-      cy.deleteAllFleetRepos();
-    })
+    it(qase(180, "FLEET-180: Test GitRepo creates bundles specified under bundles: without option: field"), { tags: '@fleet-180' }, () => {
+      const repoName = 'test-bundle';
+      const gitrepo_file = 'assets/gitrepo-bundle-create-tests/180-gitrepo-create-bundle.yaml';
+      const bundle_count = '3 / 3';
+      const resource_count = '12 / 12';
 
-    repoTestData.forEach(({ qase_id, test_name, repoName, gitrepo_file, bundle_count, resource_count, expectedBundles }) => {
-      it(qase(qase_id, `FLEET-${qase_id}: ${test_name}`), { tags: `@fleet-${qase_id}`}, () => {
-        // Create GitRepo
-        cy.continuousDeliveryMenuSelection()
-        cy.clickCreateGitRepo();
-        cy.clickButton('Edit as YAML');
-        cy.wait(1000);
-        cy.addYamlFile(gitrepo_file);
-        cy.clickButton('Create');
-        cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
-        cy.continuousDeliveryBundlesMenu();
-        expectedBundles.forEach((bundle_name: string) => {
-          cy.filterInSearchBox(bundle_name);
-          cy.verifyTableRow(0, 'Active', bundle_name);
-        });
+      // Create GitRepo
+      cy.continuousDeliveryMenuSelection()
+      cy.clickCreateGitRepo();
+      cy.clickButton('Edit as YAML');
+      cy.wait(1000);
+      cy.addYamlFile(gitrepo_file);
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
+      cy.continuousDeliveryBundlesMenu();
 
-        // Delete GitRepo
-        cy.deleteAllFleetRepos();
+      // Verify all expected bundles with Active state in a single query
+      cy.get('table tbody tr').should(($rows) => {
+        const rowTexts = $rows.toArray().map(row => row.textContent);
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-driven-helm')
+        ), 'test-bundle-driven-helm should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-driven-kustomize')
+        ), 'test-bundle-driven-kustomize should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-driven-simple')
+        ), 'test-bundle-driven-simple should be Active').to.be.true;
+      });
+    });
+
+    it(qase(181, "FLEET-181: Test GitRepo creates bundles specified under bundles: with option: field"), { tags: '@fleet-181' }, () => {
+      const repoName = 'test-bundle-dev-prod';
+      const gitrepo_file = 'assets/gitrepo-bundle-create-tests/181-gitrepo-create-dev-prod-bundle.yaml';
+      const bundle_count = '4 / 4';
+      const resource_count = '15 / 15';
+
+      // Create GitRepo
+      cy.continuousDeliveryMenuSelection()
+      cy.clickCreateGitRepo();
+      cy.clickButton('Edit as YAML');
+      cy.wait(1000);
+      cy.addYamlFile(gitrepo_file);
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
+      cy.continuousDeliveryBundlesMenu();
+
+      // Verify all expected bundles with Active state in a single query
+      cy.get('table tbody tr').should(($rows) => {
+        const rowTexts = $rows.toArray().map(row => row.textContent);
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-helm')
+        ), 'test-bundle-dev-prod-driven-helm should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-kustomize-dev')
+        ), 'test-bundle-dev-prod-driven-kustomize-dev should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-kustomize-prod')
+        ), 'test-bundle-dev-prod-driven-kustomize-prod should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-prod-driven-simple')
+        ), 'test-bundle-dev-prod-driven-simple should be Active').to.be.true;
+      });
+    });
+
+    it(qase(182, "FLEET-182: Test update GitRepo by removing prod.yaml from option and verify that prod bundle should not be created."), { tags: '@fleet-182' }, () => {
+      const repoName = 'test-bundle-dev';
+      const gitrepo_file = 'assets/gitrepo-bundle-create-tests/182-gitrepo-create-dev-bundle.yaml';
+      const bundle_count = '3 / 3';
+      const resource_count = '12 / 12';
+
+      // Create GitRepo
+      cy.continuousDeliveryMenuSelection()
+      cy.clickCreateGitRepo();
+      cy.clickButton('Edit as YAML');
+      cy.wait(1000);
+      cy.addYamlFile(gitrepo_file);
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
+      cy.continuousDeliveryBundlesMenu();
+
+      // Verify all expected bundles with Active state in a single query
+      cy.get('table tbody tr').should(($rows) => {
+        const rowTexts = $rows.toArray().map(row => row.textContent);
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-driven-helm')
+        ), 'test-bundle-dev-driven-helm should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-driven-kustomize-dev')
+        ), 'test-bundle-dev-driven-kustomize-dev should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-driven-simple')
+        ), 'test-bundle-dev-driven-simple should be Active').to.be.true;
+      });
+    });
+
+    it(qase(183, "FLEET-183: Test update GitRepo by adding test.yaml under option and verify that prod bundle should not be created."), { tags: '@fleet-183' }, () => {
+      const repoName = 'test-bundle-dev-test';
+      const gitrepo_file = 'assets/gitrepo-bundle-create-tests/183-gitrepo-create-dev-test-bundle.yaml';
+      const bundle_count = '4 / 4';
+      const resource_count = '15 / 15';
+
+      // Create GitRepo
+      cy.continuousDeliveryMenuSelection()
+      cy.clickCreateGitRepo();
+      cy.clickButton('Edit as YAML');
+      cy.wait(1000);
+      cy.addYamlFile(gitrepo_file);
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, bundle_count, resource_count);
+      cy.continuousDeliveryBundlesMenu();
+
+      // Verify all expected bundles with Active state in a single query
+      cy.get('table tbody tr').should(($rows) => {
+        const rowTexts = $rows.toArray().map(row => row.textContent);
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-test-driven-helm')
+        ), 'test-bundle-dev-test-driven-helm should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-test-driven-kustomize-dev')
+        ), 'test-bundle-dev-test-driven-kustomize-dev should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-test-driven-kustomize-test')
+        ), 'test-bundle-dev-test-driven-kustomize-test should be Active').to.be.true;
+
+        expect(rowTexts.some(text =>
+          text.includes('Active') && text.includes('test-bundle-dev-test-driven-simple')
+        ), 'test-bundle-dev-test-driven-simple should be Active').to.be.true;
       });
     });
   }


### PR DESCRIPTION
### Problem
 
- Currently, bundle tests consists of major loop around tests.
- There is also one validation loop which is required.
- Also, multiple `deleteGitRepo()` which causes extra loop.

### Solution
- Separate tests will lower the looping.
- ~Only test has validation loop.~
- Remove of `deleteGitRepo()` will reduce extra time in loop.
- Only single query to Table and each bundle gets asserted with it's state i.e. `Active`.
