### PR TITLE
Ensure test reporting does not create qase numbers and allow appending results

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -90,6 +90,11 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests finish (set false when appending multiple test suites to same run)
+        required: false
+        type: boolean
+        default: true
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
@@ -215,7 +220,7 @@ jobs:
 
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
-      QASE_TESTOPS_COMPLETE_RUN: true
+      QASE_TESTOPS_COMPLETE_RUN: ${{ inputs.qase_complete_run }}
       QASE_LOGGING_CONSOLE: false
 
     steps:

--- a/.github/workflows/qase-auto-complete.yaml
+++ b/.github/workflows/qase-auto-complete.yaml
@@ -1,0 +1,49 @@
+name: Qase Auto-Complete Old Runs
+
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  auto-complete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-complete stale Qase runs
+        env:
+          QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+        run: |
+          # jq is pre-installed on GitHub-hosted ubuntu-latest runners
+          echo "Checking for Qase runs older than 10 hours..."
+
+          # Get all active runs from Qase
+          RUNS=$(curl -s -X GET \
+            --url "https://api.qase.io/v1/run/FLEET?status=in_progress&limit=100" \
+            -H "Token: ${QASE_API_TOKEN}" \
+            -H 'accept: application/json')
+
+          # Current timestamp
+          NOW=$(date +%s)
+          TEN_HOURS_AGO=$((NOW - 36000))
+
+          # Parse and complete old runs
+          echo "$RUNS" | jq -r '.result.entities[] | "\(.id),\(.created)"' | while IFS=, read -r RUN_ID CREATED_TIME; do
+            # Convert Qase timestamp to Unix timestamp
+            CREATED_TS=$(date -d "$CREATED_TIME" +%s 2>/dev/null || echo "0")
+
+            if [ "$CREATED_TS" -lt "$TEN_HOURS_AGO" ]; then
+              echo "Completing run $RUN_ID (created at $CREATED_TIME, older than 10 hours)"
+
+              curl -X POST \
+                --url "https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete" \
+                -H "Token: ${QASE_API_TOKEN}" \
+                -H 'accept: application/json'
+
+              echo "✓ Run $RUN_ID marked as completed"
+            else
+              echo "Run $RUN_ID is recent, skipping"
+            fi
+          done
+
+          echo "Auto-complete check finished"

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -78,6 +82,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       hardening: ${{ inputs.hardening }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm-hardening.yaml
+++ b/.github/workflows/ui-rm-hardening.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -75,5 +79,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'head/2.15' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head_2.10.yaml
+++ b/.github/workflows/ui-rm_head_2.10.yaml
@@ -12,6 +12,10 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
         type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -61,5 +65,6 @@ jobs:
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.31.9+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'head/2.10' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}
       branch: ${{ inputs.branch || '2.10-stable' }}

--- a/.github/workflows/ui-rm_head_2.10.yaml
+++ b/.github/workflows/ui-rm_head_2.10.yaml
@@ -13,7 +13,7 @@ on:
         description: Qase run ID where the results will be reported
         default: auto
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
         type: string

--- a/.github/workflows/ui-rm_head_2.11.yaml
+++ b/.github/workflows/ui-rm_head_2.11.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head_2.11.yaml
+++ b/.github/workflows/ui-rm_head_2.11.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -72,5 +76,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'head/2.11' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm_head_2.12.yaml
+++ b/.github/workflows/ui-rm_head_2.12.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -72,5 +76,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm_head_2.12.yaml
+++ b/.github/workflows/ui-rm_head_2.12.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -75,5 +79,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'head/2.13' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm_head_2.13.yaml
+++ b/.github/workflows/ui-rm_head_2.13.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head_2.14.yaml
+++ b/.github/workflows/ui-rm_head_2.14.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -75,6 +79,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'head/2.14' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac @special_tests' }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}
 

