### PR TITLE
Refactor insecure command retrieval for cluster registration based on Rancher version

### DIFF
--- a/tests/e2e/only_certs_and_rancher_install_test.go
+++ b/tests/e2e/only_certs_and_rancher_install_test.go
@@ -260,14 +260,53 @@ var _ = Describe("E2E - Deploy only certs and Rancher Manager", Label("deploy-on
 				GinkgoWriter.Printf("Extracted internal cluster name: %s\n", internalClusterName)
 
 				// Get insecureCommand for importing cluster
-				// INSECURE_COMMAND=$(kubectl get ClusterRegistrationToken.management.cattle.io -n $INTERNAL_CLUSTER_NAME -o jsonpath='{.items[0].status.insecureCommand}')
-				Eventually(func() string {
-					insecureRegistrationCommand, _ = kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
-						"--namespace", internalClusterName,
-						"-o", "jsonpath={.items[0].status.insecureCommand}",
-					)
-					return insecureRegistrationCommand
-				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(ContainSubstring("curl --insecure"))
+				if useDirectInsecureCmd {
+					// Rancher <= 2.12: status.insecureCommand already embeds the real token, use as-is.
+					Eventually(func() string {
+						insecureRegistrationCommand, _ = kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.insecureCommand}",
+						)
+						return insecureRegistrationCommand
+					}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(ContainSubstring("curl --insecure"))
+				} else {
+					// Rancher 2.13+: resolve the real token from the secret and replace the {token} placeholder (rancher/rancher#55923).
+					Eventually(func() string {
+						// Get the command template
+						cmdTemplate, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.insecureCommand}",
+						)
+						if cmdTemplate == "" {
+							return ""
+						}
+
+						// Get the token secret name
+						tokenSecretName, _ := kubectl.Run("get", "ClusterRegistrationToken.management.cattle.io",
+							"--namespace", internalClusterName,
+							"-o", "jsonpath={.items[0].status.tokenSecretName}",
+						)
+						if tokenSecretName == "" {
+							return cmdTemplate
+						}
+
+						// Get the actual token from secret (kubectl auto-decodes base64)
+						actualToken, _ := kubectl.Run("get", "secret", tokenSecretName,
+							"--namespace", internalClusterName,
+							"-o", "go-template={{.data.token | base64decode}}",
+						)
+						if actualToken == "" {
+							return cmdTemplate
+						}
+
+						// Replace {token} with actual token
+						insecureRegistrationCommand = strings.ReplaceAll(cmdTemplate, "{token}", actualToken)
+						return insecureRegistrationCommand
+					}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(And(
+						ContainSubstring("curl --insecure"),
+						Not(ContainSubstring("{token}")),
+					))
+				}
 
 				// Fill the struct with the values
 				downstreamClusters = append(downstreamClusters, downstreamCluster{


### PR DESCRIPTION
Applying same logic of import cluster in `only_certs_and_rancher_install_test.go` file.

### CI status
- :green_circle: All hardening tests are passing (confirmed by @mmartin24, thanks :smile: )
  - 2.13: https://github.com/rancher/fleet-e2e/actions/runs/29728203938
  - 2.14: https://github.com/rancher/fleet-e2e/actions/runs/29730202072
  - 2.15: https://github.com/rancher/fleet-e2e/actions/runs/29730232271