### PR TITLE
Bump 2.15 to v1.36.1+k3s1

### DIFF
--- a/.github/workflows/ui-rm_head.yaml
+++ b/.github/workflows/ui-rm_head.yaml
@@ -13,7 +13,7 @@ on:
         description: Existing QASE run ID (leave empty to create a new one)
         required: false
         type: string
-        default: ''
+        default: ""
       qase_complete_run:
         description: "`Uncheck` when appending test runs. `Check` on final run to close QASE. For daily runs, keep it checked."
         default: true
@@ -36,16 +36,16 @@ on:
         required: true
       upstream_cluster_version:
         description: K3s upstream cluster version where to install Rancher
-        default: 'v1.35.2+k3s1'
+        default: "v1.36.1+k3s1"
         type: string
         required: true
       grep_test_by_tag:
         description: Grep tags. For multiple selection separate with spaces. Keep always @login
         required: false
         type: string
-        default: '@login @p0 @p1 @p1_2 @rbac @special_tests'
+        default: "@login @p0 @p1 @p1_2 @rbac @special_tests"
   schedule:
-    - cron: '00 23 * * 1-5'
+    - cron: "00 23 * * 1-5"
 
 jobs:
   ui:


### PR DESCRIPTION
Bump 2.15 to use 1.36.1+k3s1

[p0](https://github.com/rancher/fleet-e2e/actions/runs/27675500108) -> green
[p1](https://github.com/rancher/fleet-e2e/actions/runs/27675437483/job/81849557368#step:10:534) -> 2 failures (79,80)
[p1_2](https://github.com/rancher/fleet-e2e/actions/runs/27675414553) -> green
[rbac + special](https://github.com/rancher/fleet-e2e/actions/runs/27675395411/job/81849425908) -> 1 failure (51)