--- a/.github/workflows/ui-rm_head_2.14.yaml
+++ b/.github/workflows/ui-rm_head_2.14.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -8,6 +8,10 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
         type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -55,4 +59,5 @@ jobs:
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.28.8+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -9,7 +9,7 @@ on:
         description: Qase run ID where the results will be reported
         default: auto
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
         type: string

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -12,6 +12,10 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
         type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -59,5 +63,6 @@ jobs:
       upstream_cluster_version: ${{ inputs.upstream_cluster_version || 'v1.29.12+k3s1' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@login @p0 @p1 @p1_2 @rbac' }}
       branch: ${{ inputs.branch || '2.10-stable' }}

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -13,7 +13,7 @@ on:
         description: Qase run ID where the results will be reported
         default: auto
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
         type: string

--- a/.github/workflows/ui-rm_head_upgrade.yaml
+++ b/.github/workflows/ui-rm_head_upgrade.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -90,5 +94,6 @@ jobs:
       upgrade: ${{ inputs.upgrade }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       runner_template: ${{ inputs.runner_template || 'fleet-e2e-ci-runner-spot-x86-64-template-v3' }}

--- a/.github/workflows/ui-rm_head_upgrade.yaml
+++ b/.github/workflows/ui-rm_head_upgrade.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_prime_alpha_rc.yaml
+++ b/.github/workflows/ui-rm_prime_alpha_rc.yaml
@@ -18,7 +18,7 @@ on:
         type: string
         default: ''
       qase_complete_run:
-        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
       runner_template:

--- a/.github/workflows/ui-rm_prime_alpha_rc.yaml
+++ b/.github/workflows/ui-rm_prime_alpha_rc.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: ''
+      qase_complete_run:
+        description: Complete the QASE run after tests (false = append mode for multiple runs)
+        default: true
+        type: boolean
       runner_template:
         description: Runner template to use (spot or dedicated)
         default: fleet-e2e-ci-runner-spot-x86-64-template-v3
@@ -75,6 +79,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       qase_run_id: ${{ inputs.qase_run_id || '' }}
+      qase_complete_run: ${{ inputs.qase_complete_run != false }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag }}
       branch: ${{ inputs.branch }}
       runner_template: ${{ inputs.runner_template }}

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -5,6 +5,7 @@ import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN
 const qaseMode = (process.env.QASE_MODE === 'testops' && qaseAPIToken) ? 'testops' : 'off'
+const qaseCompleteRun = process.env.QASE_TESTOPS_COMPLETE_RUN !== 'false'
 
 export default defineConfig({
   viewportWidth: 1596,
@@ -35,7 +36,7 @@ export default defineConfig({
           project: 'FLEET',
           uploadAttachments: true,
           run: {
-            complete: true,
+            complete: qaseCompleteRun,
           },
         },
       framework: {

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -13,12 +13,16 @@ limitations under the License.
 */
 
 import './commands';
+import { qase } from 'cypress-qase-reporter/mocha';
 
-// This ensures the qase() function exists globally before ANY spec file loads
-(window as any).qase = (id: any, fn: any) => fn;
-console.log('Qase global initialized');
+// Make qase available globally
+(window as any).qase = qase;
 
 declare global {
+  // Qase function for linking tests to test case IDs
+  function qase(id: number, title: string): string;
+  function qase(id: number[], title: string): string;
+
   // In Cypress functions should be declared with 'namespace'
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {


### PR DESCRIPTION
## Issues Fixed

1. **Test case duplication**: Tests were creating new case numbers instead of updating existing ones
   - Fixed by importing actual `qase()` function from `cypress-qase-reporter/mocha` in `e2e.ts`

2. **Appending runs marking tests as skipped**: Running multiple test suites to same Qase run would mark previous tests as skipped
   - Fixed by adding configurable `qase_complete_run` parameter
   
   
<img width="1812" height="976" alt="2026-May-22_10-39" src="https://github.com/user-attachments/assets/16d76782-1a8c-40a8-baf1-127e64930d77" />

---

## Changes Made

- **tests/cypress/support/e2e.ts**: Import real `qase()` function instead of stub
- **tests/cypress.config.ts**: Read `QASE_TESTOPS_COMPLETE_RUN` environment variable
- **.github/workflows/master-e2e.yaml**: Added `qase_complete_run` input parameter (default: true)
- **All dispatch workflows** (ui-rm*.yaml): Added "Complete the QASE run after tests" checkbox
- **.github/workflows/qase-auto-complete.yaml**: Auto-complete runs older than 10 hours (runs every 6 hours, can be triggered manually)

## How to Append Multiple Test Runs to Same Qase Run

**Run 1 (e.g., @p0 tests):**
- ✓ Report to QASE
- Existing QASE run ID: `[leave empty]`
- ☐ **Complete the QASE run after tests** ← UNCHECK
- Grep tags: `@login @p0`
- Note the generated run ID from the workflow output

**Run 2 (e.g., @p1 tests):**
- ✓ Report to QASE
- Existing QASE run ID: `12345` ← Use run ID from Run 1
- ☐ **Complete the QASE run after tests** ← UNCHECK
- Grep tags: `@login @p1`

**Run 3 (final, e.g., @rbac tests):**
- ✓ Report to QASE
- Existing QASE run ID: `12345` ← Same run ID
- ✓ **Complete the QASE run after tests** ← CHECK (completes the run)
- Grep tags: `@login @rbac`

**Result:** All tests from @p0, @p1, and @rbac can be appended in the same Qase run.
**Note:** Test cases that don't match any grep filter across all runs will remain "Untested".

<img width="1053" height="915" alt="image" src="https://github.com/user-attachments/assets/2f3842a2-8618-48d6-8a19-4ad3ccd6ae36" />


### Important: Complete the Final Run

**Always check "Complete the QASE run" on your final appended run.**

If you don't complete the run:
- The Qase run stays in "Active/In Progress" state
- **Auto-cleanup:** A scheduled workflow automatically completes runs older than 10 hours (runs every 6 hours)
- Can be manually triggered via Actions → "Qase Auto-Complete Old Runs" → "Run workflow"
- Your Qase dashboard may show runs as unfinished until auto-cleanup runs

---

## Extra Feature: Automatic Qase Run Cleanup

A new workflow automatically closes abandoned Qase runs to prevent clutter:

- **What it does:** Completes any Qase run in "Active/In Progress" state older than 10 hours
- **Schedule:** Runs automatically every 6 hours
- **Manual trigger:** Actions → "Qase Auto-Complete Old Runs" → "Run workflow" button
- **Why:** Prevents forgotten runs from staying open indefinitely in Qase dashboard