### PR TITLE
Fix qase reporting for rbac and others trimming test titles to <255 characters

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -227,8 +227,7 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
       QASE_TESTOPS_COMPLETE_RUN: ${{ inputs.qase_complete_run }}
-      QASE_LOGGING_CONSOLE: true
-      QASE_DEBUG: true
+      QASE_LOGGING_CONSOLE: false
 
     steps:
       - name: Adding /usr/local/bin into PATH

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -227,7 +227,8 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
       QASE_TESTOPS_COMPLETE_RUN: ${{ inputs.qase_complete_run }}
-      QASE_LOGGING_CONSOLE: false
+      QASE_LOGGING_CONSOLE: true
+      QASE_DEBUG: true
 
     steps:
       - name: Adding /usr/local/bin into PATH

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -227,8 +227,7 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       QASE_TESTOPS_RUN_ID: ${{ inputs.qase_run_id }}
       QASE_TESTOPS_COMPLETE_RUN: ${{ inputs.qase_complete_run }}
-      QASE_LOGGING_CONSOLE: true
-      QASE_DEBUG: true
+      QASE_LOGGING_CONSOLE: false
 
     steps:
       - name: Adding /usr/local/bin into PATH
@@ -321,15 +320,7 @@ jobs:
           GREPTAGS: ${{ inputs.grep_test_by_tag }}
           UPGRADE: "false"
           # Add cypress/e2e/unit_tests/user.spec.ts again when implementing RBAC tests.
-          SPEC: |
-            cypress/e2e/unit_tests/first_login_rancher.spec.ts
-            cypress/e2e/unit_tests/p0_fleet.spec.ts
-            cypress/e2e/unit_tests/p1_fleet.spec.ts
-            cypress/e2e/unit_tests/p1_2_fleet.spec.ts
-            cypress/e2e/unit_tests/rbac_fleet.spec.ts
-            cypress/e2e/unit_tests/upgrade_fleet.spec.ts
-            cypress/e2e/unit_tests/hardened_fleet.spec.ts
-            cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+          SPEC: cypress/e2e/unit_tests/first_login_rancher.spec.ts,cypress/e2e/unit_tests/p0_fleet.spec.ts,cypress/e2e/unit_tests/p1_fleet.spec.ts,cypress/e2e/unit_tests/p1_2_fleet.spec.ts,cypress/e2e/unit_tests/rbac_fleet.spec.ts,cypress/e2e/unit_tests/upgrade_fleet.spec.ts,cypress/e2e/unit_tests/hardened_fleet.spec.ts,cypress/e2e/unit_tests/special_fleet_tests.spec.ts
         run: |
           if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN
@@ -434,9 +425,7 @@ jobs:
           K8S_VERSION_UPGRADE_DS_CLUSTER_TO: ${{ inputs.k8s_version_to_upgrade_ds_cluster_to }}
           QASE_TESTOPS_RUN_ID: ${{ steps.qase_run_id.outputs.qase_run_id }}
           QASE_MODE: ${{ inputs.qase_report == true && 'testops' || 'off' }}
-          SPEC: |
-            cypress/e2e/unit_tests/first_login_rancher.spec.ts
-            cypress/e2e/unit_tests/upgrade_fleet.spec.ts
+          SPEC: cypress/e2e/unit_tests/first_login_rancher.spec.ts,cypress/e2e/unit_tests/upgrade_fleet.spec.ts
         run: |
           if [[ "${{ inputs.qase_report }}" != "true" ]]; then
             unset QASE_API_TOKEN

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'cypress';
 import { plugin as cypressGrepPlugin } from '@cypress/grep/plugin';
-import { afterSpecHook } from 'cypress-qase-reporter/hooks';
 import { writeFileSync } from 'fs';
 
 const qaseAPIToken = process.env.QASE_API_TOKEN;
