### PR TITLE
Increase implicit timeout for version 2.12 and above in special fleet tests

### DIFF
--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -134,7 +134,7 @@ describe(
 
         //Version check for 2.12 (head)
         if (supported_versions_212_and_above.some((r) => r.test(rancherVersion))) {
-          timeout = 70000;
+          timeout = 180000; // 3 minutes for 2.12 and above
         }
 
         // Create new workspace.

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -1280,9 +1280,8 @@ Cypress.Commands.add('moveClusterToWorkspace', (clusterName, workspaceName, time
   cy.clickNavMenu(['Clusters']);
   cy.filterInSearchBox(clusterName);
 
-  // After move, cluster requires around 60seconds to back in Active state.
-  cy.wait(timeout);
-  cy.verifyTableRow(0, 'Active', clusterName);
+  // After move, cluster requires more than 60 seconds to back in Active state.
+  cy.verifyTableRow(0, 'Active', clusterName, timeout);
 });
 
 Cypress.Commands.add(


### PR DESCRIPTION
### Problem
- Test Fleet-51 is failing due to imported cluster is not being active within given time.

### Solution
- Increase the timeout value to 3 mins (earlier 1 min).

### CI statuses
- :green_circle: 2.15
  - https://github.com/rancher/fleet-e2e/actions/runs/29926473940/job/88945002863#step:10:412
- :green_circle: 2.14
  - https://github.com/rancher/fleet-e2e/actions/runs/29923318129/job/88934184569#step:10:417
- :green_circle: 2.13
  - https://github.com/rancher/fleet-e2e/actions/runs/29990966414/job/89153565099#step:10:417
- :green_circle: 2.12
  - https://github.com/rancher/fleet-e2e/actions/runs/29926442803/job/88950317264#step:10:386