### PR TITLE
Refactor tests by adding, removing certain code in the P1_2 tests.

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -894,37 +894,71 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
 
 describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
   const configMapName = "test-map"
-  const repoTestData: testData[] = [
-    {qase_id: 173, message: '`valuesFrom` with empty', path:'qa-test-apps/helm-app/values-from-with-empty-values' },
-    {qase_id: 174, message: '`valuesFrom` with NO', path:'qa-test-apps/helm-app/values-from-with-no-values' },
-    {qase_id: 175, message: '`valuesFiles` with empty', path: 'qa-test-apps/helm-app/values-files-with-empty-values' },
-    {qase_id: 176, message: '`valuesFiles` with NO', path: 'qa-test-apps/helm-app/values-files-with-no-values' }
-  ]
 
   beforeEach('Cleanup leftover GitRepo and ConfigMap if any.', () => {
-    cy.login();
-    cy.visit('/');
     cy.deleteConfigMap(configMapName);
-    cy.deleteAllFleetRepos();
   })
 
-  repoTestData.forEach(({ qase_id, message, path }) => {
-    it(qase(qase_id, `FLEET-${qase_id}: Test helm-app using "${message}" values in the fleet.yaml file.`), { tags: `@fleet-${qase_id}`}, () => {
-        const repoName = `local-cluster-fleet-${qase_id}`
+  it(qase(173, 'FLEET-173: Test helm-app using "`valuesFrom` with empty" values in the fleet.yaml file.'), { tags: '@fleet-173' }, () => {
+    const qase_id = 173;
+    const testPath = 'qa-test-apps/helm-app/values-from-with-empty-values';
+    const repoName = `local-cluster-fleet-${qase_id}`
 
-        // Create ConfigMap before create GitRepo
-        if (qase_id === 173 || qase_id === 174) {
-          cy.createConfigMap(configMapName);
-        }
+    // Create ConfigMap before create GitRepo
+    cy.createConfigMap(configMapName);
 
-        // Create GitRepo
-        cy.continuousDeliveryMenuSelection();
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
-        cy.clickButton('Create');
-        cy.verifyTableRow(0, 'Active', repoName);
-        cy.wait(1000);
-        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-      })
+    // Create GitRepo
+    cy.continuousDeliveryMenuSelection();
+    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
+    cy.clickButton('Create');
+    cy.verifyTableRow(0, 'Active', repoName);
+    cy.wait(1000);
+    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+  });
+
+  it(qase(174, 'FLEET-174: Test helm-app using "`valuesFrom` with NO" values in the fleet.yaml file.'), { tags: '@fleet-174' }, () => {
+    const qase_id = 174;
+    const testPath = 'qa-test-apps/helm-app/values-from-with-no-values';
+    const repoName = `local-cluster-fleet-${qase_id}`
+
+    // Create ConfigMap before create GitRepo
+    cy.createConfigMap(configMapName);
+
+    // Create GitRepo
+    cy.continuousDeliveryMenuSelection();
+    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
+    cy.clickButton('Create');
+    cy.verifyTableRow(0, 'Active', repoName);
+    cy.wait(1000);
+    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+  });
+
+  it(qase(175, 'FLEET-175: Test helm-app using "`valuesFiles` with empty" values in the fleet.yaml file.'), { tags: '@fleet-175' }, () => {
+    const qase_id = 175;
+    const testPath = 'qa-test-apps/helm-app/values-files-with-empty-values';
+    const repoName = `local-cluster-fleet-${qase_id}`
+
+    // Create GitRepo
+    cy.continuousDeliveryMenuSelection();
+    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
+    cy.clickButton('Create');
+    cy.verifyTableRow(0, 'Active', repoName);
+    cy.wait(1000);
+    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+  });
+
+  it(qase(176, 'FLEET-176: Test helm-app using "`valuesFiles` with NO" values in the fleet.yaml file.'), { tags: '@fleet-176' }, () => {
+    const qase_id = 176;
+    const testPath = 'qa-test-apps/helm-app/values-files-with-no-values';
+    const repoName = `local-cluster-fleet-${qase_id}`
+
+    // Create GitRepo
+    cy.continuousDeliveryMenuSelection();
+    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
+    cy.clickButton('Create');
+    cy.verifyTableRow(0, 'Active', repoName);
+    cy.wait(1000);
+    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
   });
 });
 
