### PR TITLE
Fix FLEET-200 flakiness

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -93,7 +93,7 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.clickButton('Save');
 
         // Verify the cluster is still Active
-        cy.wait(20000); // Wait to allow time to the status to reach "Wait" before verifying"
+        cy.wait(60000); // Wait to allow time to the status to reach "Wait" before verifying"
         cy.verifyTableRow(0, 'Active', '1');
 
         // Verify PriorityClass and PodDisruptionBudget

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -93,7 +93,7 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.clickButton('Save');
 
         // Verify the cluster is still Active
-        cy.wait(2000); // Wait to allow time to the status to reach "Wait" before verifying"
+        cy.wait(20000); // Wait to allow time to the status to reach "Wait" before verifying"
         cy.verifyTableRow(0, 'Active', '1');
 
         // Verify PriorityClass and PodDisruptionBudget

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -81,6 +81,7 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.get('.CodeMirror').then((codeMirrorElement) => {
           const cm = (codeMirrorElement[0] as any).CodeMirror;
           const currentYaml = cm.getValue();
+          // prettier-ignore
           const snippet = `\
   agentSchedulingCustomization:
     priorityClass:
@@ -93,14 +94,16 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.clickButton('Save');
 
         // Verify the cluster is still Active
-        cy.wait(60000); // Wait to allow time to the status to reach "Wait" before verifying"
-        cy.verifyTableRow(0, 'Active', '1');
+        cy.verifyTableRow(0, 'Active', '1', 600000);
 
         // Verify PriorityClass and PodDisruptionBudget
         cy.accesMenuSelection('local', 'Policy', 'Pod Disruption Budgets');
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.verifyTableRow(0, 'fleet-agent', '3');
-        cy.accesMenuSelection('local', 'More Resources', 'Scheduling');
+        cy.accesMenuSelection('local', 'More Resources');
+        cy.get('nav.side-nav')
+          .contains(/^Scheduling$/)
+          .click();
         cy.contains('PriorityClasses').click();
         cy.verifyTableRow(0, 'fleet-agent', '888');
       },

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -67,7 +67,7 @@ describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => 
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypress.expose('rancher_version'))) {
   describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
-    it.only(
+    it(
       qase(200, 'FLEET-200: Test agent scheduling customization for PDB and PriorityClass'),
       { tags: '@fleet-200' },
       () => {

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -67,7 +67,7 @@ describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => 
 
 if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypress.expose('rancher_version'))) {
   describe('Agent Scheduling Customization', { tags: '@special_tests' }, () => {
-    it(
+    it.only(
       qase(200, 'FLEET-200: Test agent scheduling customization for PDB and PriorityClass'),
       { tags: '@fleet-200' },
       () => {
@@ -78,19 +78,24 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.clickButton('Edit as YAML');
 
         // Append the agent scheduling customization
-        cy.get('.CodeMirror').then((codeMirrorElement) => {
-          const cm = (codeMirrorElement[0] as any).CodeMirror;
-          const currentYaml = cm.getValue();
-          // prettier-ignore
-          const snippet = `\
+        cy.get('.CodeMirror')
+          .should(($el) => {
+            expect(($el[0] as any).CodeMirror.getValue()).to.include('kind: Cluster');
+          })
+          .then((codeMirrorElement) => {
+            const cm = (codeMirrorElement[0] as any).CodeMirror;
+            const currentYaml = cm.getValue();
+            // prettier-ignore
+            const snippet = `\
   agentSchedulingCustomization:
     priorityClass:
       value: 888
     podDisruptionBudget:
       minAvailable: "3"`;
-          const newYaml = currentYaml.replace(/(\nspec:)/, `$1\n${snippet}`);
-          cm.setValue(newYaml);
-        });
+            const newYaml = currentYaml.replace(/(\nspec:)/, `$1\n${snippet}`);
+            expect(newYaml, 'snippet was actually inserted').to.not.eq(currentYaml);
+            cm.setValue(newYaml);
+          });
         cy.clickButton('Save');
 
         // Verify the cluster is still Active
@@ -101,9 +106,8 @@ if (!/\/2\.11/.test(Cypress.expose('rancher_version')) && !/\/2\.12/.test(Cypres
         cy.nameSpaceMenuToggle('All Namespaces');
         cy.verifyTableRow(0, 'fleet-agent', '3');
         cy.accesMenuSelection('local', 'More Resources');
-        cy.get('nav.side-nav')
-          .contains(/^Scheduling$/)
-          .click();
+        // prettier-ignore
+        cy.get('nav.side-nav').contains(/^Scheduling$/).scrollIntoView().click();
         cy.contains('PriorityClasses').click();
         cy.verifyTableRow(0, 'fleet-agent', '888');
       },


### PR DESCRIPTION

`special_fleet_tests.spec.ts` — FLEET-200 (agent scheduling customization: PDB + PriorityClass) was intermittently failing on CI.

## Root causes

1. **Silent YAML injection failure.** `cy.get('.CodeMirror').then(...)` could read the editor before Rancher finished populating the cluster YAML (race), or the `spec:` regex silently no-op'd. Either way `newYaml === currentYaml`, Save persisted no real change, and the test failed ~60s later on an empty PDB table with a misleading timeout error instead of failing at the actual point of cause.
2. **Cluster state assert too tight.** The post-save check that the cluster returns to `Active` didn't allow enough time for the agent restart triggered by the PDB/PriorityClass change.
3. **Flaky nav click.** `accesMenuSelection('local', 'More Resources', 'Scheduling')` occasionally clicked the wrong side-nav item when `Scheduling` was scrolled out of view.

## Fixes (`special_fleet_tests.spec.ts`)

- Assert the CodeMirror editor has real content loaded (`kind: Cluster`) before reading it, and `expect(newYaml).to.not.eq(currentYaml)` to fail fast if the snippet insertion is a no-op — turns a confusing downstream timeout into an immediate, clear failure at the actual cause.
- Bumped `verifyTableRow` timeout on the post-save `Active` check to 600000ms.
- Added `.scrollIntoView()` before clicking `Scheduling` in the side nav.

## Verified

Passed locally after fixes.

## CI Passing

-2.14: https://github.com/rancher/fleet-e2e/actions/runs/29425798485
-2.15: https://github.com/rancher/fleet-e2e/actions/runs/29425635720