@@ -79,9 +78,6 @@ export default defineConfig({
       cypressGrepPlugin(config);
       require('cypress-qase-reporter/plugin')(on, config);
       require('cypress-qase-reporter/metadata')(on);
-      on('after:spec', async (spec, results) => {
-        await afterSpecHook(spec, config);
-      });
       on('before:spec', () => {
         // Writes QASE_TESTOPS_RUN_ID to a file before running each spec.
         // Used in .github/workflows/master-e2e.yaml for:

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -884,7 +884,7 @@ describe(
 );
 
 describe(
-  'Test Fleet access with RBAC with "CUSTOM ROLES" and "GITREPOS" using "USER-BASE" user',
+  'Test Fleet access with RBAC with "CUSTOM ROLES" and "FLEETWORKSPACES" using "USER-BASE" user',
   { tags: '@rbac' },
   () => {
     it(

--- a/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/rbac_fleet.spec.ts
@@ -274,7 +274,7 @@ describe('Test Fleet access with RBAC with custom roles using Standard User', { 
   it(
     qase(
       42,
-      'Test "Standard User" role user with custom role to "fleetworkspaces", "gitrepos" and "bundles" and  ALL verbs access CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Cluster Registration Tokens" "BundleNamespaceMappings" and "GitRepoRestrictions"',
+      'Test "Standard User" role with custom role to "fleetworkspaces", "gitrepos" and "bundles" and ALL verbs CAN access "Workspaces", "Bundles" and "Git Repos" but NOT "Cluster Registration Tokens", "BundleNamespaceMappings" and "GitRepoRestrictions"',
     ),
     { tags: '@fleet-42' },
     () => {

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -45,6 +45,8 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     -e QASE_TESTOPS_RUN_DESCRIPTION="$QASE_TESTOPS_RUN_DESCRIPTION" \
     -e QASE_TESTOPS_RUN_ID=$QASE_TESTOPS_RUN_ID             \
     -e QASE_TESTOPS_BATCH_SIZE=1                            \
+    -e QASE_LOGGING_CONSOLE=$QASE_LOGGING_CONSOLE           \
+    -e QASE_DEBUG=$QASE_DEBUG                               \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -44,6 +44,9 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     -e QASE_TESTOPS_RUN_TITLE="$QASE_TESTOPS_RUN_TITLE"     \
     -e QASE_TESTOPS_RUN_DESCRIPTION="$QASE_TESTOPS_RUN_DESCRIPTION" \
     -e QASE_TESTOPS_RUN_ID=$QASE_TESTOPS_RUN_ID             \
+    -e QASE_TESTOPS_BATCH_SIZE=1                            \
+    -e QASE_LOGGING_CONSOLE=$QASE_LOGGING_CONSOLE           \
+    -e QASE_DEBUG=$QASE_DEBUG                               \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -45,8 +45,6 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     -e QASE_TESTOPS_RUN_DESCRIPTION="$QASE_TESTOPS_RUN_DESCRIPTION" \
     -e QASE_TESTOPS_RUN_ID=$QASE_TESTOPS_RUN_ID             \
     -e QASE_TESTOPS_BATCH_SIZE=1                            \
-    -e QASE_LOGGING_CONSOLE=$QASE_LOGGING_CONSOLE           \
-    -e QASE_DEBUG=$QASE_DEBUG                               \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \
@@ -76,4 +74,4 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     --add-host host.docker.internal:host-gateway            \
     --ipc=host                                              \
     $CYPRESS_DOCKER                                         \
-    -s $SPEC
+    -s "$SPEC"

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -44,9 +44,6 @@ docker run --init -v $PWD:/workdir -w /workdir ${GH_MOUNT} ${KUBECTL_MOUNT} ${KU
     -e QASE_TESTOPS_RUN_TITLE="$QASE_TESTOPS_RUN_TITLE"     \
     -e QASE_TESTOPS_RUN_DESCRIPTION="$QASE_TESTOPS_RUN_DESCRIPTION" \
     -e QASE_TESTOPS_RUN_ID=$QASE_TESTOPS_RUN_ID             \
-    -e QASE_TESTOPS_BATCH_SIZE=1                            \
-    -e QASE_LOGGING_CONSOLE=$QASE_LOGGING_CONSOLE           \
-    -e QASE_DEBUG=$QASE_DEBUG                               \
     -e RANCHER_VERSION=$RANCHER_VERSION                     \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \


### PR DESCRIPTION
## Summary

RBAC test cases (`rbac_fleet.spec.ts`) were silently not updating in Qase TestOps, despite all tests passing locally in CI. No error was visible anywhere — CI showed green, Qase showed nothing.

<img width="2432" height="1379" alt="image" src="https://github.com/user-attachments/assets/d3f7603d-3c3a-4faf-b955-185767d0033e" />


## Culprit

Test case **FLEET-42**'s title exceeded Qase's 255-character limit on the `title` field (was 257 chars). Qase's Bulk Results API rejects the **entire batch** if any single result fails validation — there's no per-item isolation. Since `cypress-qase-reporter` bundles a whole spec file's results into one request per spec, FLEET-42's oversized title took down all 16 RBAC results in the same batch, every run — including tests that passed cleanly and had nothing wrong with them.

This also explains why isolating to a single test (`@fleet-5`) still failed: `@cypress/grep` doesn't remove non-matching tests from the file, it marks them `pending`. Cypress still processes the whole spec's Mocha tree, so FLEET-42 rides along in the batch even when it doesn't execute.

## Flags used to determine issue

Enabled temporarily in `cypress.config.ts` reporter options (via env passthrough in `master-e2e.yaml` / `start-cypress-tests`):
- `QASE_DEBUG: true`
- `QASE_LOGGING_CONSOLE: true`

Both are off by default, which is why the failure was invisible until enabled.

## Exact discovery point

[Run 30016016021, job 89236265869, step 10, line 504](https://github.com/rancher/fleet-e2e/actions/runs/30016016021/job/89236265869#step:10:504):

Error message:

```
{"message":"The title may not be greater than 255 characters.","errors":{"title":["The title may not be greater than 255 characters."]}}

```

## Fix

- Trimmed FLEET-42's title from 257 → 245 characters.
- Audited every spec file (static and data-driven/templated titles) — confirmed no other test title in the repo exceeds 255 chars.

Proof:

- [CI 2.15 with tests fleet-5 and fleet-43](https://github.com/rancher/fleet-e2e/actions/runs/30077499309)
- [QASE report 5511](https://app.qase.io/run/FLEET/dashboard/5511)

<img width="2312" height="1379" alt="image" src="https://github.com/user-attachments/assets/17a0d121-11bf-4c83-9c37-e5658e653dd1" />

Full RBAC test cases passing and special test cases also reported:
- https://github.com/rancher/fleet-e2e/actions/runs/30077457281
- https://app.qase.io/run/FLEET/dashboard/5512

<img width="2432" height="1379" alt="image" src="https://github.com/user-attachments/assets/d3cdaddc-721a-471d-a7d4-3f453a655d3a" />


---

## Extra additions

- Removed a duplicate `after:spec` hook registration in `cypress.config.ts` — `cypress-qase-reporter/plugin` already registers `afterSpecHook` internally; the manual registration caused it to fire twice per spec.
- Fixed `SPEC` in `master-e2e.yaml` to be comma-separated instead of space/newline-separated, per Cypress's own `--spec` argument-parsing recommendation.
- Renamed a duplicate `describe()` title in `rbac_fleet.spec.ts` (two suites shared the identical title) for clarity — not confirmed as a contributing cause, but a real anomaly worth fixing regardless.