@@ -1093,19 +1127,8 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
   const appName = 'nginx-keep'
   const allowedTargetNamespace = 'allowed-namespace'
 
-  beforeEach('Cleanup leftover GitRepo if any.', () => {
-    cy.login();
-    cy.visit('/');
-    cy.deleteAllFleetRepos();
-  })
-
-  it(qase(39, 'Test "GitRepoRestrictions" on non-existent namespace throws error in the UI'), { tags: '@fleet-39' }, () => {
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
-      }
-      else {
-        cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
-      }
+  it(qase(39, 'Fleet-39: Test "GitRepoRestrictions" on non-existent namespace throws error in the UI'), { tags: '@fleet-39' }, () => {
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
       cy.readFile('assets/git-repo-restrictions-non-exists-ns.yaml').then((content) => {
         cy.get('.CodeMirror').then((codeMirrorElement) => {
@@ -1119,16 +1142,11 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
     }
   )
 
-  it(qase(40, 'Test "GitRepoRestrictions" override "defaultNamespace" in fleet.yaml of application over "allowedTargetNamespace"'), { tags: '@fleet-40' }, () => {
+  it(qase(40, 'Fleet-40: Test "GitRepoRestrictions" override "defaultNamespace" in fleet.yaml of application over "allowedTargetNamespace"'), { tags: '@fleet-40' }, () => {
       const repoName = 'local-gitreporestrictions-fleet-40'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
-      }
-      else {
-        cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
-      }
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
       cy.readFile('assets/git-repo-restrictions-allowed-target-ns.yaml').then((content) => {
         cy.get('.CodeMirror').then((codeMirrorElement) => {
@@ -1153,30 +1171,17 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.get('.col-link-detail').contains(appName).should('be.visible');
 
       // Deleting GitRepoRestrictions from the fleet-local namespace
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
-      }
-      else {
-        cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
-      }
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.fleetNamespaceToggle('fleet-local');
       cy.deleteAll(false);
-
-      // Delete GitRepo
-      cy.deleteAllFleetRepos();
     }
   )
 
-  it(qase(41, 'Test "allowedTargetNamespace" from "GitRepoRestrictions" overrides "defaultNamespace" in fleet.yaml of application on existing GitRepo'), { tags: '@fleet-41' }, () => {
+  it(qase(41, 'Fleet-41: Test "allowedTargetNamespace" from "GitRepoRestrictions" overrides "defaultNamespace" in fleet.yaml of application on existing GitRepo'), { tags: '@fleet-41' }, () => {
       const repoName = 'local-gitreporestrictions-fleet-41'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
-      }
-      else {
-        cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
-      }
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
       cy.readFile('assets/git-repo-restrictions-allowed-target-ns.yaml').then((content) => {
         cy.get('.CodeMirror').then((codeMirrorElement) => {
@@ -1208,17 +1213,9 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.get('.col-link-detail').contains(appName).should('be.visible');
 
       // Deleting GitRepoRestrictions from the fleet-local namespace
-      if (supported_versions_212_and_above.some(r => r.test(rancherVersion))) {
-        cy.accesMenuSelection('Continuous Delivery', 'Resources', 'GitRepoRestrictions');
-      }
-      else {
-        cy.accesMenuSelection('Continuous Delivery', 'Advanced', 'GitRepoRestrictions');
-      }
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.fleetNamespaceToggle('fleet-local');
       cy.deleteAll(false);
-
-      // Delete GitRepo
-      cy.deleteAllFleetRepos();
     })
 });
 

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -795,7 +795,7 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       // Check namespace is deleted
       cy.accesMenuSelection('local', 'Projects/Namespaces');
       cy.filterInSearchBox(namespaceName);
-      cy.contains(namespaceName, {timeout: 40000 }).should('not.exist');
+      cy.contains(namespaceName, {timeout: 50000 }).should('not.exist');
   })
 });
 
@@ -1083,6 +1083,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
   const allowedTargetNamespace = 'allowed-namespace'
 
   it(qase(39, 'Fleet-39: Test "GitRepoRestrictions" on non-existent namespace throws error in the UI'), { tags: '@fleet-39' }, () => {
+      cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
       cy.addYamlFile('assets/git-repo-restrictions-non-exists-ns.yaml');
@@ -1096,6 +1097,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       const repoName = 'local-gitreporestrictions-fleet-40'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
+      cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
 
@@ -1127,6 +1129,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       const repoName = 'local-gitreporestrictions-fleet-41'
 
       // Create GitRepoRestrictions with allowedTargetNamespace
+      cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
       cy.addYamlFile('assets/git-repo-restrictions-allowed-target-ns.yaml');

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -807,7 +807,6 @@ describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
       const branch = "master"
       const path = "simple"
       const repoUrl = "https://github.com/rancher/fleet-examples"
-      const timeout = 50000
       const multipliedResourceCount = true
 
       // Get Default Resources from single cluster before GitRepo.
@@ -815,7 +814,7 @@ describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
 
         cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
         cy.clickButton('Create');
-        cy.checkGitRepoStatus(repoName, '1 / 1', '18 / 18', { timeout: timeout });
+        cy.checkGitRepoStatus(repoName, '1 / 1', '18 / 18', { timeout: 50000 });
 
       // Get the Resource count from GitRepo and store it.
       cy.gitRepoResourceCountAsInteger(repoName, 'fleet-default');
@@ -825,8 +824,6 @@ describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
 
       // Compare Resource count from GitRepo with Cluster resource.
       cy.compareClusterResourceCount(multipliedResourceCount);
-
-      cy.deleteAllFleetRepos();
     })
 });
 
@@ -1050,8 +1047,6 @@ describe('Test Fleet bundle status for longhorn-crd', { tags: '@p1_2'}, () => {
       cy.filterInSearchBox(repoName);
       cy.verifyTableRow(0, 'Active', repoName);
 
-      cy.deleteAllFleetRepos();
-
     })
 });
 
@@ -1077,9 +1072,6 @@ describe('Test non-yaml file into bundle.', { tags: '@p1_2'}, () => {
           cy.checkApplicationStatus("config-map-ignored", dsCluster, 'All Namespaces', false, 'Storage', 'ConfigMaps');
         }
       )
-
-      cy.deleteAllFleetRepos();
-
     })
 });
 
