### PR TITLE
Adds Cypress E2E coverage for Application Collection (AppCo) and Fleet

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -68,6 +68,12 @@ on:
       github_app_private_key:
         description: GitHub App Private Key for github app connection
         required: false
+      appco_username:
+        description: SUSE Application Collection username
+        required: false
+      appco_access_token:
+        description: SUSE Application Collection access token
+        required: false
 
     inputs:
       branch:
@@ -307,6 +313,8 @@ jobs:
           GH_APP_ID: ${{ secrets.github_app_id }}
           GH_APP_INSTALLATION_ID: ${{ secrets.github_app_installation_id }}
           GH_APP_PRIVATE_KEY: ${{ secrets.github_app_private_key }}
+          APPCO_USERNAME: ${{ secrets.appco_username }}
+          APPCO_ACCESS_TOKEN: ${{ secrets.appco_access_token }}
           QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
           QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
           GREPTAGS: ${{ inputs.grep_test_by_tag }}

--- a/.github/workflows/ui-rm_prime_alpha_rc.yaml
+++ b/.github/workflows/ui-rm_prime_alpha_rc.yaml
@@ -71,6 +71,8 @@ jobs:
       github_app_id: ${{ secrets.GH_APP_ID }}
       github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
       github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      appco_username: ${{ secrets.APPCO_USERNAME }}
+      appco_access_token: ${{ secrets.APPCO_ACCESS_TOKEN }}
     with:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -236,23 +236,7 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
   });
 
   it(qase(469, 'Fleet-469: Test AppCo charts can be installed in local cluster'), { tags: '@fleet-469' }, () => {
-    const appcoUsername = Cypress.expose('appco_username');
-    const appcoAccessToken = Cypress.expose('appco_access_token');
     const charts = ['alertmanager'];
-
-    cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
-    cy.fleetNamespaceToggle('fleet-default');
-    cy.clickButton('Create App Bundle');
-    cy.contains('App Bundle: Create').should('be.visible');
-    cy.contains('SUSE Application Collection').should('be.visible').click();
-    cy.contains('Create an App Bundle from SUSE Application Collection').should('be.visible');
-    cy.get('input[placeholder="user@domain.org"]').type(appcoUsername);
-    cy.wait(1000);
-    cy.get('textarea[placeholder="Your SUSE Application Collection access token"]').type(appcoAccessToken, {
-      log: false,
-    });
-    cy.clickButton('Save');
-    cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
 
     charts.forEach((chartName) => {
       cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
@@ -267,10 +251,10 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
       cy.contains(chartName, { timeout: 15000 }).click();
 
       cy.contains('button', 'Install this version', { timeout: 15000 }).click();
+      cy.get('input[placeholder="A unique name"]').clear().type(chartName);
       cy.clickButton('Create');
 
-      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
-      cy.fleetNamespaceToggle('fleet-local');
+      cy.contains('App Bundles').should('be.visible');
       cy.filterInSearchBox(chartName);
       cy.verifyTableRow(0, 'Active', chartName, 120000);
       cy.verifyTableRow(0, chartName, '1/1');
@@ -278,23 +262,7 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
   });
 
   it(qase(470, 'Fleet-470: Test AppCo charts can be installed in downstream cluster'), { tags: '@fleet-470' }, () => {
-    const appcoUsername = Cypress.expose('appco_username');
-    const appcoAccessToken = Cypress.expose('appco_access_token');
-    const charts = ['vault', 'valkey'];
-
-    cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
-    cy.fleetNamespaceToggle('fleet-default');
-    cy.clickButton('Create App Bundle');
-    cy.contains('App Bundle: Create').should('be.visible');
-    cy.contains('SUSE Application Collection').should('be.visible').click();
-    cy.contains('Create an App Bundle from SUSE Application Collection').should('be.visible');
-    cy.get('input[placeholder="user@domain.org"]').type(appcoUsername);
-    cy.wait(1000);
-    cy.get('textarea[placeholder="Your SUSE Application Collection access token"]').type(appcoAccessToken, {
-      log: false,
-    });
-    cy.clickButton('Save');
-    cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+    const charts = ['tika', 'valkey'];
 
     charts.forEach((chartName) => {
       cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
@@ -309,12 +277,12 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
       cy.contains(chartName, { timeout: 15000 }).click();
 
       cy.contains('button', 'Install this version', { timeout: 15000 }).click();
+      cy.get('input[placeholder="A unique name"]').clear().type(chartName);
       cy.clickButton('Create');
 
-      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
-      cy.fleetNamespaceToggle('fleet-default');
+      cy.contains('App Bundles').should('be.visible');
       cy.filterInSearchBox(chartName);
-      cy.verifyTableRow(0, 'Active', chartName, 120000);
+      cy.verifyTableRow(0, 'Active', chartName, 180000);
       cy.verifyTableRow(0, chartName, /([1-9]\d*)\/\1/);
     });
   });

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -231,7 +231,7 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
         log: false,
       });
       cy.clickButton('Save');
