### PR TITLE
Support both 'textarea' and 'canvas' for in built terminal in Rancher

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -938,20 +938,31 @@ Cypress.Commands.add('verifyJobDeleted', (repoName, verifyJobDeletedEvent = true
 
 // Simulate typing on the canvas terminal
 Cypress.Commands.add('typeIntoCanvasTermnal', (textToType) => {
-    // Simulate typing on the canvas terminal
-    cy.get('canvas').then(($canvas) => {
-      const canvas = $canvas[0];
-      const rect = canvas.getBoundingClientRect();
-    
-      // Simulate a click on the canvas
-      cy.wrap(canvas)
-        .trigger('mousedown', { clientX: rect.left + 10, clientY: rect.top + 10 })
-        .trigger('mouseup', { clientX: rect.left + 10, clientY: rect.top + 10 });
-    
-      // Simulate typing on the canvas
-      cy.wrap(canvas)
-        .trigger('keydown', { key: 'k' })
-        .type(textToType);
+    // Simulate typing on the canvas/textarea terminal
+    // Try newer version (textarea) first, fallback to canvas for older versions
+    cy.get('body').then(($body) => {
+      const $textarea = $body.find('textarea.xterm-helper-textarea');
+
+      if ($textarea.length > 0) {
+        // Newer Rancher version - use textarea
+        cy.wrap($textarea).focus().type(textToType, { delay: 50 });
+      } else {
+        // Older Rancher version - use canvas
+        cy.get('canvas').then(($canvas) => {
+          const canvas = $canvas[0];
+          const rect = canvas.getBoundingClientRect();
+
+          // Simulate a click on the canvas
+          cy.wrap(canvas)
+            .trigger('mousedown', { clientX: rect.left + 10, clientY: rect.top + 10 })
+            .trigger('mouseup', { clientX: rect.left + 10, clientY: rect.top + 10 });
+
+          // Simulate typing on the canvas
+          cy.wrap(canvas)
+            .trigger('keydown', { key: 'k' })
+            .type(textToType);
+        });
+      }
     });
 });
 


### PR DESCRIPTION
### Problem
- P0 and P1_2 tests using, executing commands in terminal.
- Test failures:
  - P1_2 --> CI 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/27328268045/job/80734252596#step:10:573
  - P0 --> CI 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/27384228604/job/80927801370#step:10:433

- Failure reason:
  - `AssertionError: Timed out retrying after 10000ms: Expected to find element: `canvas`, but never found it.`

### Solution
- Find changed locator and update the function with it.
- New locator is `textarea` in 2.15

- This PR will address:
  - 2.15 uses `textarea` and 2.14 below uses `canvas`.
