### PR TITLE
Improve resource section loading in bundleDeployment test for better reliability

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1697,8 +1697,9 @@ describe('Validate bundleDeployment labels and status.resources', { tags: '@p1_2
 
       // Navigate to BundleDeployments
       cy.accesMenuSelection('local');
-      cy.clickNavMenu(['More Resources', 'Fleet', 'BundleDeployments']);
       cy.nameSpaceMenuToggle('All Namespaces');
+      cy.clickNavMenu(['More Resources', 'Fleet', 'BundleDeployments']);
+
 
       // Search for the bundle created by our GitRepo
       cy.filterInSearchBox(repoName);

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1700,7 +1700,6 @@ describe('Validate bundleDeployment labels and status.resources', { tags: '@p1_2
       cy.nameSpaceMenuToggle('All Namespaces');
       cy.clickNavMenu(['More Resources', 'Fleet', 'BundleDeployments']);
 
-
       // Search for the bundle created by our GitRepo
       cy.filterInSearchBox(repoName);
       cy.get('td.col-link-detail > span').contains(repoName).click();

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1704,16 +1704,15 @@ describe('Validate bundleDeployment labels and status.resources', { tags: '@p1_2
       cy.filterInSearchBox(repoName);
       cy.get('td.col-link-detail > span').contains(repoName).click();
 
-      // Scroll the main content area to bottom to see resources section
-      cy.get('main').scrollTo('bottom');
-      cy.wait(500);
-
+      // The detail page's resources section loads asynchronously, so wait for
+      // the content to render and scroll it into view rather than scrolling to a
+      // guessed page bottom before the content exists.
       // Verify the deployment resource details in order: apiVersion, createdAt, kind, name, namespace
-      cy.contains('apiVersion: apps/v1').should('be.visible');
-      cy.contains(/createdAt:\s*'?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z'?/);
-      cy.contains('kind: Deployment').should('be.visible');
-      cy.contains(`name: ${appName}`).should('be.visible');
-      cy.contains(`namespace: ${appName}`).should('be.visible');
+      cy.contains('apiVersion: apps/v1', { timeout: 30000 }).scrollIntoView().should('be.visible');
+      cy.contains(/createdAt:\s*'?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z'?/).should('be.visible');
+      cy.contains('kind: Deployment').scrollIntoView().should('be.visible');
+      cy.contains(`name: ${appName}`).scrollIntoView().should('be.visible');
+      cy.contains(`namespace: ${appName}`).scrollIntoView().should('be.visible');
     },
   );
 });


### PR DESCRIPTION
### Problem
- Fleet-81, test is failing due to not able to scroll to the bottom of `bundleDeployment` page and failing. (See below screenshot for more details)
- CI 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/29394316406/job/87284341768#step:10:508

<details><summary>Fleet-81 Error screenshot</summary>
<p>

<img width="1308" height="623" alt="image" src="https://github.com/user-attachments/assets/c35faf0e-7321-4d67-8e37-444236c5ee1f" />


</p>
</details> 

### Solution
- Added `.scrollIntoView()` cypress function to each verification element.


### CI results
- :green_circle: 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/29417858755/job/87360574769#step:10:496
- :green_circle: 2.14-head: https://github.com/rancher/fleet-e2e/actions/runs/29417910921/job/87360770695#step:10:496