### PR TITLE
Add test for correctDrift to ensure secret count does not exceed 2 after modifications

### DIFF
--- a/tests/assets/git-repo-correct-drift-138.yaml
+++ b/tests/assets/git-repo-correct-drift-138.yaml
@@ -1,0 +1,19 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: local-cluster-correct-138
+  namespace: fleet-local
+spec:
+  branch: master
+  correctDrift:
+    enabled: true
+  paths:
+    - qa-test-apps/nginx-app
+  repo: https://github.com/rancher/fleet-test-data/
+  targets:
+    - clusterSelector:
+        matchExpressions:
+          - key: provider.cattle.io
+            operator: NotIn
+            values:
+              - harvester

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -848,14 +848,20 @@ describe('Test GitRepo creation from a Git revision instead of a branch', { tags
   );
 });
 
-describe('Test correctDrift does not create excessive secrets after multiple modifications', { tags: '@p1'}, () => {
-  it(qase(138, "Fleet-138: Test correctDrift ensures secret count does not exceed 2 after multiple application modifications"), { tags: '@fleet-138' }, () => {
-      const repoName = "local-cluster-correct-138"
-      const appNamespace = "nginx-keep"
+describe('Test correctDrift does not create excessive secrets after multiple modifications', { tags: '@p1' }, () => {
+  it(
+    qase(
+      138,
+      'Fleet-138: Test correctDrift ensures secret count does not exceed 2 after multiple application modifications',
+    ),
+    { tags: '@fleet-138' },
+    () => {
+      const repoName = 'local-cluster-correct-138';
+      const appNamespace = 'nginx-keep';
 
       // Create GitRepo with correctDrift enabled via YAML
       cy.continuousDeliveryMenuSelection();
-      cy.fleetNamespaceToggle('fleet-local')
+      cy.fleetNamespaceToggle('fleet-local');
       cy.clickCreateGitRepo();
       cy.clickButton('Edit as YAML');
       cy.addYamlFile('assets/git-repo-correct-drift-138.yaml');
@@ -870,10 +876,10 @@ describe('Test correctDrift does not create excessive secrets after multiple mod
         cy.log(`Modification ${i} of 3`);
         cy.wait(2000);
         cy.get('[data-testid="button-group-child-0"]').then(($button) => {
-          if ($button.hasClass('bg-disabled')){
+          if ($button.hasClass('bg-disabled')) {
             $button.trigger('click');
           }
-        })
+        });
 
         cy.filterInSearchBox(appName);
         cy.contains(appName).click();
@@ -910,5 +916,6 @@ describe('Test correctDrift does not create excessive secrets after multiple mod
         cy.log(`Found ${secretCount} secrets in namespace ${appNamespace}`);
         expect(secretCount).to.be.lte(2, `Secret count should not exceed 2, but found ${secretCount}`);
       });
-    })
+    },
+  );
 });

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -847,3 +847,64 @@ describe('Test GitRepo creation from a Git revision instead of a branch', { tags
     },
   );
 });
+
+describe('Test correctDrift does not create excessive secrets after multiple modifications', { tags: '@p1'}, () => {
+  it(qase(138, "Fleet-138: Test correctDrift ensures secret count does not exceed 2 after multiple application modifications"), { tags: '@fleet-138' }, () => {
+      const repoName = "local-cluster-correct-138"
+      const appNamespace = "nginx-keep"
+
+      // Create GitRepo with correctDrift enabled via YAML
+      cy.continuousDeliveryMenuSelection();
+      cy.fleetNamespaceToggle('fleet-local')
+      cy.clickCreateGitRepo();
+      cy.clickButton('Edit as YAML');
+      cy.addYamlFile('assets/git-repo-correct-drift-138.yaml');
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.checkApplicationStatus(appName);
+
+      // Modify deployment three times without verification (correctDrift heals too fast)
+      cy.accesMenuSelection('local', 'Workloads', 'Deployments');
+
+      for (let i = 1; i <= 3; i++) {
+        cy.log(`Modification ${i} of 3`);
+        cy.wait(2000);
+        cy.get('[data-testid="button-group-child-0"]').then(($button) => {
+          if ($button.hasClass('bg-disabled')){
+            $button.trigger('click');
+          }
+        })
+
+        cy.filterInSearchBox(appName);
+        cy.contains(appName).click();
+
+        // Click increase button without verifying the intermediate state
+        cy.get('div.scaler > button.increase, div.plus-minus.text-right > .btn > .icon-plus')
+          .should('be.visible')
+          .click();
+
+        // Navigate back to Deployments list
+        cy.clickNavMenu(['Deployments']);
+
+        // Wait for correctDrift to restore
+        cy.wait(15000);
+      }
+
+      // Verify application is restored to 1/1 after all modifications
+      cy.nameSpaceMenuToggle(appNamespace);
+      cy.filterInSearchBox(appName);
+      cy.verifyTableRow(0, 'Active', '1/1');
+
+      // Check secrets in the application namespace
+      cy.accesMenuSelection('local', 'Storage', 'Secrets');
+      cy.nameSpaceMenuToggle(appNamespace);
+      cy.filterInSearchBox('sh.helm.release');
+
+      // Count the secrets and verify count is not more than 2
+      cy.get('table > tbody > tr.main-row').then(($rows) => {
+        const secretCount = $rows.length;
+        cy.log(`Found ${secretCount} secrets in namespace ${appNamespace}`);
+        expect(secretCount).to.be.lte(2, `Secret count should not exceed 2, but found ${secretCount}`);
+      });
+    })
+});

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -878,10 +878,14 @@ describe('Test correctDrift does not create excessive secrets after multiple mod
         cy.filterInSearchBox(appName);
         cy.contains(appName).click();
 
+        // Wait for deployment detail page to fully load
+        cy.wait(1000);
+
         // Click increase button without verifying the intermediate state
+        // Use force:true because correctDrift may cause page re-renders during click
         cy.get('div.scaler > button.increase, div.plus-minus.text-right > .btn > .icon-plus')
           .should('be.visible')
-          .click();
+          .click({ force: true });
 
         // Navigate back to Deployments list
         cy.clickNavMenu(['Deployments']);


### PR DESCRIPTION
Automate Test Fleet-138:
- Created GitRepo by enabling correctDrift
- Wait for Nginx application to be install.
- Updated deployment from 1-2  (Repeat this step 3 times.)
- Check correctDrift was restoring it back to 1.
- Verify that secrets of same application not more than 2.