### PR TITLE
Add tests for validate: bundleDeployment has cluster label

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1465,3 +1465,77 @@ describe('Test bundle deploy with overrideTargets by label availability on clust
       cy.executeKubectlCommand(removeOverrideLabelFromAllClusters);
     })
 })
+
+describe('Validate bundleDeployment labels match cluster names', { tags: '@p1_2' }, () => {
+  const CLUSTER_LABEL_KEY = 'fleet.cattle.io/cluster';
+
+  it(qase(84, 'Fleet-84: Validate bundleDeployments have correct fleet.cattle.io/cluster labels for all clusters'), { tags: '@fleet-84' }, () => {
+    const expectedClusterCount = dsAllClusterList.length;
+    const clusterMap: Record<string, string> = {}; // Map clusterID -> displayName
+
+    // Step 1: Build mapping of clusterID to displayName from Clusters page
+    cy.accesMenuSelection('Continuous Delivery', 'Clusters');
+    cy.fleetNamespaceToggle('fleet-default');
+
+    // For each known display name, get its cluster ID
+    cy.wrap(dsAllClusterList).each((displayName: any) => {
+      cy.filterInSearchBox(displayName);
+      cy.get('table > tbody > tr.main-row[data-testid^="sortable-table-"]:first td.col-link-detail > span')
+        .click();
+
+      // Get cluster ID from YAML (name field in cluster configuration)
+      cy.clickButton('Show Configuration');
+      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
+
+      cy.get('.CodeMirror').invoke('text').then((yamlText) => {
+        const match = yamlText.match(/name:\s*(c-[a-z0-9-]+)/);
+        if (match) {
+          const clusterID = match[1];
+          clusterMap[clusterID] = displayName;
+          cy.log(`Mapped: ${clusterID} -> ${displayName}`);
+        }
+        cy.clickButton('Close');
+        // Go back to clusters list
+        cy.clickNavMenu(['Clusters']);
+      });
+    });
+
+    // Step 2: Collect all fleet-agent bundle names from Bundles page
+    cy.continuousDeliveryBundlesMenu();
+    cy.filterInSearchBox('fleet-agent-c-');
+
+    const bundleClusterPairs: Array<{ bundleName: string; clusterID: string }> = [];
+    cy.get('table > tbody > tr.main-row[data-testid^="sortable-table-"] td.col-link-detail > span')
+      .should('have.length.at.least', expectedClusterCount)
+      .each(($bundleElement) => {
+        const bundleName = $bundleElement.text().trim();
+        const match = bundleName.match(/^fleet-agent-(c-[a-z0-9-]+)$/);
+        expect(match, `Bundle "${bundleName}" should match pattern "fleet-agent-c-..."`).to.not.be.null;
+        bundleClusterPairs.push({ bundleName, clusterID: match![1] });
+      });
+
+    // Step 3: Navigate to BundleDeployments page once
+    cy.accesMenuSelection('local');
+    cy.clickNavMenu(['More Resources', 'Fleet', 'BundleDeployments']);
+    cy.nameSpaceMenuToggle('All Namespaces');
+
+    // Step 4: Verify each bundleDeployment has the correct label
+    cy.wrap(bundleClusterPairs).each(({ bundleName, clusterID }: any) => {
+      const displayName = clusterMap[clusterID] || clusterID;
+
+      cy.filterInSearchBox(bundleName);
+      cy.verifyTableRow(0, bundleName);
+
+      // Click on bundleDeployment to view YAML
+      cy.get('td.col-link-detail > span').contains(bundleName).click();
+
+      // Verify the label is present in YAML
+      cy.contains(`${CLUSTER_LABEL_KEY}: ${clusterID}`).should('be.visible');
+
+      cy.log(`For cluster ${displayName} (${clusterID}): Label ${CLUSTER_LABEL_KEY}: ${clusterID} is present`);
+
+      // Go back to BundleDeployments list
+      cy.clickNavMenu(['BundleDeployments']);
+    });
+  });
+})

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1470,72 +1470,52 @@ describe('Validate bundleDeployment labels match cluster names', { tags: '@p1_2'
   const CLUSTER_LABEL_KEY = 'fleet.cattle.io/cluster';
 
   it(qase(84, 'Fleet-84: Validate bundleDeployments have correct fleet.cattle.io/cluster labels for all clusters'), { tags: '@fleet-84' }, () => {
-    const expectedClusterCount = dsAllClusterList.length;
     const clusterMap: Record<string, string> = {}; // Map clusterID -> displayName
 
-    // Step 1: Build mapping of clusterID to displayName from Clusters page
-    cy.accesMenuSelection('Continuous Delivery', 'Clusters');
-    cy.fleetNamespaceToggle('fleet-default');
+    // Step 1: Collect all cluster IDs (only navigate Cluster Management once)
+    cy.accesMenuSelection('Cluster Management', 'Clusters');
 
-    // For each known display name, get its cluster ID
     cy.wrap(dsAllClusterList).each((displayName: any) => {
+      cy.get('input.input-sm.search-box').should('be.visible').clear();
+      cy.wait(500);
       cy.filterInSearchBox(displayName);
-      cy.get('table > tbody > tr.main-row[data-testid^="sortable-table-"]:first td.col-link-detail > span')
+      cy.wait(500);
+
+      cy.get('tr.main-row')
+        .find('span.cluster-link a')
         .click();
 
-      // Get cluster ID from YAML (name field in cluster configuration)
-      cy.clickButton('Show Configuration');
-      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
-
-      cy.get('.CodeMirror').invoke('text').then((yamlText) => {
-        const match = yamlText.match(/name:\s*(c-[a-z0-9-]+)/);
+      cy.get('body').invoke('text').then((pageText) => {
+        const match = pageText.match(/(c-[a-z0-9-]+)/);
         if (match) {
           const clusterID = match[1];
           clusterMap[clusterID] = displayName;
-          cy.log(`Mapped: ${clusterID} -> ${displayName}`);
+          cy.log(`Mapped: ${clusterID} → ${displayName}`);
         }
-        cy.clickButton('Close');
-        // Go back to clusters list
-        cy.clickNavMenu(['Clusters']);
       });
+
+      cy.clickNavMenu(['Clusters']);
     });
 
-    // Step 2: Collect all fleet-agent bundle names from Bundles page
-    cy.continuousDeliveryBundlesMenu();
-    cy.filterInSearchBox('fleet-agent-c-');
-
-    const bundleClusterPairs: Array<{ bundleName: string; clusterID: string }> = [];
-    cy.get('table > tbody > tr.main-row[data-testid^="sortable-table-"] td.col-link-detail > span')
-      .should('have.length.at.least', expectedClusterCount)
-      .each(($bundleElement) => {
-        const bundleName = $bundleElement.text().trim();
-        const match = bundleName.match(/^fleet-agent-(c-[a-z0-9-]+)$/);
-        expect(match, `Bundle "${bundleName}" should match pattern "fleet-agent-c-..."`).to.not.be.null;
-        bundleClusterPairs.push({ bundleName, clusterID: match![1] });
-      });
-
-    // Step 3: Navigate to BundleDeployments page once
+    // Step 2: Navigate to BundleDeployments once and verify all
     cy.accesMenuSelection('local');
     cy.clickNavMenu(['More Resources', 'Fleet', 'BundleDeployments']);
     cy.nameSpaceMenuToggle('All Namespaces');
 
-    // Step 4: Verify each bundleDeployment has the correct label
-    cy.wrap(bundleClusterPairs).each(({ bundleName, clusterID }: any) => {
-      const displayName = clusterMap[clusterID] || clusterID;
+    cy.wrap(Object.keys(clusterMap)).each((clusterID: any) => {
+      const displayName = clusterMap[clusterID];
+      const bundleName = `fleet-agent-${clusterID}`;
 
       cy.filterInSearchBox(bundleName);
       cy.verifyTableRow(0, bundleName);
 
-      // Click on bundleDeployment to view YAML
       cy.get('td.col-link-detail > span').contains(bundleName).click();
 
-      // Verify the label is present in YAML
       cy.contains(`${CLUSTER_LABEL_KEY}: ${clusterID}`).should('be.visible');
 
-      cy.log(`For cluster ${displayName} (${clusterID}): Label ${CLUSTER_LABEL_KEY}: ${clusterID} is present`);
+      cy.log(`✓ For cluster ${displayName} (${clusterID}): Label ${CLUSTER_LABEL_KEY}: ${clusterID} is present`);
 
-      // Go back to BundleDeployments list
-      cy.clickNavMenu(['BundleDeployments']);
+      cy.go('back');
     });
   });
 })


### PR DESCRIPTION
## Test Summary: Fleet-84

**Validates that bundleDeployments have correct cluster labels**

This test verifies that each `bundleDeployment` in Fleet contains the correct `fleet.cattle.io/cluster` label that matches its associated cluster ID.

### What the test does:

1. **Collect cluster IDs** - Navigates to Cluster Management page, searches for each cluster by display name (e.g., `imported-0`), clicks into the cluster details, and extracts the cluster ID (e.g., `c-vcwwd`) from the page content. Builds a mapping: `{ 'c-vcwwd': 'imported-0' }`

2. **Verify bundleDeployments** - Navigates to BundleDeployments page once, then for each cluster ID constructs the expected bundle name (`fleet-agent-c-vcwwd`), finds the bundleDeployment, and verifies the YAML contains the correct `fleet.cattle.io/cluster: c-vcwwd` label

### Verification output:
- For cluster imported-0 (c-vcwwd): Label fleet.cattle.io/cluster: c-vcwwd is present
- For cluster imported-1 (c-abcde): Label fleet.cattle.io/cluster: c-abcde is present
- For cluster imported-2 (c-xyz12): Label fleet.cattle.io/cluster: c-xyz12 is present


### Key improvements:
- Pure `UI-based` validation (no `kubectl` dependencies)
- Optimized navigation: `Cluster Management` visited once, `BundleDeployments` visited once
- Clear verification logs showing both cluster display name and cluster ID
- Simplified flow with minimal page navigation


> [!IMPORTANT]
> Above cluster ID's are not real. 