-      cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+      cy.contains('charts in total', { timeout: 120000 }).should('be.visible');
     });
   });
 

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -211,3 +211,111 @@ describe('Global settings related tests', { tags: '@special_tests' }, () => {
     },
   );
 });
+
+describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
+  it(qase(468, 'Fleet-468: Verify AppCo connection with Fleet'), { tags: '@fleet-468' }, () => {
+    const appcoUsername = Cypress.expose('appco_username');
+    const appcoAccessToken = Cypress.expose('appco_access_token');
+    const namespaces = ['fleet-local', 'fleet-default'];
+
+    namespaces.forEach((namespace) => {
+      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+      cy.fleetNamespaceToggle(namespace);
+      cy.clickButton('Create App Bundle');
+      cy.contains('App Bundle: Create').should('be.visible');
+      cy.contains('SUSE Application Collection').should('be.visible').click();
+      cy.contains('Create an App Bundle from SUSE Application Collection').should('be.visible');
+      cy.get('input[placeholder="user@domain.org"]').type(appcoUsername);
+      cy.wait(1000);
+      cy.get('textarea[placeholder="Your SUSE Application Collection access token"]').type(appcoAccessToken, {
+        log: false,
+      });
+      cy.clickButton('Save');
+      cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+    });
+  });
+
+  it(qase(469, 'Fleet-469: Test AppCo charts can be installed in local cluster'), { tags: '@fleet-469' }, () => {
+    const appcoUsername = Cypress.expose('appco_username');
+    const appcoAccessToken = Cypress.expose('appco_access_token');
+    const charts = ['alertmanager'];
+
+    cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+    cy.fleetNamespaceToggle('fleet-default');
+    cy.clickButton('Create App Bundle');
+    cy.contains('App Bundle: Create').should('be.visible');
+    cy.contains('SUSE Application Collection').should('be.visible').click();
+    cy.contains('Create an App Bundle from SUSE Application Collection').should('be.visible');
+    cy.get('input[placeholder="user@domain.org"]').type(appcoUsername);
+    cy.wait(1000);
+    cy.get('textarea[placeholder="Your SUSE Application Collection access token"]').type(appcoAccessToken, {
+      log: false,
+    });
+    cy.clickButton('Save');
+    cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+
+    charts.forEach((chartName) => {
+      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.clickButton('Create App Bundle');
+      cy.contains('App Bundle: Create').should('be.visible');
+      cy.contains('SUSE Application Collection').should('be.visible').click();
+      cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+
+      cy.get('input[placeholder="Search the catalog..."]').clear().type(chartName);
+      cy.wait(1000);
+      cy.contains(chartName, { timeout: 15000 }).click();
+
+      cy.contains('button', 'Install this version', { timeout: 15000 }).click();
+      cy.clickButton('Create');
+
+      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+      cy.fleetNamespaceToggle('fleet-local');
+      cy.filterInSearchBox(chartName);
+      cy.verifyTableRow(0, 'Active', chartName, 120000);
+      cy.verifyTableRow(0, chartName, '1/1');
+    });
+  });
+
+  it(qase(470, 'Fleet-470: Test AppCo charts can be installed in downstream cluster'), { tags: '@fleet-470' }, () => {
+    const appcoUsername = Cypress.expose('appco_username');
+    const appcoAccessToken = Cypress.expose('appco_access_token');
+    const charts = ['vault', 'valkey'];
+
+    cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+    cy.fleetNamespaceToggle('fleet-default');
+    cy.clickButton('Create App Bundle');
+    cy.contains('App Bundle: Create').should('be.visible');
+    cy.contains('SUSE Application Collection').should('be.visible').click();
+    cy.contains('Create an App Bundle from SUSE Application Collection').should('be.visible');
+    cy.get('input[placeholder="user@domain.org"]').type(appcoUsername);
+    cy.wait(1000);
+    cy.get('textarea[placeholder="Your SUSE Application Collection access token"]').type(appcoAccessToken, {
+      log: false,
+    });
+    cy.clickButton('Save');
+    cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+
+    charts.forEach((chartName) => {
+      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.clickButton('Create App Bundle');
+      cy.contains('App Bundle: Create').should('be.visible');
+      cy.contains('SUSE Application Collection').should('be.visible').click();
+      cy.contains('charts in total', { timeout: 60000 }).should('be.visible');
+
+      cy.get('input[placeholder="Search the catalog..."]').clear().type(chartName);
+      cy.wait(1000);
+      cy.contains(chartName, { timeout: 15000 }).click();
+
+      cy.contains('button', 'Install this version', { timeout: 15000 }).click();
+      cy.clickButton('Create');
+
+      cy.accesMenuSelection('Continuous Delivery', 'App Bundles');
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.filterInSearchBox(chartName);
+      cy.verifyTableRow(0, 'Active', chartName, 120000);
+      cy.verifyTableRow(0, chartName, /([1-9]\d*)\/\1/);
+    });
+  });
+});

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -55,6 +55,8 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.expose.gh_app_id = process.env.GH_APP_ID;
   config.expose.gh_app_installation_id = process.env.GH_APP_INSTALLATION_ID;
   config.expose.gh_app_private_key = process.env.GH_APP_PRIVATE_KEY;
