### PR TITLE
Add continuous delivery menu selection before deleting GitRepoRestrictions

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1119,6 +1119,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.get('.col-link-detail').contains(appName).should('be.visible');
 
       // Deleting GitRepoRestrictions from the fleet-local namespace
+      cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.fleetNamespaceToggle('fleet-local');
       cy.deleteAll(false);
@@ -1157,6 +1158,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.get('.col-link-detail').contains(appName).should('be.visible');
 
       // Deleting GitRepoRestrictions from the fleet-local namespace
+      cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.fleetNamespaceToggle('fleet-local');
       cy.deleteAll(false);


### PR DESCRIPTION
### Problem
In today's 2.14-head run:
- Tests related to GitRepoRestrictions are failing when cleaning-up GitRepoRestrictions.
- The Failure reason is `ContinuousDelivery` Menu navigation was missing at the cleanup.

### Solution
- Added ContinuousDelivery menu to the cleanup part. 
