### PR TITLE
Add automation for GitJob's job cloud provider taint toleration

### DIFF
--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -805,51 +805,55 @@ describe('Test GitJob security context', { tags: ['@p0', '@pr-tests'] }, () => {
   });
 });
 
-describe('Test GitJob tolerations', { tags: '@p0' }, () => {
+describe.only('Test GitJob tolerations', { tags: '@p0' }, () => {
   // Ref: https://github.com/rancher/fleet/issues/2783
   // GitJob must tolerate the common cloud provider taint
   // 'node.cloudprovider.kubernetes.io/uninitialized' so that jobs can be
   // scheduled on nodes that are still being initialized by the cloud provider.
-  it(
-    qase(150, 'FLEET-150: Test GitJob tolerates cloud provider "uninitialized" taint'),
-    { tags: '@fleet-150' },
-    () => {
-      const repoName = 'local-150-gitjob-cloudprovider-toleration';
-      const repoUrl = 'https://github.com/rancher/fleet-test-data/';
-      const branch = 'master';
-      // Use a bad path on purpose: an unsuccessful GitJob is NOT cleaned up, so
-      // the Job (with its tolerations) remains available for inspection. On a
-      // successful run the Job is removed immediately, which makes the
-      // toleration impossible to verify reliably from the UI.
-      const path = 'qa-test-apps/nginx-app-bad-path';
-      const cloudProviderToleration = 'node.cloudprovider.kubernetes.io/uninitialized';
+  it(qase(150, 'FLEET-150: Test GitJob tolerates cloud provider "uninitialized" taint'), { tags: '@fleet-150' }, () => {
+    const repoName = 'local-150-gitjob-cloudprovider-toleration';
+    const repoUrl = 'https://github.com/rancher/fleet-test-data/';
+    const branch = 'master';
+    // Use a bad path on purpose: an unsuccessful GitJob is NOT cleaned up, so
+    // the Job (with its tolerations) remains available for inspection. On a
+    // successful run the Job is removed immediately, which makes the
+    // toleration impossible to verify reliably from the UI.
+    const path = 'qa-test-apps/nginx-app-bad-path';
+    const cloudProviderToleration = 'node.cloudprovider.kubernetes.io/uninitialized';
 
-      // Deploy GitRepo
-      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
-      cy.clickButton('Create');
-      cy.verifyTableRow(0, /Git Updating|Error/, '0/0');
+    // Deploy GitRepo
+    cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
+    cy.clickButton('Create');
+    cy.verifyTableRow(0, /Git Updating|Error/, '0/0');
 
-      // Navigate to the Kubernetes Job created by GitJob
-      cy.accesMenuSelection('local', 'Workloads', 'Jobs');
-      cy.nameSpaceMenuToggle('All Namespaces');
-      cy.filterInSearchBox(repoName);
-      cy.get('table > tbody > tr').contains(repoName).should('be.visible');
+    // Navigate to the Kubernetes Job created by GitJob
+    cy.accesMenuSelection('local', 'Workloads', 'Jobs');
+    cy.nameSpaceMenuToggle('All Namespaces');
+    cy.filterInSearchBox(repoName);
+    cy.get('table > tbody > tr').contains(repoName).should('be.visible');
 
-      // Open the Job's YAML and verify the cloud provider toleration is present.
-      // Assert on booleans (not the YAML string) so Cypress does not dump the
-      // entire Job YAML into the command log/output.
-      cy.open3dotsMenu(repoName, 'View YAML');
-      cy.get('.CodeMirror', { log: false }).then(($el) => {
-        const yamlText = $el.text();
-        expect(
-          yamlText.includes(cloudProviderToleration),
-          `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
-        ).to.be.true;
-        // The toleration is a NoSchedule/Equal toleration with value "true".
-        expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
-      });
-    },
-  );
+    // Open the Job's YAML from its detail page and verify the cloud provider
+    // toleration is present. Assert on booleans (not the YAML string) so
+    // Cypress does not dump the entire Job YAML into the command log/output.
+    cy.contains(repoName).click();
+    // 'Show Configuration' + YAML tab is available from Rancher 2.14 onwards;
+    // older versions expose a direct 'YAML' button on the detail page.
+    if (!/\/2\.(1[0-3])/.test(Cypress.expose('rancher_version'))) {
+      cy.clickButton('Show Configuration');
+      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
+    } else {
+      cy.clickButton('YAML');
+    }
+    cy.get('.CodeMirror', { log: false }).then(($el) => {
+      const yamlText = $el.text();
+      expect(
+        yamlText.includes(cloudProviderToleration),
+        `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
+      ).to.be.true;
+      // The toleration is a NoSchedule/Equal toleration with value "true".
+      expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
+    });
+  });
 });
 
 describe('Test lifecycle secrets', { tags: '@p0' }, () => {

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -832,17 +832,23 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
     cy.filterInSearchBox(repoName);
     cy.get('table > tbody > tr').contains(repoName).should('be.visible');
 
-    // Open the Job's YAML from its detail page and verify the cloud provider
-    // toleration is present. Assert on booleans (not the YAML string) so
-    // Cypress does not dump the entire Job YAML into the command log/output.
-    cy.contains(repoName).click();
-    // 'Show Configuration' + YAML tab is available from Rancher 2.14 onwards;
-    // older versions expose a direct 'YAML' button on the detail page.
-    if (!/\/2\.(1[0-3])/.test(Cypress.expose('rancher_version'))) {
+    // Open the Job's YAML and verify the cloud provider toleration is
+    // present. Assert on booleans (not the YAML string) so Cypress does not
+    // dump the entire Job YAML into the command log/output.
+    if (/\/2\.11/.test(Cypress.expose('rancher_version'))) {
+      // Rancher 2.11 has no 'Show Configuration' detail view; open the Job YAML
+      // from the list 3-dot menu instead. The action is labelled 'Edit YAML' or
+      // 'View YAML' depending on the Job's edit permission - accept either.
+      cy.contains('tr.main-row', repoName).find('.icon.icon-actions').click({ force: true });
+      cy.get('.list-unstyled.menu li, [role="menuitem"]')
+        .contains(/View YAML|Edit YAML/)
+        .click({ force: true });
+    } else {
+      // 'Show Configuration' + YAML tab exists on the resource detail page
+      // from Rancher 2.12 onwards.
+      cy.contains(repoName).click();
       cy.clickButton('Show Configuration');
       cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
-    } else {
-      cy.clickButton('YAML');
     }
     cy.get('.CodeMirror', { log: false }).then(($el) => {
       const yamlText = $el.text();

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -849,7 +849,6 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
       ).to.eq(true);
       expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.eq(true);
     });
-
     // Visibility: scroll the toleration line into view and confirm it renders.
     cy.get('.CodeMirror').contains(cloudProviderToleration).scrollIntoView().should('be.visible');
   });

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -832,15 +832,19 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
       .contains(/View YAML|Edit YAML/)
       .click({ force: true });
 
-    // Assert on booleans so Cypress does not dump the whole YAML into the log.
+    // Existence: read the full document (getValue) since CodeMirror only renders
+    // the visible lines. Assert on booleans so the whole YAML is not logged.
     cy.get('.CodeMirror', { log: false }).then(($el) => {
-      const yamlText = $el.text();
+      const yamlText = ($el[0] as any).CodeMirror.getValue();
       expect(
         yamlText.includes(cloudProviderToleration),
         `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
       ).to.be.true;
       expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
     });
+
+    // Visibility: scroll the toleration line into view and confirm it renders.
+    cy.get('.CodeMirror').contains(cloudProviderToleration).scrollIntoView().should('be.visible');
   });
 });
 

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -805,7 +805,7 @@ describe('Test GitJob security context', { tags: ['@p0', '@pr-tests'] }, () => {
   });
 });
 
-describe.only('Test GitJob tolerations', { tags: '@p0' }, () => {
+describe('Test GitJob tolerations', { tags: '@p0' }, () => {
   // Ref: https://github.com/rancher/fleet/issues/2783
   // GitJob must tolerate the common cloud provider taint
   // 'node.cloudprovider.kubernetes.io/uninitialized' so that jobs can be

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -805,6 +805,53 @@ describe('Test GitJob security context', { tags: ['@p0', '@pr-tests'] }, () => {
   });
 });
 
+describe('Test GitJob tolerations', { tags: '@p0' }, () => {
+  // Ref: https://github.com/rancher/fleet/issues/2783
+  // GitJob must tolerate the common cloud provider taint
+  // 'node.cloudprovider.kubernetes.io/uninitialized' so that jobs can be
+  // scheduled on nodes that are still being initialized by the cloud provider.
+  it(
+    qase(150, 'FLEET-150: Test GitJob tolerates cloud provider "uninitialized" taint'),
+    { tags: '@fleet-150' },
+    () => {
+      const repoName = 'local-150-gitjob-cloudprovider-toleration';
+      const repoUrl = 'https://github.com/rancher/fleet-test-data/';
+      const branch = 'master';
+      // Use a bad path on purpose: an unsuccessful GitJob is NOT cleaned up, so
+      // the Job (with its tolerations) remains available for inspection. On a
+      // successful run the Job is removed immediately, which makes the
+      // toleration impossible to verify reliably from the UI.
+      const path = 'qa-test-apps/nginx-app-bad-path';
+      const cloudProviderToleration = 'node.cloudprovider.kubernetes.io/uninitialized';
+
+      // Deploy GitRepo
+      cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
+      cy.clickButton('Create');
+      cy.verifyTableRow(0, /Git Updating|Error/, '0/0');
+
+      // Navigate to the Kubernetes Job created by GitJob
+      cy.accesMenuSelection('local', 'Workloads', 'Jobs');
+      cy.nameSpaceMenuToggle('All Namespaces');
+      cy.filterInSearchBox(repoName);
+      cy.get('table > tbody > tr').contains(repoName).should('be.visible');
+
+      // Open the Job's YAML and verify the cloud provider toleration is present.
+      // Assert on booleans (not the YAML string) so Cypress does not dump the
+      // entire Job YAML into the command log/output.
+      cy.open3dotsMenu(repoName, 'View YAML');
+      cy.get('.CodeMirror', { log: false }).then(($el) => {
+        const yamlText = $el.text();
+        expect(
+          yamlText.includes(cloudProviderToleration),
+          `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
+        ).to.be.true;
+        // The toleration is a NoSchedule/Equal toleration with value "true".
+        expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
+      });
+    },
+  );
+});
+
 describe('Test lifecycle secrets', { tags: '@p0' }, () => {
   const repoUrl = 'https://github.com/rancher/fleet-test-data/';
   const branch = 'master';

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -823,7 +823,7 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
     cy.accesMenuSelection('local', 'Workloads', 'Jobs');
     cy.nameSpaceMenuToggle('All Namespaces');
     cy.filterInSearchBox(repoName);
-    cy.verifyTableRow(0, /Active|Running|Failed/, repoName);
+    cy.verifyTableRow(0, /Active|Running|Failed|Error/, repoName);
 
     // 3-dot YAML action opens CodeMirror on all versions (2.11 - 2.15);
     // its label is 'Edit YAML' or 'View YAML' depending on edit permission.

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -807,56 +807,38 @@ describe('Test GitJob security context', { tags: ['@p0', '@pr-tests'] }, () => {
 
 describe('Test GitJob tolerations', { tags: '@p0' }, () => {
   // Ref: https://github.com/rancher/fleet/issues/2783
-  // GitJob must tolerate the common cloud provider taint
-  // 'node.cloudprovider.kubernetes.io/uninitialized' so that jobs can be
-  // scheduled on nodes that are still being initialized by the cloud provider.
   it(qase(150, 'FLEET-150: Test GitJob tolerates cloud provider "uninitialized" taint'), { tags: '@fleet-150' }, () => {
     const repoName = 'local-150-gitjob-cloudprovider-toleration';
     const repoUrl = 'https://github.com/rancher/fleet-test-data/';
     const branch = 'master';
-    // Use a bad path on purpose: an unsuccessful GitJob is NOT cleaned up, so
-    // the Job (with its tolerations) remains available for inspection. On a
-    // successful run the Job is removed immediately, which makes the
-    // toleration impossible to verify reliably from the UI.
+    // Bad path keeps the (unsuccessful) Job around; successful Jobs are deleted immediately.
     const path = 'qa-test-apps/nginx-app-bad-path';
     const cloudProviderToleration = 'node.cloudprovider.kubernetes.io/uninitialized';
 
-    // Deploy GitRepo
     cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
     cy.clickButton('Create');
     cy.verifyTableRow(0, /Git Updating|Error/, '0/0');
 
-    // Navigate to the Kubernetes Job created by GitJob
+    // Open the Job created by GitJob
     cy.accesMenuSelection('local', 'Workloads', 'Jobs');
     cy.nameSpaceMenuToggle('All Namespaces');
     cy.filterInSearchBox(repoName);
-    cy.get('table > tbody > tr').contains(repoName).should('be.visible');
+    cy.verifyTableRow(0, /Active|Running|Failed/, repoName);
 
-    // Open the Job's YAML and verify the cloud provider toleration is
-    // present. Assert on booleans (not the YAML string) so Cypress does not
-    // dump the entire Job YAML into the command log/output.
-    if (/\/2\.11/.test(Cypress.expose('rancher_version'))) {
-      // Rancher 2.11 has no 'Show Configuration' detail view; open the Job YAML
-      // from the list 3-dot menu instead. The action is labelled 'Edit YAML' or
-      // 'View YAML' depending on the Job's edit permission - accept either.
-      cy.contains('tr.main-row', repoName).find('.icon.icon-actions').click({ force: true });
-      cy.get('.list-unstyled.menu li, [role="menuitem"]')
-        .contains(/View YAML|Edit YAML/)
-        .click({ force: true });
-    } else {
-      // 'Show Configuration' + YAML tab exists on the resource detail page
-      // from Rancher 2.12 onwards.
-      cy.contains(repoName).click();
-      cy.clickButton('Show Configuration');
-      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
-    }
+    // 3-dot YAML action opens CodeMirror on all versions (2.11 - 2.15);
+    // its label is 'Edit YAML' or 'View YAML' depending on edit permission.
+    cy.contains('tr.main-row', repoName).find('.icon.icon-actions').click({ force: true });
+    cy.get('.list-unstyled.menu li, [role="menuitem"]')
+      .contains(/View YAML|Edit YAML/)
+      .click({ force: true });
+
+    // Assert on booleans so Cypress does not dump the whole YAML into the log.
     cy.get('.CodeMirror', { log: false }).then(($el) => {
       const yamlText = $el.text();
       expect(
         yamlText.includes(cloudProviderToleration),
         `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
       ).to.be.true;
-      // The toleration is a NoSchedule/Equal toleration with value "true".
       expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
     });
   });

--- a/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p0_fleet.spec.ts
@@ -825,12 +825,19 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
     cy.filterInSearchBox(repoName);
     cy.verifyTableRow(0, /Active|Running|Failed|Error/, repoName);
 
-    // 3-dot YAML action opens CodeMirror on all versions (2.11 - 2.15);
-    // its label is 'Edit YAML' or 'View YAML' depending on edit permission.
-    cy.contains('tr.main-row', repoName).find('.icon.icon-actions').click({ force: true });
-    cy.get('.list-unstyled.menu li, [role="menuitem"]')
-      .contains(/View YAML|Edit YAML/)
-      .click({ force: true });
+    // Open the Job's YAML. From 2.12 onwards the detail page exposes
+    // 'Show Configuration' + a YAML tab; 2.11 has neither, so fall back to the
+    // list 3-dot action ('Edit YAML' / 'View YAML' depending on edit permission).
+    if (/\/2\.11/.test(Cypress.expose('rancher_version'))) {
+      cy.contains('tr.main-row', repoName).find('.icon.icon-actions').click({ force: true });
+      cy.get('.list-unstyled.menu li, [role="menuitem"]')
+        .contains(/View YAML|Edit YAML/)
+        .click({ force: true });
+    } else {
+      cy.contains(repoName).click();
+      cy.clickButton('Show Configuration');
+      cy.get('[data-testid="btn-yaml-tab"]').contains('YAML').click();
+    }
 
     // Existence: read the full document (getValue) since CodeMirror only renders
     // the visible lines. Assert on booleans so the whole YAML is not logged.
@@ -839,8 +846,8 @@ describe('Test GitJob tolerations', { tags: '@p0' }, () => {
       expect(
         yamlText.includes(cloudProviderToleration),
         `GitJob's Job should tolerate the "${cloudProviderToleration}" taint`,
-      ).to.be.true;
-      expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.be.true;
+      ).to.eq(true);
+      expect(yamlText.includes('NoSchedule'), 'Toleration should use the "NoSchedule" effect').to.eq(true);
     });
 
     // Visibility: scroll the toleration line into view and confirm it renders.


### PR DESCRIPTION
### What
Adds a new Cypress test **FLEET-150** verifying that the Kubernetes Job created by GitJob tolerates the common cloud provider taint `node.cloudprovider.kubernetes.io/uninitialized`.

### How the test works
- Creates a `GitRepo` in the `local` cluster.
- Navigates to the Kubernetes **Job** created by GitJob (Workloads → Jobs).
- Opens the Job's YAML (`View YAML`) and asserts the `node.cloudprovider.kubernetes.io/uninitialized` toleration is present with the `NoSchedule` effect.

### Notes
- The test uses an intentionally **bad repo path** so the Job is unsuccessful and therefore **not auto-cleaned**, keeping it available for YAML inspection. Successful GitJob Jobs are deleted immediately, which makes the toleration impossible to verify reliably from the UI. The toleration is set at Job creation regardless of clone success, so this remains a valid check.
- Assertions are made on **booleans** (`yamlText.includes(...)`) rather than the full YAML string, so Cypress does not dump the entire Job YAML into the command log/output.

### CI Statuses

- :green_circle: 2.15-head: 
  - https://github.com/rancher/fleet-e2e/actions/runs/29582080730/job/87890076717#step:10:447
  - https://github.com/rancher/fleet-e2e/actions/runs/29920691698/job/88927659307#step:10:447
  
- :green_circle: 2.14-head: 
  - https://github.com/rancher/fleet-e2e/actions/runs/29582228610/job/87890575450#step:10:449
  - https://github.com/rancher/fleet-e2e/actions/runs/29917051936/job/88913392766#step:10:447
  
- :green_circle: 2.13-head: 
  - https://github.com/rancher/fleet-e2e/actions/runs/29582096213/job/87890110173#step:10:446
  - https://github.com/rancher/fleet-e2e/actions/runs/29917063037/job/88913422432#step:10:448
  
- :green_circle: 2.12-head: 
  - https://github.com/rancher/fleet-e2e/actions/runs/29582194229/job/87890436141#step:10:416
  - https://github.com/rancher/fleet-e2e/actions/runs/29917075135/job/88913447819#step:10:421

### Current implementation problem
- 2.15 onwards, `Gitjob`'s  `job` doesn't contain `View YAML` or `Edit YAML` menu in Edit Job menu (see below screenshot)
- So, for 2.12 onwards, checking Toleration via `Show Configuration` menu only.
- For 2.11 checking it via `View YAML` or `Edit YAML` way.

  <details><summary>Screenshot showing absence of View YAML or Edit YAML option on Job page.</summary>
  <p>
  
  <img width="2559" height="1289" alt="Screenshot from 2026-07-22 17-44-26" src="https://github.com/user-attachments/assets/dd25236c-c749-46a6-bd31-73cd603593f1" />
  
  </p>
  </details> 