### PR TITLE
Fleetqa/fix rbac 2.15

### DIFF
--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -123,8 +123,10 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.continuousDeliveryWorkspacesMenu();
       cy.verifyTableRow(0, 'Active', 'fleet-default');
       cy.verifyTableRow(1, 'Active', 'fleet-local');
-      cy.get('a.btn.role-primary').contains('Create').should('be.visible');
-      
+      cy.clickButton('Create');
+      cy.get('h2').contains('Allowed Target Namespaces').should('be.visible');
+      cy.clickButton('Cancel');
+
       // Ensuring the user is not able to "edit" or "delete" workspaces.
       cy.open3dotsMenu('fleet-default', 'Delete', true);
       cy.open3dotsMenu('fleet-default', 'Edit Config', true);
@@ -162,7 +164,9 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.wait(1000)
       cy.continuousDeliveryBundlesMenu();
       cy.continuousDeliveryWorkspacesMenu();
-      cy.get('a.btn.role-primary').contains('Create').should('be.visible');
+      cy.clickButton('Create');
+      cy.get('h2').contains('Allowed Target Namespaces').should('be.visible');
+      cy.clickButton('Cancel');
       cy.verifyTableRow(0, 'Active', 'fleet-default');
       cy.verifyTableRow(1, 'Active', 'fleet-local');
       cy.open3dotsMenu('fleet-default', 'Edit Config');
@@ -271,12 +275,15 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.wait(500);
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
       cy.clickButton('Create');
+      cy.wait(1000);
       cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
   
       cy.continuousDeliveryMenuSelection();
+      cy.wait(500);
       cy.fleetNamespaceToggle('fleet-default');
       cy.addFleetGitRepo({ repoName: repoNameDefault, repoUrl, branch, path: pathDefault });
       cy.clickButton('Create');
+      cy.wait(1000);
       cy.checkGitRepoStatus(repoNameDefault, '1 / 1');
     })
     
@@ -756,7 +763,9 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.continuousDeliveryWorkspacesMenu();
       cy.verifyTableRow(0, 'Active', 'fleet-default');
       cy.verifyTableRow(1, 'Active', 'fleet-local');
-      cy.get('a.btn.role-primary').contains('Create').should('be.visible');
+      cy.clickButton('Create');
+      cy.get('h2').contains('Allowed Target Namespaces').should('be.visible');
+      cy.clickButton('Cancel');
       
       // Ensuring the user is not able to "edit" or "delete" workspaces.
       cy.open3dotsMenu('fleet-default', 'Delete', true);
@@ -794,7 +803,9 @@ describe('Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "
       cy.wait(1000)
       cy.continuousDeliveryBundlesMenu();
       cy.continuousDeliveryWorkspacesMenu();
-      cy.get('a.btn.role-primary').contains('Create').should('be.visible');
+      cy.clickButton('Create');
+      cy.get('h2').contains('Allowed Target Namespaces').should('be.visible');
+      cy.clickButton('Cancel');
       cy.verifyTableRow(0, 'Active', 'fleet-default');
       cy.verifyTableRow(1, 'Active', 'fleet-local');
       cy.open3dotsMenu('fleet-default', 'Edit Config');

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -275,16 +275,14 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
       cy.wait(500);
       cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
       cy.clickButton('Create');
-      cy.wait(1000);
-      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+      cy.verifyTableRow(0, 'Active', '1/1');
   
       cy.continuousDeliveryMenuSelection();
       cy.wait(500);
       cy.fleetNamespaceToggle('fleet-default');
       cy.addFleetGitRepo({ repoName: repoNameDefault, repoUrl, branch, path: pathDefault });
       cy.clickButton('Create');
-      cy.wait(1000);
-      cy.checkGitRepoStatus(repoNameDefault, '1 / 1');
+      cy.verifyTableRow(0, 'Active', '3/3');
     })
     
   it(qase(46, 'Fleet-46: Test "Standard-user" | Custom Role | Fleetworkspaces), Bundles = [ALL] | GitRepos = [List]'), { tags: '@fleet-46' }, () => {


### PR DESCRIPTION
## Fixed RBAC test failures in Rancher 2.15-head

### Issue
- 4 RBAC tests (Fleet-43, 44, 10, 11) failing with "Create button not found" 
- Tests timing out looking for `a.btn.role-primary` selector that doesn't exist in Rancher 2.15

### Root Cause
- Incorrect selector - tests were looking for `a.btn.role-primary` but the actual Create button uses `.btn` class
- Tests only checked if button exists, didn't verify user can actually click it and access the Create form

### Fix
- Replaced wrong selector check with actual button click: `cy.clickButton('Create')`
- Added verification that Create form opens by checking for "Allowed Target Namespaces" heading
- Click Cancel to return to table
- Replaced `cy.checkGitRepoStatus()` with `cy.verifyTableRow()` in `before` hooks for faster, more reliable GitRepo status verification
- Added small wait (500ms) before namespace toggle in `before` hook

### Tests Fixed
- Fleet-43: Standard User with list/create verbs for fleetworkspaces
- Fleet-44: Standard User with all-except-delete verbs for fleetworkspaces  
- Fleet-10: Base User with list/create for fleetworkspaces
- Fleet-11: Base User with all-except-delete for fleetworkspaces

--- 

## CI TESTS PASSING:

[2.15](https://github.com/rancher/fleet-e2e/actions/runs/26639260755/job/78507659647#step:10:429)
[2.12](https://github.com/rancher/fleet-e2e/actions/runs/26639286006/job/78507748612#step:10:355)
