### PR TITLE
Adapting tests for helmRepoURLRegex enforcement

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -215,20 +215,20 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
     const pwdOrPrivateKey = 'password'
     const gitOrHelmAuth = 'Helm'
     const gitAuthType = "http"
-    let helmUrlRegex
+    let helmRepoURLRegex
 
     const privateHelmData: testData[] = [
       { qase_id: 64,
         repoName: "local-private-helm-repo-64",
         path: 'helm-urlregex-repo',
         test_explanation: 'repo',
-        helmUrlRegex_matching: '^http.*',
+        helmRepoURLRegex_matching: '^http.*',
       },
       { qase_id: 65,
         repoName: "local-private-helm-chart-65",
         path: 'helm-urlregex-chart',
         test_explanation: 'chart',
-        helmUrlRegex_matching: '^http.*app.*tgz$',
+        helmRepoURLRegex_matching: '^http.*app.*tgz$',
       },
     ]
 
@@ -242,17 +242,17 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
     });
 
     privateHelmData.forEach(
-      ({qase_id, repoName, path, helmUrlRegex_matching, test_explanation}) => {
+      ({qase_id, repoName, path, helmRepoURLRegex_matching, test_explanation}) => {
         it(qase(qase_id, `Fleet-${qase_id}: Test private helm registries for \"helmRepoURLRegex\" matches with \"${test_explanation}\" URL specified in fleet.yaml file`), { tags: `@fleet-${qase_id}` }, () => {;
-            
-            // Adding wait for mitigation of intermittent failures due to slow communication with helm registry 
+
+            // Adding wait for mitigation of intermittent failures due to slow communication with helm registry
             // and also to make sure previous test's resources are deleted and not interfering with current test.
-            
+
             cy.wait(5000);
 
             // Positive test using matching regex
-            helmUrlRegex = helmUrlRegex_matching
-            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex, local: true });
+            helmRepoURLRegex = helmRepoURLRegex_matching
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmRepoURLRegex, local: true });
             cy.clickButton('Create');
             cy.verifyTableRow(0, 'Active', /([1-9]\d*)\/\1/);
             cy.accesMenuSelection('local', 'Storage', 'ConfigMaps');
@@ -263,8 +263,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
             cy.get('section#data').should('contain', 'sample-cm').and('contain', 'sample-data-inside');
             cy.deleteAllFleetRepos();
             // Negative test using non-matching regex 1234.*
-            helmUrlRegex = '1234.*'
-            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex, local: true });
+            helmRepoURLRegex = '1234.*'
+            cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmRepoURLRegex, local: true });
             cy.clickButton('Create');
             cy.get('.text-error', { timeout: 120000 }).should('contain', '401');
 
@@ -300,9 +300,10 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         const gitAuthType = "http"
         const userOrPublicKey = Cypress.expose("gh_private_user")
         const pwdOrPrivateKey = Cypress.expose("gh_private_pwd")
-    
+        const helmRepoURLRegex = '^oci://ghcr\\.io/.*'
+
         cy.fleetNamespaceToggle('fleet-default');
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey});
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmRepoURLRegex});
         cy.clickButton('Create');
         cy.verifyTableRow(0, 'Active', /([1-9]\d*)\/\1/);
         cy.accesMenuSelection(dsFirstClusterName, 'Storage', 'ConfigMaps');

--- a/tests/cypress/fixtures/assets/git-repo-oci-127-with-helm-regex.yaml
+++ b/tests/cypress/fixtures/assets/git-repo-oci-127-with-helm-regex.yaml
@@ -1,0 +1,24 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: default-oci-127
+  namespace: fleet-local
+spec:
+  repo: https://github.com/fleetqa/fleet-qa-examples-public
+  branch: main
+  paths:
+  - helm-oci-auth
+  targets:
+  - clusterSelector: {}
+  helmSecretNameForPaths: fleet-helm-secret-127
+  helmRepoURLRegex: '^oci://ghcr\.io/.*'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleet-helm-secret-127
+  namespace: fleet-local
+type: kubernetes.io/basic-auth
+stringData:
+  username: ${GH_PRIVATE_USER}
+  password: ${GH_PRIVATE_PWD}

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -35,14 +35,14 @@ Cypress.Commands.add('addPathOnGitRepoCreate', (path, index=0) => {
   cy.get(`[data-testid="array-list-box${ index }"] input[placeholder="e.g. /directory/in/your/repo"], [data-testid="array-list-box${ index }"] input[placeholder="e.g. /directory/in/your/repo"]`).clear().type(path);
 })
 
