### PR TITLE
Fix insecure registration command check to actual token present

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -309,7 +309,10 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 						"-o", "jsonpath={.items[0].status.insecureCommand}",
 					)
 					return insecureRegistrationCommand
-				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(ContainSubstring("curl --insecure"))
+				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(And(
+					ContainSubstring("curl --insecure"),
+					Not(ContainSubstring("{token}")),
+				))
 
 				// Fill the struct with the values
 				downstreamClusters = append(downstreamClusters, downstreamCluster{

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -302,6 +302,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				GinkgoWriter.Printf("Extracted internal cluster name: %s\n", internalClusterName)
 
 				// Get insecureCommand and replace {token} placeholder with actual token from secret
+				// TODO: Remove this workaround when Rancher bug:https://github.com/rancher/rancher/issues/55923 is fixed - status.insecureCommand should have actual token, not {token} placeholder
 				Eventually(func() string {
 					// Get the command template
 					cmdTemplate, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -301,9 +301,19 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				// DEBUG uncomment to see the internal cluster name
 				GinkgoWriter.Printf("Extracted internal cluster name: %s\n", internalClusterName)
 
-				// Get insecureCommand for importing cluster
-				// INSECURE_COMMAND=$(kubectl get ClusterRegistrationToken.management.cattle.io -n $INTERNAL_CLUSTER_NAME -o jsonpath='{.items[0].status.insecureCommand}')
+				// Get insecureCommand for importing cluster and wait until token is populated
+				// First verify the actual token field is generated, then fetch the command
 				Eventually(func() string {
+					// Check if the token field is populated first
+					token, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+						"--namespace", internalClusterName,
+						"-o", "jsonpath={.items[0].status.token}",
+					)
+					if token == "" {
+						return "" // Token not ready yet, return empty to retry
+					}
+
+					// Token exists, now fetch the insecure command
 					insecureRegistrationCommand, _ = kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
 						"--namespace", internalClusterName,
 						"-o", "jsonpath={.items[0].status.insecureCommand}",

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -301,25 +301,39 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				// DEBUG uncomment to see the internal cluster name
 				GinkgoWriter.Printf("Extracted internal cluster name: %s\n", internalClusterName)
 
-				// Get insecureCommand for importing cluster and wait until token is populated
-				// First verify the actual token field is generated, then fetch the command
+				// Get insecureCommand and replace {token} placeholder with actual token from secret
 				Eventually(func() string {
-					// Check if the token field is populated first
-					token, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
-						"--namespace", internalClusterName,
-						"-o", "jsonpath={.items[0].status.token}",
-					)
-					if token == "" {
-						return "" // Token not ready yet, return empty to retry
-					}
-
-					// Token exists, now fetch the insecure command
-					insecureRegistrationCommand, _ = kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+					// Get the command template
+					cmdTemplate, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
 						"--namespace", internalClusterName,
 						"-o", "jsonpath={.items[0].status.insecureCommand}",
 					)
+					if cmdTemplate == "" {
+						return ""
+					}
+
+					// Get the token secret name
+					tokenSecretName, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+						"--namespace", internalClusterName,
+						"-o", "jsonpath={.items[0].status.tokenSecretName}",
+					)
+					if tokenSecretName == "" {
+						return cmdTemplate
+					}
+
+					// Get the actual token from secret (kubectl auto-decodes base64)
+					actualToken, _ := kubectl.Run("get", "secret", tokenSecretName,
+						"--namespace", internalClusterName,
+						"-o", "go-template={{.data.token | base64decode}}",
+					)
+					if actualToken == "" {
+						return cmdTemplate
+					}
+
+					// Replace {token} with actual token
+					insecureRegistrationCommand = strings.ReplaceAll(cmdTemplate, "{token}", actualToken)
 					return insecureRegistrationCommand
-				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(And(
+				}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(And(
 					ContainSubstring("curl --insecure"),
 					Not(ContainSubstring("{token}")),
 				))


### PR DESCRIPTION
### Problem
- Our CI's are not importing k3d cluster due to issue: `{token}` present in the registration URL instead of actual token string.

### Solution
- With this workaround:
  - Fetch the real token from the secret referenced by tokenSecretName
  - Replace the token placeholder with actual token before executing the registration command.


CI working with fix:
- https://github.com/rancher/fleet-e2e/actions/runs/28779343159

Screenshot of the imported clusters:
<img width="1919" height="961" alt="Screenshot from 2026-07-06 14-27-48" src="https://github.com/user-attachments/assets/81ed02ab-4e1b-42e9-aa17-1c673a365804" />

