### PR TITLE
Adding test to verify webhook regex metacharacter escaping

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -448,12 +448,13 @@ jobs:
           name: cypress-videos-after-upgrade-${{ inputs.cluster_name }}
           path: tests/cypress/videos
           retention-days: 7
-      - name: Upload webhook setup log
+      - name: Upload webhook logs
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: webhook-setup-log-${{ inputs.cluster_name }}
-          path: tests/assets/webhook-tests/webhook_setup.log
+          name: webhook-logs-${{ inputs.cluster_name }}
+          path: tests/assets/webhook-tests/*.log
+          if-no-files-found: ignore
       - name: Add summary
         if: ${{ always() }}
         run: |

--- a/tests/assets/webhook-tests/test-803-auto.sh
+++ b/tests/assets/webhook-tests/test-803-auto.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+set -euo pipefail
+
+# Webhook Regex Escaping Test
+# Auto-detects webhook URL from cluster ingress
+
+# Redirect all output to log file
+exec > >(tee -i $PWD/assets/webhook-tests/test-803-auto.log)
+exec 2>&1
+
+TEST_NAMESPACE="fleet-local"
+
+echo "Webhook Regex Escaping Test"
+
+# Auto-detect webhook URL
+WEBHOOK_HOST=$(kubectl get ingress -n cattle-fleet-system webhook-ingress -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo "")
+
+if [ -z "$WEBHOOK_HOST" ]; then
+    echo "ERROR: Cannot find webhook-ingress"
+    kubectl get ingress -A
+    exit 1
+fi
+
+WEBHOOK_URL="http://${WEBHOOK_HOST}/"
+echo "Webhook URL: $WEBHOOK_URL"
+
+# Check Fleet version
+FLEET_VERSION=$(kubectl get deployment -n cattle-fleet-system fleet-controller -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null | grep -oP '(?<=:).*' || echo "unknown")
+echo "Fleet version: $FLEET_VERSION"
+
+# Check/remove webhook secret
+if kubectl get secret -n cattle-fleet-system gitjob-webhook &>/dev/null; then
+    kubectl delete secret -n cattle-fleet-system gitjob-webhook
+    sleep 10
+fi
+
+# Create test GitRepos
+echo "Creating test GitRepos..."
+kubectl apply -f - <<'EOF'
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: test-regex-1
+  namespace: fleet-local
+spec:
+  repo: https://github.com/rancher/fleet-examples.git
+  branch: master
+  disablePolling: true
+  paths:
+  - single-cluster/helm
+---
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: test-regex-2
+  namespace: fleet-local
+spec:
+  repo: https://github.com/rancher/fleet-examples.git
+  branch: master
+  disablePolling: true
+  paths:
+  - single-cluster/manifests
+---
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: test-regex-3
+  namespace: fleet-local
+spec:
+  repo: https://github.com/rancher/fleet.git
+  branch: main
+  disablePolling: true
+  paths:
+  - dev/helm
+EOF
+
+sleep 15
+
+kubectl get gitrepo -n fleet-local test-regex-1 test-regex-2 test-regex-3 \
+  -o custom-columns=NAME:.metadata.name,REPO:.spec.repo,WEBHOOK_COMMIT:.status.webhookCommit
+
+echo "TEST 1: Wildcard Pattern - https://.*/.*"
+
+RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}\n" \
+  -X POST "${WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -d '{"ref":"refs/heads/master","after":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","repository":{"html_url":"https://.*/.*"}}')
+
+echo "Response:"
+echo "$RESPONSE"
+
+sleep 5
+
+echo "Checking if GitRepos were affected by wildcard..."
+AFFECTED1=0
+for repo in test-regex-1 test-regex-2 test-regex-3; do
+    commit=$(kubectl get gitrepo -n fleet-local $repo -o jsonpath='{.status.webhookCommit}' 2>/dev/null || echo "")
+
+    if [ "$commit" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]; then
+        echo "  ✗ $repo: AFFECTED - webhookCommit=${commit}"
+        AFFECTED1=$((AFFECTED1 + 1))
+    else
+        echo "  ✓ $repo: Not affected (webhookCommit=${commit})"
+    fi
+done
+
+if [ $AFFECTED1 -eq 3 ]; then
+    echo "RESULT: All 3 GitRepos matched wildcard"
+    RESULT1="AFFECTED"
+elif [ $AFFECTED1 -gt 0 ]; then
+    echo "RESULT: ${AFFECTED1}/3 GitRepos matched wildcard"
+    RESULT1="AFFECTED"
+else
+    echo "RESULT: 0/3 GitRepos matched wildcard"
+    RESULT1="NOT_AFFECTED"
+fi
+
+echo "TEST 2: Wildcard Hostname"
+echo "Sending: https://.*/rancher/fleet-examples.git"
+
+RESPONSE2=$(curl -s -w "\nHTTP_CODE:%{http_code}\n" \
+  -X POST "${WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -d '{"ref":"refs/heads/master","after":"cccccccccccccccccccccccccccccccccccccccc","repository":{"html_url":"https://.*/rancher/fleet-examples.git"}}')
+
+echo "Response:"
+echo "$RESPONSE2"
+
+sleep 5
+
+echo "Checking GitRepos..."
+AFFECTED2=0
+for repo in test-regex-1 test-regex-2 test-regex-3; do
+    commit=$(kubectl get gitrepo -n fleet-local $repo -o jsonpath='{.status.webhookCommit}' 2>/dev/null || echo "")
+    repo_url=$(kubectl get gitrepo -n fleet-local $repo -o jsonpath='{.spec.repo}')
+
+    if [ "$commit" = "cccccccccccccccccccccccccccccccccccccccc" ]; then
+        echo "  ✗ $repo ($repo_url): MATCHED"
+        AFFECTED2=$((AFFECTED2 + 1))
+    else
+        echo "  ✓ $repo: Not affected"
+    fi
+done
+
+if [ $AFFECTED2 -gt 0 ]; then
+    echo "RESULT: ${AFFECTED2} repos matched wildcard hostname"
+    RESULT2="AFFECTED"
+else
+    echo "RESULT: Wildcard hostname blocked"
+    RESULT2="NOT_AFFECTED"
+fi
+
+echo "Cleanup"
+kubectl delete gitrepo -n fleet-local test-regex-1 test-regex-2 test-regex-3 --ignore-not-found=true
+
+echo "Final Results"
+echo "Environment: $WEBHOOK_HOST"
+echo "Fleet Version: $FLEET_VERSION"
+echo "Test 1 (wildcard): $RESULT1"
+echo "Test 2 (hostname): $RESULT2"
+
+if [ "$RESULT1" = "AFFECTED" ] || [ "$RESULT2" = "AFFECTED" ]; then
+    echo "AFFECTED - REGEX NOT ESCAPED"
+    exit 1
+else
+    echo "NOT AFFECTED - REGEX ESCAPED"
+    exit 0
+fi

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -566,7 +566,14 @@ describe('Test gitrepos with cabundle', { tags: '@p0' }, () => {
         cy.contains('HMAC verification failed').should('exist');
       })
     }
