### PR TITLE
Add test `defaultServiceAccount` GitRepoRestriction enforcement

### DIFF
--- a/tests/assets/git-repo-restrictions-153.yaml
+++ b/tests/assets/git-repo-restrictions-153.yaml
@@ -1,0 +1,14 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: local-gitreporestrictions-fleet-153
+  namespace: fleet-default
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+    - qa-test-apps/nginx-app
+  targets:
+    - clusterSelector:
+        matchLabels:
+          management.cattle.io/cluster-display-name: imported-0

--- a/tests/assets/git-repo-restrictions-default-service-account.yaml
+++ b/tests/assets/git-repo-restrictions-default-service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepoRestriction
+metadata:
+  name: restriction
+  namespace: fleet-default
+defaultServiceAccount: limited-service-account

--- a/tests/assets/limited-service-account.yaml
+++ b/tests/assets/limited-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: limited-service-account
+  namespace: cattle-fleet-system

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1285,6 +1285,65 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.deleteAll(false);
     },
   );
+
+  it(
+    qase(153, 'Fleet-153: Test "defaultServiceAccount" from "GitRepoRestrictions" is enforced on downstream cluster'),
+    { tags: '@fleet-153' },
+    () => {
+      const repoName = 'local-gitreporestrictions-fleet-153';
+      const dsCluster = 'imported-0';
+
+      // Ensure no GitRepoRestriction is left over from a previous (failed) run,
+      // otherwise the "unrestricted" deploy below would be restricted too.
+      cy.continuousDeliveryMenuSelection();
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.wait(1000);
+      cy.deleteAll(false);
+
+      // Deploy GitRepo, no restriction present yet, deploy succeeds using the fleet-agent's own credentials.
+      cy.addFleetRepoFromYaml('assets/git-repo-restrictions-153.yaml', 'fleet-default');
+      cy.verifyTableRow(0, 'Active', repoName);
+      cy.checkGitRepoStatus(repoName, '1 / 1');
+      cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
+
+      // Add "limited-service-account" on the downstream cluster, pointed at by the restriction below.
+      // It has no RoleBinding, so it has no permissions on the downstream cluster.
+      cy.importYaml(dsCluster, 'assets/limited-service-account-rolebinding.yaml');
+
+      // Add GitRepoRestriction on the upstream cluster, defaulting the GitRepo's service account.
+      cy.continuousDeliveryMenuSelection();
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
+      cy.clickButton('Create from YAML');
+      cy.addYamlFile('assets/git-repo-restrictions-default-service-account.yaml');
+      cy.clickButton('Create');
+
+      // Let the page settle on the GitRepoRestrictions list before navigating away,
+      // otherwise the burger-menu click below can be intercepted by a covering nav element.
+      cy.contains('restriction').should('be.visible');
+
+      // Force update the GitRepo, so it picks up the "defaultServiceAccount" restriction.
+      cy.continuousDeliveryMenuSelection();
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.open3dotsMenu(repoName, 'Force Update');
+
+      // Deploy is now denied: the Bundle's error banner names the defaulted service
+      // account, proving the restriction's defaulting was applied, and that its lack
+      // of RBAC on the downstream cluster is what denies the deploy.
+      cy.verifyTableRow(0, 'Err Applied', repoName);
+      cy.contains(repoName).click();
+      cy.contains('limited-service-account').should('be.visible');
+
+      // Cleanup: remove the restriction. The GitRepo itself is cleaned up by the
+      // top-level beforeEach's cy.deleteAllFleetRepos() before the next test runs.
+      cy.continuousDeliveryMenuSelection();
+      cy.continuousDeliveryGitRepoRestrictionsMenu();
+      cy.fleetNamespaceToggle('fleet-default');
+      cy.get('table > tbody > tr').contains('restriction').should('be.visible');
+      cy.wait(1000);
+      cy.deleteAll(false);
+    },
+  );
 });
 
 describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.', { tags: '@p1_2' }, () => {