@@ -1093,12 +1085,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
   it(qase(39, 'Fleet-39: Test "GitRepoRestrictions" on non-existent namespace throws error in the UI'), { tags: '@fleet-39' }, () => {
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
-      cy.readFile('assets/git-repo-restrictions-non-exists-ns.yaml').then((content) => {
-        cy.get('.CodeMirror').then((codeMirrorElement) => {
-          const cm = (codeMirrorElement[0] as any).CodeMirror;
-          cm.setValue(content);
-        });
-      })
+      cy.addYamlFile('assets/git-repo-restrictions-non-exists-ns.yaml');
       cy.clickButton('Create');
       cy.get('[data-testid="banner-content"] > span').contains('namespaces "iamnotexists" not found');
       cy.clickButton('Cancel');
@@ -1111,12 +1098,8 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       // Create GitRepoRestrictions with allowedTargetNamespace
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
-      cy.readFile('assets/git-repo-restrictions-allowed-target-ns.yaml').then((content) => {
-        cy.get('.CodeMirror').then((codeMirrorElement) => {
-          const cm = (codeMirrorElement[0] as any).CodeMirror;
-          cm.setValue(content);
-        });
-      })
+
+      cy.addYamlFile('assets/git-repo-restrictions-allowed-target-ns.yaml');
       cy.clickButton('Create');
 
       // Add Fleet repository and create it
@@ -1146,12 +1129,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       // Create GitRepoRestrictions with allowedTargetNamespace
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.clickButton('Create from YAML');
-      cy.readFile('assets/git-repo-restrictions-allowed-target-ns.yaml').then((content) => {
-        cy.get('.CodeMirror').then((codeMirrorElement) => {
-          const cm = (codeMirrorElement[0] as any).CodeMirror;
-          cm.setValue(content);
-        });
-      })
+      cy.addYamlFile('assets/git-repo-restrictions-allowed-target-ns.yaml');
       cy.clickButton('Create');
 
       // Add Fleet repository and create it
@@ -1392,7 +1370,6 @@ describe('Test GitRepo state for missing resources with and without `diff` used 
       cy.clickButton('Create');
       cy.verifyTableRow(0, 'Modified', repoName);
       cy.checkGitRepoStatus(repoName, '0 / 1', '3 / 6', { repoStatus: 'Modified' });
-
 })
 
   it(qase(339, `FLEET-339: Test GitRepo shows 'Active' state for missing resources when using 'diff' in 'fleet.yaml'`), { tags: '@fleet-339'}, () => {
@@ -1444,6 +1421,9 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
 
       const repoName = 'test-override-targets-with-label'
       const path = "qa-test-apps/overrideTargets"
+      const addOverrideLabelToAllClusters = `kubectl label -n fleet-default clusters.fleet.cattle.io -l \
+        'management.cattle.io/cluster-display-name in (${dsAllClusterList.join(',')})' env=override {enter}`
+      const removeOverrideLabelFromAllClusters = `kubectl label clusters.management.cattle.io --all env-{enter}`;
 
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
       cy.clickButton('Create');
@@ -1458,18 +1438,12 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
         .invoke('text')
         .should('match', /This\s+git\s*repo\s+is not targeting any clusters/i);
 
-      // Open local terminal in Rancher UI
-      cy.accesMenuSelection('local');
-      cy.get('#btn-kubectl').click();
-      cy.contains('Connected').should('be.visible');
-
-      // Assign label (similar to label mentioned in fleet.yaml file.) to All the clusters using terminal.
-      cy.typeIntoCanvasTermnal('\
-      kubectl label clusters.management.cattle.io --all env=override{enter}');
-
-      cy.continuousDeliveryMenuSelection();
+      // Assign label (similar to label mentioned in fleet.yaml file.) to all the clusters
+      // i.e. imported-0, imported-1 and imported-2 using kubectl command in terminal.
+      cy.executeKubectlCommand(addOverrideLabelToAllClusters);
 
       //Toggle Fleet namespace on cluster page to `fleet-default` if not being selected already.
+      cy.continuousDeliveryMenuSelection();
       cy.fleetNamespaceToggle('fleet-default');
 
       cy.verifyTableRow(0, 'Active', repoName);
@@ -1482,14 +1456,7 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
         }
       )
 
-      // Remove labels from the clusters.
-      // Open local terminal in Rancher UI
-      cy.accesMenuSelection('local');
-      cy.get('#btn-kubectl').click();
-      cy.contains('Connected').should('be.visible');
-
       // Remove assigned label (similar to label mentioned in fleet.yaml file.) from All the clusters using terminal.
-      cy.typeIntoCanvasTermnal('\
-      kubectl label clusters.management.cattle.io --all env-{enter}');
+      cy.executeKubectlCommand(removeOverrideLabelFromAllClusters);
     })
 })

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -758,7 +758,7 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       // Check namespace is deleted
       cy.accesMenuSelection('local', 'Projects/Namespaces');
       cy.filterInSearchBox(namespaceName);