-  })
+
+    it(qase(463, 'Verify webhook regex metacharacter escaping'), { tags: '@fleet-463' }, () => {
+        cy.exec('bash assets/webhook-tests/test-803-auto.sh', { timeout: 120000 }).then((result) => {
+          cy.log(result.stdout, result.stderr);
+        });
+      }
+    )
+  });
 
   // New tests for jobs cleanup
 describe('Test Fleet job cleanup', { tags: ['@p0', '@pr-tests'] }, () => {

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -6,7 +6,7 @@ set -evx
 npm install
 
 # Start Cypress tests with docker
-# Mount gh CLI from host if available for webhook tests
+# Mount gh CLI from host if available for some tests
 GH_MOUNT=""
 if command -v gh &> /dev/null; then
   GH_PATH=$(command -v gh)
@@ -14,7 +14,30 @@ if command -v gh &> /dev/null; then
   echo "Mounting gh CLI from host: ${GH_PATH}"
 fi
 
-docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} \
+# Mount kubectl from host if available for some tests
+KUBECTL_MOUNT=""
+if command -v kubectl &> /dev/null; then
+  KUBECTL_PATH=$(command -v kubectl)
+  KUBECTL_MOUNT="-v ${KUBECTL_PATH}:/usr/local/bin/kubectl:ro"
+  echo "Mounting kubectl from host: ${KUBECTL_PATH}"
+fi
+
+# Mount kubeconfig from host for kubectl access
+KUBECONFIG_MOUNT=""
+if [ -f "${HOME}/.kube/config" ]; then
+  KUBECONFIG_MOUNT="-v ${HOME}/.kube/config:/root/.kube/config:ro"
+  echo "Mounting kubeconfig from: ${HOME}/.kube/config"
+fi
+
+# Mount curl from host if available for some tests
+CURL_MOUNT=""
+if command -v curl &> /dev/null; then
+  CURL_PATH=$(command -v curl)
+  CURL_MOUNT="-v ${CURL_PATH}:/usr/local/bin/curl:ro"
+  echo "Mounting curl from host: ${CURL_PATH}"
+fi
+
+docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KUBECONFIG_MOUNT} ${CURL_MOUNT} \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
     -e QASE_API_TOKEN=$QASE_API_TOKEN                       \
     -e QASE_MODE=$QASE_MODE                                 \


