### PR TITLE
Add choice on Harden tests to make it compatible with Rancher 2.11

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -247,6 +247,7 @@ jobs:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}
           PUBLIC_DOMAIN: bc.googleusercontent.com
           RANCHER_PASSWORD: ${{ secrets.rancher_password }}
+          HARDENING_CLUSTER_VERSION: ${{ inputs.hardening_cluster_version }}
         run: |
           if ${{ inputs.hardening != '' }}; then
             cd tests && make e2e-install-rke2-hardened-cluster && make e2e-install-only-certs-and-rancher

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -41,7 +41,7 @@ on:
         type: boolean
         default: true
       hardening_cluster_version:
-        description: Upstream cluster version for HARDENING where to install Rancher
+        description: 'Upstream cluster version for HARDENING where to install Rancher (for Rancher 2.11 use <K8s 1.33)'
         default: 'v1.33.0+rke2r1'
         type: choice
         options:

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -41,7 +41,7 @@ on:
         type: boolean
         default: true
       hardening_cluster_version:
-        description: 'Upstream cluster version for HARDENING where to install Rancher (for Rancher 2.11 use <K8s 1.33)'
+        description: 'RKE2 version for hardened upstream cluster (Rancher 2.11 requires K8s < 1.33, use v1.32.8+rke2r1)'
         default: 'v1.33.0+rke2r1'
         type: choice
         options:

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -43,8 +43,10 @@ on:
       hardening_cluster_version:
         description: Upstream cluster version for HARDENING where to install Rancher
         default: 'v1.33.0+rke2r1'
-        type: string
-        required: true
+        type: choice
+        options:
+          - 'v1.33.0+rke2r1'
+          - 'v1.32.8+rke2r1'
       grep_test_by_tag:
         description: Grep tags. For hardened tests, use @hardening-tests Keep always @login
         required: false
@@ -80,4 +82,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id || '' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       hardening: ${{ inputs.hardening }}
+      hardening_cluster_version: ${{ inputs.hardening_cluster_version }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/tests/scripts/provision-rke2-hardened.sh
+++ b/tests/scripts/provision-rke2-hardened.sh
@@ -7,8 +7,31 @@ KUBECTL_VERSION="1.33.0"
 # renovate: datasource=github-releases depName=kubernetes/kubernetes digestVersion="1.33.0"
 KUBECTL_SHA256="9efe8d3facb23e1618cba36fb1c4e15ac9dc3ed5a2c2e18109e4a66b2bac12dc"
 
-HARDENED_VERSION="v1.33.0+rke2r1"
-HARDENED_SHA256="acf7c6f69c932b46313d84db862f3ff5583050036d63bb3d344fffff2037a39f"
+# Get version from environment variable or use default
+HARDENED_VERSION="${HARDENING_CLUSTER_VERSION:-v1.33.0+rke2r1}"
+
+# Function to get checksum for a given version
+get_checksum_for_version() {
+  local version="$1"
+  case "$version" in
+    "v1.33.0+rke2r1")
+      echo "acf7c6f69c932b46313d84db862f3ff5583050036d63bb3d344fffff2037a39f"
+      ;;
+    "v1.32.8+rke2r1")
+      echo "c6b6362ac5638cabfe7674e99cf31db07c11bfee1386ec45c8df4c4f8fc4c9e3"
+      ;;
+    *)
+      echo "ERROR: Unknown RKE2 version: $version" >&2
+      echo "Supported versions:" >&2
+      echo "  - v1.33.0+rke2r1" >&2
+      echo "  - v1.32.8+rke2r1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Get the checksum for the requested version
+HARDENED_SHA256=$(get_checksum_for_version "$HARDENED_VERSION")
 
 ### Deploy Kubectl && alias
 
@@ -104,7 +127,8 @@ echo "pod-security-admission-config-file: $PWD/psa.yaml" | sudo tee -a /etc/ranc
 echo "profile: cis" | sudo tee -a /etc/rancher/rke2/config.yaml > /dev/null
 
 # Deploy RKE2
-echo "Downloading RKE2"
+echo "Downloading RKE2 version: ${HARDENED_VERSION}"
+echo "Expected SHA256: ${HARDENED_SHA256}"
 curl -sSfL "https://github.com/rancher/rke2/releases/download/${HARDENED_VERSION}/rke2.linux-amd64.tar.gz" -o rke2.tar.gz
 echo "${HARDENED_SHA256}  rke2.tar.gz" | sha256sum -c -
 curl -sSfL "https://get.rke2.io" -o install.sh

