### PR TITLE
Add test to verify helmRepoURLRegex set to nothing is not deployed and displays warning

### DIFF
--- a/tests/.prettierignore
+++ b/tests/.prettierignore
@@ -4,3 +4,5 @@ build
 coverage
 *.min.js
 package-lock.json
+assets/local-kubeconfig-skel.yaml
+assets/local-kubeconfig-token-skel.yaml

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -411,6 +411,41 @@ describe('Test OCI support', { tags: ['@p1', '@pr-tests'] }, () => {
       cy.get('section#data').should('contain', 'default-name').and('contain', 'value');
     },
   );
+
+  it(
+    qase(467, 'Fleet-467: Test PRIVATE OCI helm chart without helmRepoURLRegex returns propper error message'),
+    { tags: '@fleet-467' },
+    () => {
+      const repoName = 'local-oci-467';
+      const repoUrl = 'https://github.com/fleetqa/fleet-qa-examples-public';
+      const branch = 'main';
+      const path = 'helm-oci-auth';
+      const gitOrHelmAuth = 'Helm';
+      const gitAuthType = 'http';
+      const userOrPublicKey = Cypress.expose('gh_private_user');
+      const pwdOrPrivateKey = Cypress.expose('gh_private_pwd');
+      const helmRepoURLRegex = '';
+
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.addFleetGitRepo({
+        repoName,
+        repoUrl,
+        branch,
+        path,
+        gitOrHelmAuth,
+        gitAuthType,
+        userOrPublicKey,
+        pwdOrPrivateKey,
+        helmRepoURLRegex,
+      });
+      cy.clickButton('Create');
+      cy.verifyTableRow(0, 'Git Updating', '0/0');
+      cy.contains(
+        '.text-error',
+        'response status code 401: unauthorized: authentication required: helmRepoURLRegex is empty, so Helm credentials were not forwarded; set spec.helmRepoURLRegex to allow credential forwarding',
+      ).should('be.visible');
+    },
+  );
 });
 
 describe(


### PR DESCRIPTION
### Test summary:

Adds E2E coverage for Fleet-467: verifies that creating a GitRepo with private OCI Helm auth and empty helmRepoURLRegex produces the expected 401 error in the UI:

```
response status code 401: unauthorized: authentication required: helmRepoURLRegex is empty, so Helm credentials were not forwarded; set spec.helmRepoURLRegex to allow credential forwarding
```

Confirms error is visible to user and credentials are not forwarded.

---

CI passing in 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/28847484595/job/85556078430#step:10:433

---

Added also in `.gitignore` because Prettier tries to format assets/local-kubeconfig*-skel.yaml files, chokes on %PLACEHOLDER% — YAML spec treats % as directive indicator, invalid as unquoted value start.

```
assets/local-kubeconfig-skel.yaml
assets/local-kubeconfig-token-skel.yaml
```