### PR DESCRIPTION
## Test Description

Automated test that verifies Fleet webhook handler properly escapes regex metacharacters in repository URLs to prevent unintended GitRepo matches.

### Test Cases

**Test 1: Full URL Wildcard (`https://.*/.*`)**
- **When VULNERABLE:** All 3 GitRepos get `webhookCommit` updated (wildcard matches everything)
- **When NOT VULNERABLE:** 0 GitRepos match, no `webhookCommit` changes

**Test 2: Hostname Wildcard (`https://.*/rancher/fleet-examples.git`)**
- **When VULNERABLE:** 2 GitRepos with matching path get updated
- **When NOT VULNERABLE:** 0 GitRepos match

**Expected Result:** Both tests should show 0 matches (properly secured)

### Test Setup
- Uses `before` hook to configure webhook ingress via `webhook_setup.sh`
- Creates webhook endpoint with external IP using nip.io
- Removes HMAC secret for unauthenticated testing

### Test Reporting + CI's

**When Test PASSES:**
- Test passes silently, no logs shown in Cypress runner
- Exit code 0, output shows "NOT VULNERABLE"

Example: [head/2.13 on v1.34.3+k3s1 - @login @fleet-463 destroy=true #341](https://github.com/rancher/fleet-e2e/actions/runs/26573212632/job/78285583936#step:10:414)
<img width="667" height="104" alt="image" src="https://github.com/user-attachments/assets/6c5fd137-6df0-4abb-87b5-49fe81e49d70" />


**When Test FAILS:**
- Cypress test fails with error message
- Full test output logged in Cypress runner
- `test-803-auto.log` uploaded as workflow artifact
- Log shows which repos were affected and detailed failure reasons
- Exit code 1, output shows "VULNERABLE TO ISSUE #803"

[Example: prime/2.13.1 on v1.33.2+k3s1 - @login @fleet-463 destroy=true #396](https://github.com/rancher/fleet-e2e/actions/runs/26574097812/job/78288706486#step:10:412)

<img width="1091" height="527" alt="image" src="https://github.com/user-attachments/assets/e1fc8817-a950-4807-9d89-4138c34f2ff7" />

Artifact will be generated:
<img width="882" height="246" alt="image" src="https://github.com/user-attachments/assets/5bbc6fbe-bb69-4d64-b4a6-69c5d024863b" />

With this log:
[test-803-auto.log](https://github.com/user-attachments/files/28348435/test-803-auto.log)


--- 

## Infrastructure Changes

This PR also adds the following tools to the Cypress Docker container for use in tests:

- ✅ **kubectl** - Mounted from host for direct cluster interactions
- ✅ **curl** - Mounted from host for webhook payload delivery
- ✅ **kubeconfig** - Mounted (read-only) for kubectl authentication

These tools are now available for any Cypress test that needs to interact with Kubernetes resources or send HTTP requests directly.

