### PR TITLE
Refactor test for moving cluster to new workspace and remove feature flag

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -121,7 +121,6 @@ describe(
         const branch = 'master';
         const path = 'simple';
         const repoUrl = 'https://github.com/rancher/fleet-examples';
-        const flagName = 'provisioningv2-fleet-workspace-back-population';
         const newWorkspaceName = 'new-fleet-workspace';
         const fleetDefault = 'fleet-default';
         let timeout = 30000;
@@ -130,9 +129,6 @@ describe(
         if (supported_versions_212_and_above.some((r) => r.test(rancherVersion))) {
           timeout = 70000;
         }
-
-        // Enable cluster can move to another Fleet workspace feature flag.
-        cy.enableFeatureFlag(flagName);
 
         // Create new workspace.
         cy.createNewFleetWorkspace(newWorkspaceName);

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -134,6 +134,7 @@ describe(
         cy.createNewFleetWorkspace(newWorkspaceName);
 
         // Switch to 'fleet-default' workspace
+        cy.continuousDeliveryMenuSelection();
         cy.fleetNamespaceToggle(fleetDefault);
         cy.clickNavMenu(['Clusters']);
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -124,10 +124,12 @@ Cypress.Commands.add('continuousDeliveryWorkspacesMenu', () => {
   cy.get('body', { timeout: 15000 }).then(($body) => {
     if ($body.text().includes('App Bundles')) {
       cy.contains('App Bundles').should('be.visible');
-      cy.clickNavMenu(['Workspaces']);
+      cy.get('nav').contains('Workspaces').click({ force: true });
+      cy.get('.title').contains('Workspaces').should('be.visible');
     } else if ($body.text().includes('Git Repos')) {
       cy.contains('Git Repos').should('be.visible');
       cy.clickNavMenu(['Advanced', 'Workspaces']);
+      cy.contains('Workspaces').should('be.visible');
     } else {
       throw new Error('Neither "App Bundles" nor "Git Repos" found');
     }


### PR DESCRIPTION
### Problem
- For test Fleet-51, 
  - This test will ensure move of Fleet cluster from `fleet-default` workspace to `newly-created workspace`.
- Enable/Disable `provisioningv2-fleet-workspace-back-population` flag is not required for Imported cluster.
- Workspace navigation:
  - Cypress or what, not able to click navigation properly.

### Solution
- In this PR, we are removing `cy.enableFeatureFlag(flagName);`.
- This will ensure cluster move from one workspace to another without enable feature flag.
- Updated direct navigation to the Workspace menu with `force: true` option.

### Screenshot and CI links
- 2.15-head
  - :green_circle: CI Link: https://github.com/rancher/fleet-e2e/actions/runs/29254785690/job/86832227993#step:10:458
 
  <details><summary>Screenshot showing Fleet-51 passes on 2.15</summary>
  <p>
  
  <img width="1419" height="1154" alt="image" src="https://github.com/user-attachments/assets/2a81563f-6e22-46f6-97a4-de1ff3007b62" />
  
  </p>
  </details> 
  

- 2.14-head
  - :green_circle: CI Link: https://github.com/rancher/fleet-e2e/actions/runs/29254764145/job/86832156361#step:10:464
  
  <details><summary>Screenshot showing Fleet-51 passes on 2.14</summary>
  <p>
  
  <img width="1516" height="1239" alt="image" src="https://github.com/user-attachments/assets/66b0b041-5647-4689-ae2c-f32b645d7b03" />
  
  </p>
  </details> 
  