### PR TITLE
Add test for applying custom namespaceLabels and namespaceAnnotations from fleet.yaml

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -2092,3 +2092,39 @@ describe(
     );
   },
 );
+
+describe(
+  'Test custom namespaceLabels and namespaceAnnotations are applied to the bundle namespace from fleet.yaml file.',
+  { tags: '@p1_2' },
+  () => {
+    it(
+      qase(72, 'Fleet-72: Test as an admin user, add GitRepo having labels "new: fleet-label2" in fleet.yaml file.'),
+      { tags: '@fleet-72' },
+      () => {
+        const repoUrl = 'https://github.com/rancher/fleet-test-data.git';
+        const branch = 'test-data-ns-label-annotation';
+        const repoName = 'test-namespace-labels';
+        const path = 'qa-test-apps/namespace-labels-annotations';
+        const namespaceName = 'my-labeled-namespace';
+
+        cy.addFleetGitRepo({ repoName, repoUrl, branch, path, local: true });
+        cy.clickButton('Create');
+        cy.checkGitRepoStatus(repoName, '1 / 1', '1 / 1');
+
+        cy.accesMenuSelection('local', 'Projects/Namespaces');
+        cy.filterInSearchBox(namespaceName);
+        cy.verifyTableRow(0, 'Active', namespaceName);
+
+        cy.open3dotsMenu(namespaceName, 'Edit YAML');
+        // Read the full YAML via getValue (CodeMirror only renders visible lines).
+        cy.get('.CodeMirror', { log: false }).then(($el) => {
+          const yamlText = ($el[0] as any).CodeMirror.getValue();
+          expect(yamlText.includes('env: test'), 'Namespace should carry the configured namespaceLabels').to.eq(true);
+          expect(yamlText.includes('pod: deny'), 'Namespace should carry the configured namespaceAnnotations').to.eq(
+            true,
+          );
+        });
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Automate Fleet issue #1553 — namespaceLabels / namespaceAnnotations on bundle namespaces (qase 72)

Adds Cypress coverage verifying that `namespaceLabels` and `namespaceAnnotations`
set in `fleet.yaml` are applied to the namespace Fleet creates for a bundle
([rancher/fleet#1553](https://github.com/rancher/fleet/issues/1553)).

### What the test does

- Deploys a GitRepo pointing at `qa-test-apps/namespace-labels-annotations`, whose
  `fleet.yaml` sets `defaultNamespace: my-labeled-namespace` with `namespaceLabels`
  (`env: test`) and `namespaceAnnotations` (`pod: deny`).
- Waits for the GitRepo to reach `1 / 1` bundles / resources.
- Opens the created namespace's YAML and asserts (via `CodeMirror.getValue()`) that
  the configured label and annotation are present.

### CI Status
- :green_circle: 2.15: https://github.com/rancher/fleet-e2e/actions/runs/30109690551/job/89535887175#step:10:487
- :green_circle: 2.14: https://github.com/rancher/fleet-e2e/actions/runs/30108845045/job/89533050149#step:10:489
- :green_circle: 2.13: https://github.com/rancher/fleet-e2e/actions/runs/30108856112/job/89533072526#step:10:487
- :green_circle: 2.12: https://github.com/rancher/fleet-e2e/actions/runs/30108865952/job/89535734989#step:10:460