### PR TITLE
Fleetqa/fix qase auto complete timestamp

### DIFF
--- a/.github/workflows/qase-auto-complete.yaml
+++ b/.github/workflows/qase-auto-complete.yaml
@@ -28,9 +28,20 @@ jobs:
           TEN_HOURS_AGO=$((NOW - 36000))
 
           # Parse and complete old runs
-          echo "$RUNS" | jq -r '.result.entities[] | "\(.id),\(.created)"' | while IFS=, read -r RUN_ID CREATED_TIME; do
+          echo "$RUNS" | jq -r '.result.entities[] | "\(.id),\(.created_at // .created // .start_time)"' | while IFS=, read -r RUN_ID CREATED_TIME; do
+            # Skip if no valid timestamp
+            if [ -z "$CREATED_TIME" ] || [ "$CREATED_TIME" = "null" ]; then
+              echo "⚠ Run $RUN_ID has no timestamp, skipping"
+              continue
+            fi
+
             # Convert Qase timestamp to Unix timestamp
-            CREATED_TS=$(date -d "$CREATED_TIME" +%s 2>/dev/null || echo "0")
+            CREATED_TS=$(date -d "$CREATED_TIME" +%s 2>/dev/null)
+
+            if [ -z "$CREATED_TS" ]; then
+              echo "⚠ Run $RUN_ID has invalid timestamp format: $CREATED_TIME, skipping"
+              continue
+            fi
 
             if [ "$CREATED_TS" -lt "$TEN_HOURS_AGO" ]; then
               echo "Completing run $RUN_ID (created at $CREATED_TIME, older than 10 hours)"
@@ -42,7 +53,7 @@ jobs:
 
               echo "✓ Run $RUN_ID marked as completed"
             else
-              echo "Run $RUN_ID is recent, skipping"
+              echo "Run $RUN_ID is recent (created $CREATED_TIME), skipping"
             fi
           done
 

--- a/.github/workflows/qase-auto-complete.yaml
+++ b/.github/workflows/qase-auto-complete.yaml
@@ -2,9 +2,14 @@ name: Qase Auto-Complete Old Runs
 
 on:
   schedule:
-    # Run every 6 hours
-    - cron: '0 */6 * * *'
+    # Run every 10 days - completes ALL active runs
+    - cron: '0 0 */10 * *'
   workflow_dispatch:
+    inputs:
+      qase_run_id:
+        description: 'Specific QASE run ID to complete (leaving it empty will not do anything on manual dispatch, but will complete ALL active runs on scheduled dispatch)'
+        type: string
+        default: ''
 
 jobs:
   auto-complete:
@@ -15,7 +20,31 @@ jobs:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
         run: |
           # jq is pre-installed on GitHub-hosted ubuntu-latest runners
-          echo "Checking for Qase runs older than 10 hours..."
+          SPECIFIC_RUN="${{ inputs.qase_run_id }}"
+          EVENT_NAME="${{ github.event_name }}"
+
+          # If specific run ID provided, complete only that run
+          if [ -n "$SPECIFIC_RUN" ]; then
+            echo "Completing specific run $SPECIFIC_RUN..."
+
+            curl -X POST \
+              --url "https://api.qase.io/v1/run/FLEET/${SPECIFIC_RUN}/complete" \
+              -H "Token: ${QASE_API_TOKEN}" \
+              -H 'accept: application/json'
+
+            echo "✓ Run $SPECIFIC_RUN marked as completed"
+            exit 0
+          fi
+
+          # If manual dispatch without run ID, do nothing
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ℹ️  Manual dispatch without run ID - doing nothing"
+            echo "To complete a specific run, provide a run ID in the input field"
+            exit 0
+          fi
+
+          # Scheduled run (cron) - complete ALL active runs
+          echo "⚠️  SCHEDULED RUN: Completing ALL active runs (runs every 10 days)"
 
           # Get all active runs from Qase
           RUNS=$(curl -s -X GET \
@@ -23,38 +52,16 @@ jobs:
             -H "Token: ${QASE_API_TOKEN}" \
             -H 'accept: application/json')
 
-          # Current timestamp
-          NOW=$(date +%s)
-          TEN_HOURS_AGO=$((NOW - 36000))
+          # Parse and complete ALL runs (scheduled cleanup)
+          echo "$RUNS" | jq -r '.result.entities[] | .id' | while read -r RUN_ID; do
+            echo "Completing run $RUN_ID (scheduled cleanup - all active runs)"
 
-          # Parse and complete old runs
-          echo "$RUNS" | jq -r '.result.entities[] | "\(.id),\(.created_at // .created // .start_time)"' | while IFS=, read -r RUN_ID CREATED_TIME; do
-            # Skip if no valid timestamp
-            if [ -z "$CREATED_TIME" ] || [ "$CREATED_TIME" = "null" ]; then
-              echo "⚠ Run $RUN_ID has no timestamp, skipping"
-              continue
-            fi
+            curl -X POST \
+              --url "https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete" \
+              -H "Token: ${QASE_API_TOKEN}" \
+              -H 'accept: application/json'
 
-            # Convert Qase timestamp to Unix timestamp
-            CREATED_TS=$(date -d "$CREATED_TIME" +%s 2>/dev/null)
-
-            if [ -z "$CREATED_TS" ]; then
-              echo "⚠ Run $RUN_ID has invalid timestamp format: $CREATED_TIME, skipping"
-              continue
-            fi
-
-            if [ "$CREATED_TS" -lt "$TEN_HOURS_AGO" ]; then
-              echo "Completing run $RUN_ID (created at $CREATED_TIME, older than 10 hours)"
-
-              curl -X POST \
-                --url "https://api.qase.io/v1/run/FLEET/${RUN_ID}/complete" \
-                -H "Token: ${QASE_API_TOKEN}" \
-                -H 'accept: application/json'
-
-              echo "✓ Run $RUN_ID marked as completed"
-            else
-              echo "Run $RUN_ID is recent (created $CREATED_TIME), skipping"
-            fi
+            echo "✓ Run $RUN_ID marked as completed"
           done
 
-          echo "Auto-complete check finished"
+          echo "Scheduled cleanup finished - all active runs completed"


### PR DESCRIPTION

## Issues Fixed

1. **Test case duplication** - Fixed by importing real `qase()` function from `cypress-qase-reporter/mocha`

2. **Appending runs** - Added `qase_complete_run` parameter to all workflows to prevent marking previous tests as "skipped"

3. **Auto-cleanup workflow** - Created `qase-auto-complete.yaml`:
   - **Cron:** Every 10 days → Closes ALL active runs
   - **Manual with run ID:** Closes that specific run
   - **Manual without run ID:** Does nothing

4. **Fixed timestamp bug** - Prevented workflow from closing all runs when API returns null timestamps

5. **Tested** - Run 5116 successfully closed via manual dispatch ✅

Proof:
Tried with test 5093 (which was initially in state `In Progress`

<img width="2365" height="930" alt="image" src="https://github.com/user-attachments/assets/bb0666ef-5b9f-4b05-968c-1dff25e198b3" />

We pass the qase number `5093`

<img width="2531" height="1107" alt="image" src="https://github.com/user-attachments/assets/253e9043-8ed1-4fff-91d0-793c582fedd0" />

And finally in state `Failed`:

<img width="2531" height="933" alt="image" src="https://github.com/user-attachments/assets/1256bb76-106c-4dac-88d7-2c0d864bfb9e" />

