### PR TITLE
Fleetqa/bump cypress reporter and others

### DIFF
--- a/.github/workflows/ui-rm_head_2.10.yaml
+++ b/.github/workflows/ui-rm_head_2.10.yaml
@@ -16,7 +16,6 @@ on:
         description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true

--- a/.github/workflows/ui-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rm_head_2.8.yaml
@@ -12,7 +12,6 @@ on:
         description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true

--- a/.github/workflows/ui-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rm_head_2.9.yaml
@@ -16,7 +16,6 @@ on:
         description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
         type: boolean
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,14 +33,14 @@
     "cypress-mochawesome-reporter": "^4.0.2",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-plugin-tab": "^2.0.0",
-    "cypress-qase-reporter": "^3.6.0",
+    "cypress-qase-reporter": "^3.6.1",
     "dotenv": "^17.4.2",
     "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@cypress/grep": "^6.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.58.0",
-    "@typescript-eslint/parser": "^8.58.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.4",
+    "@typescript-eslint/parser": "^8.59.4",
     "eslint-plugin-cypress": "^6.4.1"
   }
 }


### PR DESCRIPTION
### Done:

- Bumping `cypress-qase-reporter`, `typescript-eslint/eslint-plugin` and `typescript-eslint/parser`
- Removing leftover field `type: string` on `.github/workflows/ui-rm_head_2.8.yaml`, `.github/workflows/ui-rm_head_2.9.yaml` and `.github/workflows/ui-rm_head_2.10.yaml` after other merge in other pr.

### CI tests 2.12 seem ok:

- https://github.com/rancher/fleet-e2e/actions/runs/26292146525
- https://github.com/rancher/fleet-e2e/actions/runs/26292129600
- https://github.com/rancher/fleet-e2e/actions/runs/26292108156
- https://github.com/rancher/fleet-e2e/actions/runs/26292088755

### Reporting seems correct:

<img width="2531" height="922" alt="image" src="https://github.com/user-attachments/assets/d9e01a84-a3ee-4a65-a3e5-c19797971a9e" />

