### PR TITLE
Add test to validate GitRepo status.perClusterResourceCounts for each cluster

### DIFF
--- a/tests/assets/git-repo-per-cluster-resource-counts.yaml
+++ b/tests/assets/git-repo-per-cluster-resource-counts.yaml
@@ -1,0 +1,12 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: test-per-cluster-resource-counts
+  namespace: fleet-default
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/nginx-app
+  targets:
+  - clusterSelector: {}

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1557,3 +1557,51 @@ describe('Validate bundleDeployment labels and status.resources', { tags: '@p1_2
     cy.contains(`namespace: ${appName}`).should('be.visible');
   });
 })
+
+describe('Validate GitRepo perClusterResourceCounts', { tags: '@p1_2' }, () => {
+
+  it(qase(167, 'Fleet-167: Validate GitRepo status.perClusterResourceCounts shows correct resource counts for each cluster'), { tags: '@fleet-167' }, () => {
+    const repoName = 'test-per-cluster-resource-counts';
+
+    // Collect all cluster IDs
+    cy.getClusterIds(dsAllClusterList).then(() => {
+      // Create GitRepo from YAML
+      cy.addFleetRepoFromYaml('assets/git-repo-per-cluster-resource-counts.yaml', 'fleet-default');
+      cy.verifyTableRow(0, 'Active', repoName);
+      cy.checkGitRepoStatus(repoName, '1 / 1', '3 / 3');
+
+      // Navigate to GitRepo detail page
+      cy.contains(repoName).click();
+      cy.clickButton('Show Configuration');
+      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
+
+      // Scroll to perClusterResourceCounts section and verify it exists
+      cy.contains('perClusterResourceCounts:').scrollIntoView().should('be.visible');
+      cy.contains('readyClusters: 3').should('be.visible');
+
+      // Verify all 3 clusters are present
+      cy.contains('fleet-default/c-').should('be.visible');
+
+      // Verify the structure contains all expected fields
+      cy.contains('desiredReady: 1').should('be.visible');
+      cy.contains('ready: 1').should('be.visible');
+      cy.contains('missing: 0').should('be.visible');
+      cy.contains('modified: 0').should('be.visible');
+      cy.contains('notReady: 0').should('be.visible');
+      cy.contains('orphaned: 0').should('be.visible');
+      cy.contains('unknown: 0').should('be.visible');
+      cy.contains('waitApplied: 0').should('be.visible');
+
+      // Verify counts match: 3 clusters × 1 resource each
+      cy.get('.CodeMirror').invoke('text').then((yamlText) => {
+        const desiredReadyCount = (yamlText.match(/desiredReady:\s*1/g) || []).length;
+        const readyCount = (yamlText.match(/ready:\s*1/g) || []).length;
+
+        expect(desiredReadyCount).to.equal(3, 'All 3 clusters should have desiredReady: 1');
+        expect(readyCount).to.equal(3, 'All 3 clusters should have ready: 1');
+      });
+
+      cy.clickButton('Close');
+    });
+  });
+})

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1563,8 +1563,8 @@ describe('Validate GitRepo perClusterResourceCounts', { tags: '@p1_2' }, () => {
   it(qase(167, 'Fleet-167: Validate GitRepo status.perClusterResourceCounts shows correct resource counts for each cluster'), { tags: '@fleet-167' }, () => {
     const repoName = 'test-per-cluster-resource-counts';
 
-    // Collect all cluster IDs
-    cy.getClusterIds(dsAllClusterList).then(() => {
+    // Get actual cluster IDs from the system
+    cy.getClusterIds(dsAllClusterList).then((clusterMap) => {
       // Create GitRepo from YAML
       cy.addFleetRepoFromYaml('assets/git-repo-per-cluster-resource-counts.yaml', 'fleet-default');
       cy.verifyTableRow(0, 'Active', repoName);
@@ -1575,30 +1575,54 @@ describe('Validate GitRepo perClusterResourceCounts', { tags: '@p1_2' }, () => {
       cy.clickButton('Show Configuration');
       cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
 
-      // Scroll to perClusterResourceCounts section and verify it exists
+      // Scroll to perClusterResourceCounts section
       cy.contains('perClusterResourceCounts:').scrollIntoView().should('be.visible');
-      cy.contains('readyClusters: 3').should('be.visible');
 
-      // Verify all 3 clusters are present
-      cy.contains('fleet-default/c-').should('be.visible');
+      // Get YAML text and validate each cluster
+      cy.get('.CodeMirror', { log: false }).then(($el) => {
+        const yamlText = $el.text();
+        const clusterIDs = Object.keys(clusterMap);
 
-      // Verify the structure contains all expected fields
-      cy.contains('desiredReady: 1').should('be.visible');
-      cy.contains('ready: 1').should('be.visible');
-      cy.contains('missing: 0').should('be.visible');
-      cy.contains('modified: 0').should('be.visible');
-      cy.contains('notReady: 0').should('be.visible');
-      cy.contains('orphaned: 0').should('be.visible');
-      cy.contains('unknown: 0').should('be.visible');
-      cy.contains('waitApplied: 0').should('be.visible');
+        // Loop through each cluster ID and validate complete structure
+        cy.wrap(clusterIDs).each((clusterID: any) => {
+          const displayName = clusterMap[clusterID];
+          const clusterKey = `fleet-default/${clusterID}:`;
 
-      // Verify counts match: 3 clusters × 1 resource each
-      cy.get('.CodeMirror').invoke('text').then((yamlText) => {
-        const desiredReadyCount = (yamlText.match(/desiredReady:\s*1/g) || []).length;
-        const readyCount = (yamlText.match(/ready:\s*1/g) || []).length;
+          // Verify cluster ID exists in perClusterResourceCounts
+          expect(yamlText).to.include(clusterKey, `Should contain ${clusterKey} for ${displayName}`);
 
-        expect(desiredReadyCount).to.equal(3, 'All 3 clusters should have desiredReady: 1');
-        expect(readyCount).to.equal(3, 'All 3 clusters should have ready: 1');
+          // Extract this cluster's section from YAML
+          const clusterIndex = yamlText.indexOf(clusterKey);
+          const remainingText = yamlText.substring(clusterIndex);
+          const nextClusterMatch = remainingText.indexOf('fleet-default/c-', 1);
+          const readyClustersMatch = remainingText.indexOf('readyClusters:');
+
+          let endIndex = yamlText.length;
+          if (nextClusterMatch > 0) {
+            endIndex = clusterIndex + nextClusterMatch;
+          } else if (readyClustersMatch > 0) {
+            endIndex = clusterIndex + readyClustersMatch;
+          }
+
+          const clusterSection = yamlText.substring(clusterIndex, endIndex);
+
+          // Validate complete structure under this cluster
+          expect(clusterSection).to.match(/desiredReady:\s*1/, `${displayName} should have desiredReady: 1`);
+          expect(clusterSection).to.match(/ready:\s*1/, `${displayName} should have ready: 1`);
+          expect(clusterSection).to.match(/missing:\s*0/, `${displayName} should have missing: 0`);
+          expect(clusterSection).to.match(/modified:\s*0/, `${displayName} should have modified: 0`);
+          expect(clusterSection).to.match(/notReady:\s*0/, `${displayName} should have notReady: 0`);
+          expect(clusterSection).to.match(/orphaned:\s*0/, `${displayName} should have orphaned: 0`);
+          expect(clusterSection).to.match(/unknown:\s*0/, `${displayName} should have unknown: 0`);
+          expect(clusterSection).to.match(/waitApplied:\s*0/, `${displayName} should have waitApplied: 0`);
+
+          cy.log(`✓ Validated complete structure for ${displayName} (${clusterID})`);
+        });
+
+        // After loop, verify readyClusters count
+        const readyClustersMatch = yamlText.match(/readyClusters:\s*(\d+)/);
+        const readyClustersValue = readyClustersMatch ? parseInt(readyClustersMatch[1]) : 0;
+        expect(readyClustersValue).to.equal(3, 'Should have readyClusters: 3');
       });
 
       cy.clickButton('Close');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -155,8 +155,12 @@ Cypress.Commands.add('continuousDeliveryGitRepoRestrictionsMenu', () => {
 Cypress.Commands.add('addFleetRepoFromYaml', (yamlFilePath, fleetNamespace='fleet-local') => {
   cy.continuousDeliveryMenuSelection();
   cy.fleetNamespaceToggle(fleetNamespace);
-  cy.clickButton('Create App Bundle');
-  cy.get('[data-testid="subtype-banner-item-fleet.cattle.io.gitrepo"]').should('be.visible').click();
+  if (fleetNamespace === 'fleet-local') {
+    cy.clickCreateGitRepo(true);
+  }
+  else {
+    cy.clickCreateGitRepo(false);
+  }
   cy.clickButton('Edit as YAML');
   cy.addYamlFile(yamlFilePath);
   cy.clickButton('Create');
@@ -1360,3 +1364,34 @@ Cypress.Commands.add('executeKubectlCommand', (labelCommand, clusterName='local'
   cy.get('i.closer.icon').click();
   }
 );
+
+// Collect cluster IDs for all clusters
+Cypress.Commands.add('getClusterIds', (clusterList) => {
+  const clusterMap: Record<string, string> = {}; // Map clusterID -> displayName
+
+  cy.accesMenuSelection('Cluster Management', 'Clusters');
+
+  cy.wrap(clusterList).each((displayName: any) => {
+    cy.get('input.input-sm.search-box').should('be.visible').clear();
+    cy.wait(500);
+    cy.filterInSearchBox(displayName);
+    cy.wait(500);
+
+    cy.get('tr.main-row')
+      .find('span.cluster-link a')
+      .click();
+
+    cy.get('body').invoke('text').then((pageText) => {
+      const match = pageText.match(/(c-[a-z0-9-]+)/);
+      if (match) {
+        const clusterID = match[1];
+        clusterMap[clusterID] = displayName;
+        cy.log(`Mapped: ${clusterID} → ${displayName}`);
+      }
+    });
+
+    cy.clickNavMenu(['Clusters']);
+  });
+
+  return cy.wrap(clusterMap);
+});

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -88,6 +88,7 @@ declare global {
       addFleetRepoFromYaml(yamlFilePath: string, fleetNamespace?: string): Chainable<Element>;
       executeKubectlCommand(labelCommand: string,clusterName?: string): Chainable<Element>;
       continuousDeliveryGitRepoRestrictionsMenu(): Chainable<Element>;
+      getClusterIds(clusterList: string[]): Chainable<Record<string, string>>;
     }
   }
 }


### PR DESCRIPTION
## Add test to validate GitRepo `perClusterResourceCounts` (167)

Adds Cypress test to verify GitRepo `status.perClusterResourceCounts` shows correct resource counts for each cluster.

### Test validates:
- `readyClusters: 3`
- Each cluster has `desiredReady: 1`, `ready: 1`, and all error counts at 0

### GitRepo `perClusterResourceCounts`  YAML Output looks like:
```yaml
status:
  perClusterResourceCounts:
    fleet-default/c-xxxxx:
      desiredReady: 1
      missing: 0
      modified: 0
      notReady: 0
      orphaned: 0
      ready: 1
      unknown: 0
      waitApplied: 0
    fleet-default/c-yyyyy:
      desiredReady: 1
      missing: 0
      modified: 0
      notReady: 0
      orphaned: 0
      ready: 1
      unknown: 0
      waitApplied: 0
    fleet-default/c-zzzzz:
      desiredReady: 1
      missing: 0
      modified: 0
      notReady: 0
      orphaned: 0
      ready: 1
      unknown: 0
      waitApplied: 0
  readyClusters: 3
```