### PR TITLE
Update Git repository creation logic for compatibility with Rancher versions 2.15 and below

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -143,13 +143,21 @@ describe(
       () => {
         const repoName = 'Test.1-repo-local-cluster';
 
-        // Add Fleet repository and create it
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
-        cy.clickButton('Create');
-
-        // Navigate back to GitRepo page
-        cy.clickButton('Cancel');
-        cy.contains(new RegExp(NoAppBundleOrGitRepoPresentMessages.join('|'))).should('be.visible');
+        // For version 2.15 onwards, only add invalid name and check Next button is disabled
+        if (!/\/2\.(1[0-4])/.test(rancherVersion)) {
+          cy.continuousDeliveryMenuSelection();
+          cy.clickCreateGitRepo();
+          cy.typeValue('Name', repoName);
+          cy.wait(500);
+          cy.contains('button', 'Next').should('be.disabled');
+          cy.clickButton('Cancel');
+        } else {
+          // For older versions (2.14 and below), allow Create but verify repo is not created
+          cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+          cy.clickButton('Create');
+          cy.clickButton('Cancel');
+          cy.contains(new RegExp(NoAppBundleOrGitRepoPresentMessages.join('|'))).should('be.visible');
+        }
       },
     );
 
@@ -193,13 +201,21 @@ describe(
       () => {
         const repoName = 'Test.1-repo-local-cluster';
 
-        // Add Fleet repository and create it
-        cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
-        cy.clickButton('Create');
-
-        // Navigate back to GitRepo page
-        cy.clickButton('Cancel');
-        cy.contains(new RegExp(NoAppBundleOrGitRepoPresentMessages.join('|'))).should('be.visible');
+        // For version 2.15 onwards, only add invalid name and check Next button is disabled
+        if (!/\/2\.(1[0-4])/.test(rancherVersion)) {
+          cy.continuousDeliveryMenuSelection();
+          cy.clickCreateGitRepo();
+          cy.typeValue('Name', repoName);
+          cy.wait(500);
+          cy.contains('button', 'Next').should('be.disabled');
+          cy.clickButton('Cancel');
+        } else {
+          // For older versions (2.14 and below), allow Create but verify repo is not created
+          cy.addFleetGitRepo({ repoName, repoUrl, branch, path });
+          cy.clickButton('Create');
+          cy.clickButton('Cancel');
+          cy.contains(new RegExp(NoAppBundleOrGitRepoPresentMessages.join('|'))).should('be.visible');
+        }
       },
     );
   },


### PR DESCRIPTION
### Problem
- In today's CI 2.15: Invalid GitRepo name tests are failing.
- When invalid name is added it not proceeding and failing tests.
- CI link: 
  - Fleet-105: https://github.com/rancher/fleet-e2e/actions/runs/27991215835/job/82843963799#step:10:696
  - Fleet-61: https://github.com/rancher/fleet-e2e/actions/runs/27991215835/job/82843963799#step:10:702
<details><summary>Failed Test 61 and 105</summary>
<p>

<img width="1280" height="720" alt="Test GitRepo Bundle name validation and max character trimming behavior in bundle -- Fleet-105 Test GitRepo NAME with &#39;INVALID and NORMAL characters&#39; displays ERROR message and does NOT get created (Qase ID 105) (failed)" src="https://github.com/user-attachments/assets/8f9a9b01-4834-4044-9874-990a90697bb4" />

<img width="1280" height="720" alt="Test GitRepo Bundle name validation and max character trimming behavior in bundle -- Fleet-61 Test GitRepo NAME with &#39;INVALID and SPECIAL characters&#39; displays ERROR message and does NOT get created (Qase ID 61) (failed)" src="https://github.com/user-attachments/assets/7b29ab2e-b407-4adf-bfc5-e6679ecf07df" />


</p>
</details> 

### Solution
- Update existing tests to check the `Next` button is not enabled.

### Additional Information
- Before fix tests passing on CI 2.15: 
  - 20-Jun: https://github.com/rancher/fleet-e2e/actions/runs/27852913098/job/82435200575#step:10:583 (1 Failure is hiccup.)