### PR TITLE
Automate new 122

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -828,3 +828,22 @@ if (
     );
   });
 }
+
+describe.only('Test GitRepo creation from a Git revision instead of a branch', { tags: '@p1' }, () => {
+  it(
+    qase(122, 'Fleet-122: Test GitRepo can be created from a specific Git revision (tag) instead of a branch'),
+    { tags: '@fleet-122' },
+    () => {
+      const repoName = 'local-cluster-revision-122';
+      const revision = 'v1.0.0';
+
+      // Create a GitRepo pinned to a Git revision (tag) instead of the master branch.
+      cy.addFleetGitRepo({ repoName, repoUrl, revision, path, local: true });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+
+      // Application should be deployed from the pinned revision.
+      cy.checkApplicationStatus(appName);
+    },
+  );
+});

--- a/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_fleet.spec.ts
@@ -829,7 +829,7 @@ if (
   });
 }
 
-describe.only('Test GitRepo creation from a Git revision instead of a branch', { tags: '@p1' }, () => {
+describe('Test GitRepo creation from a Git revision instead of a branch', { tags: '@p1' }, () => {
   it(
     qase(122, 'Fleet-122: Test GitRepo can be created from a specific Git revision (tag) instead of a branch'),
     { tags: '@fleet-122' },

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -231,12 +231,8 @@ Cypress.Commands.add(
       }
       // Use a specific Git revision (tag or commit) instead of a branch.
       if (revision) {
-        cy.get('div.labeled-select.create.hoverable')
-          .first()
-          .should('be.visible');
-        cy.get('div.labeled-select.create.hoverable')
-          .first()
-          .click({ force: true });
+        cy.get('div.labeled-select.create.hoverable').first().should('be.visible');
+        cy.get('div.labeled-select.create.hoverable').first().click({ force: true });
         cy.get('ul.vs__dropdown-menu > li').contains('A Revision').should('exist').click();
         cy.typeValue('Tag or Commit Hash', revision);
       }

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -231,7 +231,14 @@ Cypress.Commands.add(
       }
       // Use a specific Git revision (tag or commit) instead of a branch.
       if (revision) {
-        cy.typeValue('Revision', revision);
+        cy.get('div.labeled-select.create.hoverable')
+          .first()
+          .should('be.visible');
+        cy.get('div.labeled-select.create.hoverable')
+          .first()
+          .click({ force: true });
+        cy.get('ul.vs__dropdown-menu > li').contains('A Revision').should('exist').click();
+        cy.typeValue('Tag or Commit Hash', revision);
       }
     }
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -192,6 +192,7 @@ Cypress.Commands.add(
     repoName,
     repoUrl,
     branch,
+    revision,
     path,
     path2,
     gitOrHelmAuth,
@@ -225,7 +226,13 @@ Cypress.Commands.add(
       cy.clickButton('Next');
 
       cy.typeValue('Repository URL', repoUrl);
-      cy.typeValue('Branch Name', branch);
+      if (branch) {
+        cy.typeValue('Branch Name', branch);
+      }
+      // Use a specific Git revision (tag or commit) instead of a branch.
+      if (revision) {
+        cy.typeValue('Revision', revision);
+      }
     }
 
     if (path) {

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -41,6 +41,7 @@ declare global {
         repoName: string,
         repoUrl?: string,
         branch?: string,
+        revision?: string,
         path?: string,
         path2?: string,
         fleetNamespace?: string,


### PR DESCRIPTION
### New automation
- Fleet-122 is new test automation, which verifies GitRepo deploys application from the revision i.e. tags created on GitHub repository.
- It is normal GitRepo creation, the key difference:
  - It fetches applications from tag/revision.

### CI status
- :green_circle: 2.15-head: https://github.com/rancher/fleet-e2e/actions/runs/29424217233/job/87382438715#step:10:456
- :green_circle: 2.14-head: https://github.com/rancher/fleet-e2e/actions/runs/29424245422/job/87382546454#step:10:453
- :green_circle: 2.13-head: https://github.com/rancher/fleet-e2e/actions/runs/29493622569/job/87605453946#step:10:452
- :green_circle: 2.12-head: https://github.com/rancher/fleet-e2e/actions/runs/29489560241/job/87592254572#step:10:426
