### PR TITLE
Refactor insecure command retrieval for cluster registration based on Rancher version

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -301,43 +301,54 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				// DEBUG uncomment to see the internal cluster name
 				GinkgoWriter.Printf("Extracted internal cluster name: %s\n", internalClusterName)
 
-				// Get insecureCommand and replace {token} placeholder with actual token from secret
-				// TODO: Remove this workaround when Rancher bug:https://github.com/rancher/rancher/issues/55923 is fixed - status.insecureCommand should have actual token, not {token} placeholder
-				Eventually(func() string {
-					// Get the command template
-					cmdTemplate, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
-						"--namespace", internalClusterName,
-						"-o", "jsonpath={.items[0].status.insecureCommand}",
-					)
-					if cmdTemplate == "" {
-						return ""
-					}
+				// Get insecureCommand for importing cluster
+				if useDirectInsecureCmd {
+					// Rancher <= 2.12: status.insecureCommand already embeds the real token, use as-is.
+					Eventually(func() string {
+						insecureRegistrationCommand, _ = kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.insecureCommand}",
+						)
+						return insecureRegistrationCommand
+					}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(ContainSubstring("curl --insecure"))
+				} else {
+					// Rancher 2.13+: resolve the real token from the secret and replace the {token} placeholder (rancher/rancher#55923).
+					Eventually(func() string {
+						// Get the command template
+						cmdTemplate, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.insecureCommand}",
+						)
+						if cmdTemplate == "" {
+							return ""
+						}
 
-					// Get the token secret name
-					tokenSecretName, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
-						"--namespace", internalClusterName,
-						"-o", "jsonpath={.items[0].status.tokenSecretName}",
-					)
-					if tokenSecretName == "" {
-						return cmdTemplate
-					}
+						// Get the token secret name
+						tokenSecretName, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.tokenSecretName}",
+						)
+						if tokenSecretName == "" {
+							return cmdTemplate
+						}
 
-					// Get the actual token from secret (kubectl auto-decodes base64)
-					actualToken, _ := kubectl.Run("get", "secret", tokenSecretName,
-						"--namespace", internalClusterName,
-						"-o", "go-template={{.data.token | base64decode}}",
-					)
-					if actualToken == "" {
-						return cmdTemplate
-					}
+						// Get the actual token from secret (kubectl auto-decodes base64)
+						actualToken, _ := kubectl.Run("get", "secret", tokenSecretName,
+							"--namespace", internalClusterName,
+							"-o", "go-template={{.data.token | base64decode}}",
+						)
+						if actualToken == "" {
+							return cmdTemplate
+						}
 
-					// Replace {token} with actual token
-					insecureRegistrationCommand = strings.ReplaceAll(cmdTemplate, "{token}", actualToken)
-					return insecureRegistrationCommand
-				}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(And(
-					ContainSubstring("curl --insecure"),
-					Not(ContainSubstring("{token}")),
-				))
+						// Replace {token} with actual token
+						insecureRegistrationCommand = strings.ReplaceAll(cmdTemplate, "{token}", actualToken)
+						return insecureRegistrationCommand
+					}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(And(
+						ContainSubstring("curl --insecure"),
+						Not(ContainSubstring("{token}")),
+					))
+				}
 
 				// Fill the struct with the values
 				downstreamClusters = append(downstreamClusters, downstreamCluster{

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,8 @@ var (
 	rancherUpgradeHeadVersion string
 	rancherUpgradeVersion     string
 	testCaseID                int64
+	// useDirectInsecureCmd is true for Rancher <= 2.12, whose insecureCommand embeds the real token.
+	useDirectInsecureCmd bool
 )
 
 /**
@@ -141,6 +144,19 @@ var _ = BeforeSuite(func() {
 		}
 		if len(s) > 2 {
 			rancherHeadVersion = s[2]
+		}
+
+		// Set useDirectInsecureCmd for Rancher <= 2.12 (e.g. "2.11", "2.12.12-alpha1").
+		if v := strings.SplitN(rancherVersion, ".", 3); len(v) >= 2 {
+			maj, errMaj := strconv.Atoi(strings.TrimSpace(v[0]))
+			minStr := v[1]
+			if i := strings.IndexFunc(minStr, func(r rune) bool { return r < '0' || r > '9' }); i >= 0 {
+				minStr = minStr[:i]
+			}
+			min, errMin := strconv.Atoi(minStr)
+			if errMaj == nil && errMin == nil {
+				useDirectInsecureCmd = maj < 2 || (maj == 2 && min <= 12)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Select `insecureCommand` handling by Rancher version

### Problem
- Rancher changed how the downstream cluster registration command is exposed on `ClusterRegistrationToken.status.insecureCommand`.
- Rancher **≤2.12** embeds the real token directly in the command, while **2.13+** ships a `{token}` placeholder that must be resolved from the registration token secret [rancher/rancher#55923](https://github.com/rancher/rancher/issues/55923)
- A single hard-coded approach only works for one version range, causing the k3d import
step to fail on the other.

### Solution
- Detect the Rancher version once in `BeforeSuite` and branch the registration-command logic:
  - **≤2.12** → read `status.insecureCommand` and use it as-is.
  - **2.13+** → resolve the token from the registration token secret and replace the `{token}` placeholder.

- Version detection reuses the existing `RANCHER_VERSION` parsing and exposes a `useDirectInsecureCmd` flag.
- It handles forms like `head/2.11` and `prime-alpha/2.12.12-alpha1`; unparseable/empty values default to the 2.13+ path.

### 2.11 and 2.12 head Status
- :green_circle: 2.11-head: https://github.com/rancher/fleet-e2e/actions/runs/29347653681/job/87135601727
- :green_circle: 2.12-head: https://github.com/rancher/fleet-e2e/actions/runs/29345403164/job/87127819770


### 2.12 alpha run status
- :green_circle: 2.12.12-alpha1: https://github.com/rancher/fleet-e2e/actions/runs/29392979135/job/87280328258

### 2.13, 2.14 and head (2.15) version status
- :green_circle: 2.14-head: https://github.com/rancher/fleet-e2e/actions/runs/29393839641
- :green_circle: 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/29393799922/job/87282788012
- :green_circle: 2.13-head: Check the PR CI.