+  config.expose.appco_username = process.env.APPCO_USERNAME;
+  config.expose.appco_access_token = process.env.APPCO_ACCESS_TOKEN;
 
   return config;
 };

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -68,6 +68,8 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     -e "GH_APP_ID=$GH_APP_ID"                       \
     -e "GH_APP_INSTALLATION_ID=$GH_APP_INSTALLATION_ID"     \
     -e "GH_APP_PRIVATE_KEY=$GH_APP_PRIVATE_KEY"     \
+    -e "APPCO_USERNAME=$APPCO_USERNAME"                     \
+    -e "APPCO_ACCESS_TOKEN=$APPCO_ACCESS_TOKEN"             \
     --add-host host.docker.internal:host-gateway            \
     --ipc=host                                              \
     $CYPRESS_DOCKER                                         \


### PR DESCRIPTION
- New suite `special_fleet_tests.spec.ts` (`@appco` tag)
We start installing only 3 charts: `alertmanager`, `tika` and `valkey`. More to come soon.

  - **Fleet-468**: connects AppCo credentials for `fleet-local` and `fleet-default` namespaces.
  - **Fleet-469**: installs `alertmanager` chart via AppCo into local cluster.
  - **Fleet-470**: installs `tika` + `valkey` charts via AppCo into downstream cluster.

- CI plumbing: added `APPCO_USERNAME` / `APPCO_ACCESS_TOKEN` secrets pass-through in:
  - `.github/workflows/master-e2e.yaml`
  - `.github/workflows/ui-rm_prime_alpha_rc.yaml`
  - `tests/cypress/plugins/index.ts`
  - `tests/scripts/start-cypress-tests`
  
  ***Important***: 
  - Only works in Prime
  - Test adapted for `2.15.0-alpha.17`; previous versions may fail due to some changes while deploying charts.
 ---
 
CI passing in `2.15.0-alpha-17`: https://github.com/rancher/fleet-e2e/actions/runs/29091758818

<img width="1135" height="164" alt="image" src="https://github.com/user-attachments/assets/c03fd404-4c2a-4a24-9ff6-e97ddc713052" />