-      cy.contains(namespaceName, { timeout: 30000 }).should('not.exist');
+      cy.contains(namespaceName, { timeout: 40000 }).should('not.exist');
     }
   )
 
@@ -787,7 +787,7 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       cy.continuousDeliveryMenuSelection();
       cy.fleetNamespaceToggle('fleet-local');
       cy.filterInSearchBox(repoName); // this is the main one
-      
+
       // Since whe expeect that the deletion of the main one also
       // deletes the nested one, the 'deleteAll' function will check this
       cy.deleteAll();
@@ -795,8 +795,8 @@ describe('Test namespace deletion when bundle is deleted', { tags: ['@p1_2', '@p
       // Check namespace is deleted
       cy.accesMenuSelection('local', 'Projects/Namespaces');
       cy.filterInSearchBox(namespaceName);
-      cy.contains(namespaceName, {timeout: 20000 }).should('not.exist');
-    })
+      cy.contains(namespaceName, {timeout: 40000 }).should('not.exist');
+  })
 });
 
 describe('Test Fleet Resource Count', { tags: '@p1_2'}, () => {
@@ -894,71 +894,34 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version'))) {
 
 describe('Test Helm app with Custom Values', { tags: '@p1_2' }, () => {
   const configMapName = "test-map"
+  const repoTestData: testData[] = [
+    {qase_id: 173, message: '`valuesFrom` with empty', path:'qa-test-apps/helm-app/values-from-with-empty-values' },
+    {qase_id: 174, message: '`valuesFrom` with NO', path:'qa-test-apps/helm-app/values-from-with-no-values' },
+    {qase_id: 175, message: '`valuesFiles` with empty', path: 'qa-test-apps/helm-app/values-files-with-empty-values' },
+    {qase_id: 176, message: '`valuesFiles` with NO', path: 'qa-test-apps/helm-app/values-files-with-no-values' }
+  ]
 
-  beforeEach('Cleanup leftover GitRepo and ConfigMap if any.', () => {
+  beforeEach('Cleanup leftover ConfigMap if any.', () => {
     cy.deleteConfigMap(configMapName);
   })
 
-  it(qase(173, 'FLEET-173: Test helm-app using "`valuesFrom` with empty" values in the fleet.yaml file.'), { tags: '@fleet-173' }, () => {
-    const qase_id = 173;
-    const testPath = 'qa-test-apps/helm-app/values-from-with-empty-values';
-    const repoName = `local-cluster-fleet-${qase_id}`
+  repoTestData.forEach(({ qase_id, message, path }) => {
+    it(qase(qase_id, `FLEET-${qase_id}: Test helm-app using "${message}" values in the fleet.yaml file.`), { tags: `@fleet-${qase_id}`}, () => {
+        const repoName = `local-cluster-fleet-${qase_id}`
 
-    // Create ConfigMap before create GitRepo
-    cy.createConfigMap(configMapName);
+        // Create ConfigMap before create GitRepo
+        if (qase_id === 173 || qase_id === 174) {
+          cy.createConfigMap(configMapName);
+        }
 
-    // Create GitRepo
-    cy.continuousDeliveryMenuSelection();
-    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
-    cy.clickButton('Create');
-    cy.verifyTableRow(0, 'Active', repoName);
-    cy.wait(1000);
-    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-  });
-
-  it(qase(174, 'FLEET-174: Test helm-app using "`valuesFrom` with NO" values in the fleet.yaml file.'), { tags: '@fleet-174' }, () => {
-    const qase_id = 174;
-    const testPath = 'qa-test-apps/helm-app/values-from-with-no-values';
-    const repoName = `local-cluster-fleet-${qase_id}`
-
-    // Create ConfigMap before create GitRepo
-    cy.createConfigMap(configMapName);
-
-    // Create GitRepo
-    cy.continuousDeliveryMenuSelection();
-    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
-    cy.clickButton('Create');
-    cy.verifyTableRow(0, 'Active', repoName);
-    cy.wait(1000);
-    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-  });
-
-  it(qase(175, 'FLEET-175: Test helm-app using "`valuesFiles` with empty" values in the fleet.yaml file.'), { tags: '@fleet-175' }, () => {
-    const qase_id = 175;
-    const testPath = 'qa-test-apps/helm-app/values-files-with-empty-values';
-    const repoName = `local-cluster-fleet-${qase_id}`
-
-    // Create GitRepo
-    cy.continuousDeliveryMenuSelection();
-    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
-    cy.clickButton('Create');
-    cy.verifyTableRow(0, 'Active', repoName);
-    cy.wait(1000);
-    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
-  });
-
-  it(qase(176, 'FLEET-176: Test helm-app using "`valuesFiles` with NO" values in the fleet.yaml file.'), { tags: '@fleet-176' }, () => {
-    const qase_id = 176;
-    const testPath = 'qa-test-apps/helm-app/values-files-with-no-values';
-    const repoName = `local-cluster-fleet-${qase_id}`
-
-    // Create GitRepo
-    cy.continuousDeliveryMenuSelection();
-    cy.addFleetGitRepo({ repoName, repoUrl, branch, path: testPath, local: true });
-    cy.clickButton('Create');
-    cy.verifyTableRow(0, 'Active', repoName);
-    cy.wait(1000);
-    cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+        // Create GitRepo
+        cy.continuousDeliveryMenuSelection();
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
+        cy.clickButton('Create');
+        cy.verifyTableRow(0, 'Active', repoName);
+        cy.wait(1000);
+        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      })
   });
 });
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -1184,6 +1184,7 @@ Cypress.Commands.add('createConfigMap', (configMapName) => {
   cy.addYamlFile('assets/helm-app-test-map-configmap.yaml');
   cy.wait(1000);
   cy.clickButton('Create');
+  cy.wait(1000);
   cy.filterInSearchBox(configMapName);
   cy.verifyTableRow(0, configMapName);
 })

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -136,6 +136,21 @@ Cypress.Commands.add('continuousDeliveryBundlesMenu', () => {
   });
 });
 
+Cypress.Commands.add('continuousDeliveryGitRepoRestrictionsMenu', () => {
+  cy.get('body', { timeout: 15000 }).then(($body) => {
+    if ($body.text().includes('App Bundles')) {
+      cy.contains('App Bundles').should('be.visible');
+      cy.clickNavMenu(['Resources']);
+      cy.get('nav').contains(/^GitRepoRestrictions$/).click();
+    } else if ($body.text().includes('Git Repos')) {
+      cy.contains('Git Repos').should('be.visible');
+      cy.clickNavMenu(['Advanced', 'GitRepoRestrictions']);
+    } else {
+      throw new Error('Neither "App Bundles" nor "Git Repos" found');
+    }
+  });
+});
+
 // Command to add Fleet Repo from YAML file
 Cypress.Commands.add('addFleetRepoFromYaml', (yamlFilePath, fleetNamespace='fleet-local') => {
   cy.continuousDeliveryMenuSelection();

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -87,6 +87,7 @@ declare global {
       addHelmOp(fleetNamespace: string?, repoName: string, repoUrl: string, chart: string, version?: string, values?: string, deployTo?: string, serviceAccountName?: string, targetNamespace?: string, helmAuth?: string): Chainable<Element>;
       addFleetRepoFromYaml(yamlFilePath: string, fleetNamespace?: string): Chainable<Element>;
       executeKubectlCommand(labelCommand: string,clusterName?: string): Chainable<Element>;
+      continuousDeliveryGitRepoRestrictionsMenu(): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
- Remove the `deleteAllFleetRepos()` from the `beforeEach` block in the tests.
  - One global `beforeEach` does the same thing.
- Remove extra `login()` per test.
  - Currently, we're using `login` type as `session()` which don't require to login again and again.
  - Fixing label addition using existing method.
- Refactored `gitRepoRestrictions` tests:
  - Used `cy.addYaml()` instead of `cy.readFile()`.
  - Added test case no. in title of tests.
  - Added separate GitRepoRestrictions menu.
- Removed extra variable `timeout` from test.
- Increased timeout in the Namespace related tests.
    - Observed that namespace deletion usually taking time to delete it is almost 30-35 seconds.
