### PR TITLE
Add wait and table verification to mitigate occasional blank page in GitRepo tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -287,6 +287,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.accesMenuSelection(dsFirstClusterName, 'Storage', 'ConfigMaps');
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.filterInSearchBox('fleet-test-configmap');
+        cy.wait(500); // Adding wait and table verification to mitigate ocassional blank page.
+        cy.verifyTableRow(0, 'fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
       })
@@ -309,6 +311,8 @@ describe('Test resource behavior after deleting GitRepo using keepResources opti
         cy.accesMenuSelection(dsFirstClusterName, 'Storage', 'ConfigMaps');
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.filterInSearchBox('fleet-test-configmap');
+        cy.wait(500); // Adding wait and table verification to mitigate ocassional blank page.
+        cy.verifyTableRow(0, 'fleet-test-configmap');
         cy.get('.col-link-detail').contains('fleet-test-configmap').should('be.visible').click({ force: true });
         cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
       })


### PR DESCRIPTION
## Issue

At times the step between filtering a configmap and clicking on that configmap is not fully completed and leaves the page blank.

[Screencast from 2026-06-04 10-32-54.webm](https://github.com/user-attachments/assets/3309adf6-f471-4ad6-a2c2-ed4acbbd5011)

This never happens with the browser opened but yes ocassionally on 2.15 in headless mode.

<img width="1291" height="1029" alt="2026-May-27_10-32" src="https://github.com/user-attachments/assets/af8cea6e-f763-4081-9b86-b43f93f644f5" />

<img width="1043" height="320" alt="image" src="https://github.com/user-attachments/assets/8b92e284-9f7c-46c3-a701-bb91b7860b7b" />


## Mitigation

Add small wait and extra tablerow verification to ensure the confimap filtering is completed before next step.

Local tests passing:

<img width="1043" height="215" alt="image" src="https://github.com/user-attachments/assets/df748fbb-bea3-4f85-aef5-d3a8ed31c47a" />

CI 2.15 passing: https://github.com/rancher/fleet-e2e/actions/runs/26940341747/job/79483139595#step:10:417