--- a/tests/scripts/provision-rke2-hardened.sh
+++ b/tests/scripts/provision-rke2-hardened.sh
@@ -18,7 +18,7 @@ get_checksum_for_version() {
       echo "acf7c6f69c932b46313d84db862f3ff5583050036d63bb3d344fffff2037a39f"
       ;;
     "v1.32.8+rke2r1")
-      echo "c6b6362ac5638cabfe7674e99cf31db07c11bfee1386ec45c8df4c4f8fc4c9e3"
+      echo "8a4494e75b41433fb01b8dab3673f60639b503df1adbb917f2b674068de6e72e"
       ;;
     *)
       echo "ERROR: Unknown RKE2 version: $version" >&2
@@ -128,8 +128,8 @@ echo "profile: cis" | sudo tee -a /etc/rancher/rke2/config.yaml > /dev/null
 
 # Deploy RKE2
 echo "Downloading RKE2 version: ${HARDENED_VERSION}"
-echo "Expected SHA256: ${HARDENED_SHA256}"
 curl -sSfL "https://github.com/rancher/rke2/releases/download/${HARDENED_VERSION}/rke2.linux-amd64.tar.gz" -o rke2.tar.gz
+echo "Validating SHA256: ${HARDENED_SHA256}"
 echo "${HARDENED_SHA256}  rke2.tar.gz" | sha256sum -c -
 curl -sSfL "https://get.rke2.io" -o install.sh
 chmod 700 install.sh


### PR DESCRIPTION
## Issues Fixed

1. **Test case duplication**: Tests were creating new case numbers instead of updating existing ones
   - Fixed by importing actual `qase()` function from `cypress-qase-reporter/mocha` in `e2e.ts`

2. **Appending runs marking tests as skipped**: Running multiple test suites to same Qase run would mark previous tests as skipped
   - Fixed by adding configurable `qase_complete_run` parameter
   
   
<img width="1812" height="976" alt="2026-May-22_10-39" src="https://github.com/user-attachments/assets/16d76782-1a8c-40a8-baf1-127e64930d77" />

---

## Changes Made

- **tests/cypress/support/e2e.ts**: Import real `qase()` function instead of stub
- **tests/cypress.config.ts**: Read `QASE_TESTOPS_COMPLETE_RUN` environment variable
- **.github/workflows/master-e2e.yaml**: Added `qase_complete_run` input parameter (default: true)
- **All dispatch workflows** (ui-rm*.yaml): Added "Complete the QASE run after tests" checkbox
- **.github/workflows/qase-auto-complete.yaml**: Auto-complete runs older than 10 hours (runs every 6 hours, can be triggered manually)

## How to Append Multiple Test Runs to Same Qase Run

**Run 1 (e.g., @p0 tests):**
- ✓ Report to QASE
- Existing QASE run ID: `[leave empty]`
- ☐ **Complete the QASE run after tests** ← UNCHECK
- Grep tags: `@login @p0`
- Note the generated run ID from the workflow output

**Run 2 (e.g., @p1 tests):**
- ✓ Report to QASE
- Existing QASE run ID: `12345` ← Use run ID from Run 1
- ☐ **Complete the QASE run after tests** ← UNCHECK
- Grep tags: `@login @p1`

**Run 3 (final, e.g., @rbac tests):**
- ✓ Report to QASE
- Existing QASE run ID: `12345` ← Same run ID
- ✓ **Complete the QASE run after tests** ← CHECK (completes the run)
- Grep tags: `@login @rbac`

**Result:** All tests from @p0, @p1, and @rbac can be appended in the same Qase run.
**Note:** Test cases that don't match any grep filter across all runs will remain "Untested".

<img width="1053" height="915" alt="image" src="https://github.com/user-attachments/assets/2f3842a2-8618-48d6-8a19-4ad3ccd6ae36" />


### Important: Complete the Final Run

**Always check "Complete the QASE run" on your final appended run.**

If you don't complete the run:
- The Qase run stays in "Active/In Progress" state
- **Auto-cleanup:** A scheduled workflow automatically completes runs older than 10 hours (runs every 6 hours)
- Can be manually triggered via Actions → "Qase Auto-Complete Old Runs" → "Run workflow"
- Your Qase dashboard may show runs as unfinished until auto-cleanup runs

---

## Extra Feature: Automatic Qase Run Cleanup

A new workflow automatically closes abandoned Qase runs to prevent clutter:

- **What it does:** Completes any Qase run in "Active/In Progress" state older than 10 hours
- **Schedule:** Runs automatically every 6 hours
- **Manual trigger:** Actions → "Qase Auto-Complete Old Runs" → "Run workflow" button
- **Why:** Prevents forgotten runs from staying open indefinitely in Qase dashboard