-Cypress.Commands.add('gitRepoAuth', (gitOrHelmAuth='Git', gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex ) => {
+Cypress.Commands.add('gitRepoAuth', (gitOrHelmAuth='Git', gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmRepoURLRegex ) => {
   cy.contains(`${gitOrHelmAuth} Authentication`).click()
 
   // Select the Git auth method
   cy.get('ul.vs__dropdown-menu > li > div', { timeout: 15000 }).contains(gitAuthType, { matchCase: false }).should('be.visible').click();
-  
-  if (helmUrlRegex) {
-    cy.typeValue('Helm Repos', helmUrlRegex, false,  false ); //not adding (URL Regex) after new regexp in "typeValue" function
+
+  if (helmRepoURLRegex) {
+    cy.typeValue('Helm Repos', helmRepoURLRegex, false,  false ); //not adding (URL Regex) after new regexp in "typeValue" function
   }
 
   if (gitAuthType === 'http') {
@@ -149,7 +149,7 @@ Cypress.Commands.add('addFleetRepoFromYaml', (yamlFilePath, fleetNamespace='flee
 
 // Command add and edit Fleet Git Repository
 // TODO: Rename this command name to 'addEditFleetGitRepo'
-Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path2, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, tlsOption, tlsCertificate, keepResources, correctDrift, fleetNamespace='fleet-local', editConfig=false, helmUrlRegex, deployToTarget, allowedTargetNamespace="", local=false }) => {
+Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path2, gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, tlsOption, tlsCertificate, keepResources, correctDrift, fleetNamespace='fleet-local', editConfig=false, helmRepoURLRegex, deployToTarget, allowedTargetNamespace="", local=false }) => {
 
   cy.continuousDeliveryMenuSelection();
 
@@ -192,7 +192,7 @@ Cypress.Commands.add('addFleetGitRepo', ({ repoName, repoUrl, branch, path, path
   cy.clickButton('Next');
 
   if (gitAuthType) {
-    cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmUrlRegex);
+    cy.gitRepoAuth(gitOrHelmAuth, gitAuthType, userOrPublicKey, pwdOrPrivateKey, helmRepoURLRegex);
   }
 
   if (tlsOption) {

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -26,8 +26,8 @@ declare global {
       // Functions declared in commands.ts
       open3dotsMenu(name: string, selection?: string, checkNotInMenu?: boolean): Chainable<Element>;
       addPathOnGitRepoCreate(path: string, index?: number): Chainable<Element>;
-      gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string, helmUrlRegex?: string): Chainable<Element>;
-      addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string, path2?: string, fleetNamespace?: string, editConfig?: boolean, helmUrlRegex?: string, deployToTarget?: string, tlsOption?: string, tlsCertificate?: string, allowedTargetNamespace?: string, local?: boolean): Chainable<Element>;
+      gitRepoAuth(AuthType: string, userOrPublicKey?: string, pwdOrPrivateKey?: string, gitOrHelmAuth?: string, helmRepoURLRegex?: string): Chainable<Element>;
+      addFleetGitRepo(repoName: string, repoUrl?: string, branch?: string, path?: string, path2?: string, fleetNamespace?: string, editConfig?: boolean, helmRepoURLRegex?: string, deployToTarget?: string, tlsOption?: string, tlsCertificate?: string, allowedTargetNamespace?: string, local?: boolean): Chainable<Element>;
       fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
       verifyTableRow(rowNumber: number, expectedText1?: string|RegExp, expectedText2?: string|RegExp, timeout?: number): Chainable<Element>;
       nameSpaceMenuToggle(namespaceName: string): Chainable<Element>;


### PR DESCRIPTION
## Overview

This PR fixes the fleet-127 test failure and standardizes the naming convention for Helm repository URL patterns across the codebase to align with Fleet's Issue 804 security fix.

## Background: Fleet Issue 804 Security Fix

Fleet now requires an explicit `helmRepoURLRegex` pattern in GitRepo resources to control which Helm repository URLs receive authentication credentials. This secure-by-default approach prevents credentials from being forwarded to unintended repositories. Without the pattern specified, credentials are not forwarded, resulting in 401 unauthorized errors when accessing private Helm charts.

## Changes Made

### 1. Test fleet-127: Private OCI Helm Chart Support on GitHub Container Registry

**File:** `tests/cypress/e2e/unit_tests/p1_fleet.spec.ts`

- Added `helmRepoURLRegex` constant with pattern `'^oci://ghcr\\.io/.*'` to allow credential forwarding to GitHub Container Registry OCI URLs
- Updated test to pass `helmRepoURLRegex` parameter to `cy.addFleetGitRepo()`
- Test now properly authenticates to private OCI Helm charts on ghcr.io

### 2. Tests fleet-64 and fleet-65: Private Helm Repository Tests

**File:** `tests/cypress/e2e/unit_tests/p1_fleet.spec.ts`

- Renamed variable from `let helmUrlRegex` to `let helmRepoURLRegex`
- Updated test data array properties from `helmUrlRegex_matching` to `helmRepoURLRegex_matching`
- Both tests now use consistent naming convention matching Fleet's CRD field name

### 3. TypeScript Interface Declarations

**File:** `tests/cypress/support/e2e.ts`

- Renamed parameter `helmUrlRegex` to `helmRepoURLRegex` in `gitRepoAuth()` interface
- Renamed parameter `helmUrlRegex` to `helmRepoURLRegex` in `addFleetGitRepo()` interface
- No other interface changes were made

## Tests Affected

- ✅ fleet-127: Private OCI helm chart support on GitHub Container Registry
- ✅ fleet-64: Private Helm repository with repo-level URL regex
- ✅ fleet-65: Private Helm chart with chart-level URL regex

---
CI Local passing:

<img width="1890" height="994" alt="2026-May-20_10-15" src="https://github.com/user-attachments/assets/f2ef9a15-785a-4e86-98a9-63043fdd8b93" />

CI 2.14 [p1 passing in those tests](https://github.com/rancher/fleet-e2e/actions/runs/26155503706/job/76933793922#step:10:367): 

<img width="1336" height="161" alt="image" src="https://github.com/user-attachments/assets/53ccb251-6977-412f-a510-5cf363963785" />
