### PR TITLE
Increase timeout for verifying active clusters in EC2 deployment test

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -55,7 +55,7 @@ describe('Test Fleet on AWS EC2 imported cluster', { tags: '@cloud_ds' }, () => 
     cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: false });
     cy.clickButton('Create');
     cy.wait(45000); // Adding 45 seconds due to slow comunication and size of ec2 cluster
-    cy.verifyTableRow(0, 'Active', '4/4'); // 4 clusters means gitrepo was deployed to ec2 cluster
+    cy.verifyTableRow(0, 'Active', '4/4', 1200000); // 4 clusters means gitrepo was deployed to ec2 cluster
   });
 
   it(qase(188, 'Delete EC2 cluster'), () => {


### PR DESCRIPTION
Done:

Adding implict timeout to wait for gitrepo to be deployed in all clusters.

CI working:

2.12: https://github.com/rancher/fleet-e2e/actions/runs/29810705161/job/88570948632#step:10:381
2.13: https://github.com/rancher/fleet-e2e/actions/runs/29810743941/job/88571073654#step:10:408
2.14: https://github.com/rancher/fleet-e2e/actions/runs/29810783233/job/88571218981#step:10:406
2.15: https://github.com/rancher/fleet-e2e/actions/runs/29810811617/job/88571272104#step:10:455

<img width="962" height="187" alt="image" src="https://github.com/user-attachments/assets/b4939d80-cf4b-485e-8a50-c57d44db7c40" />