--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1308,8 +1308,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
 
       // Add "limited-service-account" on the downstream cluster, pointed at by the restriction below.
-      // It has no RoleBinding, so it has no permissions on the downstream cluster.
-      cy.importYaml(dsCluster, 'assets/limited-service-account-rolebinding.yaml');
+      cy.importYaml({ clusterName: dsCluster, yamlFilePath: 'assets/limited-service-account.yaml' });
 
       // Add GitRepoRestriction on the upstream cluster, defaulting the GitRepo's service account.
       cy.continuousDeliveryMenuSelection();
@@ -1320,7 +1319,7 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
 
       // Let the page settle on the GitRepoRestrictions list before navigating away,
       // otherwise the burger-menu click below can be intercepted by a covering nav element.
-      cy.contains('restriction').should('be.visible');
+      cy.verifyTableRow(0, 'Active', 'restriction');
 
       // Force update the GitRepo, so it picks up the "defaultServiceAccount" restriction.
       cy.continuousDeliveryMenuSelection();
@@ -1328,19 +1327,16 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
       cy.open3dotsMenu(repoName, 'Force Update');
 
       // Deploy is now denied: the Bundle's error banner names the defaulted service
-      // account, proving the restriction's defaulting was applied, and that its lack
-      // of RBAC on the downstream cluster is what denies the deploy.
+      // account, proving the restriction's defaulting was applied.
       cy.verifyTableRow(0, 'Err Applied', repoName);
       cy.contains(repoName).click();
       cy.contains('limited-service-account').should('be.visible');
 
-      // Cleanup: remove the restriction. The GitRepo itself is cleaned up by the
-      // top-level beforeEach's cy.deleteAllFleetRepos() before the next test runs.
+      // Cleanup: remove the restriction.
       cy.continuousDeliveryMenuSelection();
       cy.continuousDeliveryGitRepoRestrictionsMenu();
       cy.fleetNamespaceToggle('fleet-default');
-      cy.get('table > tbody > tr').contains('restriction').should('be.visible');
-      cy.wait(1000);
+      cy.verifyTableRow(0, 'Active', 'restriction');
       cy.deleteAll(false);
     },
   );

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -90,7 +90,7 @@ Cypress.Commands.add('importYaml', ({ clusterName, yamlFilePath }) => {
   });
   cy.clickButton('Import');
   cy.get('div.card-container')
-    .contains(/Applied \d+ Resources/)
+    .contains(/Applied \d+ Resources?/)
     .should('be.visible');
 
   // Check if there is a column with age which contains a number

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -91,7 +91,7 @@ declare global {
       deleteUser(userName: string): Chainable<Element>;
       deleteAllUsers(): Chainable<Element>;
       deleteRole(roleName: string, roleTypeTemplate: string): Chainable<Element>;
-      importYaml(clusterName: string, yamlFilePath: string): Chainable<Element>;
+      importYaml({ clusterName, yamlFilePath }: { clusterName: string; yamlFilePath: string }): Chainable<Element>;
       allowRancherPreReleaseVersions(): Chainable<Element>;
       upgradeFleet(): Chainable<Element>;
       assignClusterLabel(clusterName: string, key: string, value: string): Chainable<Element>;


### PR DESCRIPTION
## Summary
- Add Cypress test verifying that a `GitRepoRestriction`'s `defaultServiceAccount` is applied to a `GitRepo` and enforced on the downstream cluster (deploy denied when the service account has no RBAC).
- Add fixture assets: GitRepo, GitRepoRestriction, and ServiceAccount YAMLs used by the new test.
- Fix `importYaml` regex in `commands.ts` (`Applied \d+ Resources` → `Applied \d+ Resources?`) to match the singular-resource case.
- Fix `importYaml` type declaration in `e2e.ts` to match its actual object-parameter implementation.

CI passing in 2.15: https://github.com/rancher/fleet-e2e/actions/runs/29908655962/job/88886169831#step:10:468