### PR TITLE
Add test for "helm.sh/resource-policy: keep" annotation on CRDs

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -2128,3 +2128,52 @@ describe(
     );
   },
 );
+
+describe('Test "helm.sh/resource-policy: keep" annotation is added to CRDs only.', { tags: '@p1_2' }, () => {
+  it(
+    qase(149, 'Fleet-149: Test "helm/resource-policy" was set to keep when installing helm charts via fleet'),
+    { tags: '@fleet-149' },
+    () => {
+      const basePath = 'qa-test-apps/helm-resource-policy';
+      const keepCrdName = 'resourcepolicykeeps.qa.fleet.cattle.io';
+      const deleteCrdName = 'resourcepolicydeletes.qa.fleet.cattle.io';
+      const configMapName = 'resource-policy-cm';
+      const serviceName = 'resource-policy-svc';
+      const keepRepoName = 'test-resource-policy-keep';
+      const deleteRepoName = 'test-resource-policy-delete';
+
+      // deleteCRDResources unset (defaults to false): only the CRD is annotated.
+      cy.addFleetGitRepo({ repoName: keepRepoName, repoUrl, branch, path: `${basePath}/default`, local: true });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(keepRepoName, '1 / 1', '3 / 3');
+      cy.checkResourcePolicyAnnotation({
+        crdName: keepCrdName,
+        serviceName,
+        configMapName,
+        annotationOnCrd: true,
+      });
+
+      // The kept CRD outlives its GitRepo by design, so remove it before the next
+      // scenario; a leftover would break Helm release ownership on re-runs.
+      cy.deleteAllFleetRepos();
+      cy.executeKubectlCommand(`kubectl delete crd ${keepCrdName} --ignore-not-found {enter}`);
+
+      // deleteCRDResources: true: nothing is annotated, not even the CRD.
+      cy.addFleetGitRepo({
+        repoName: deleteRepoName,
+        repoUrl,
+        branch,
+        path: `${basePath}/delete-crd-resources`,
+        local: true,
+      });
+      cy.clickButton('Create');
+      cy.checkGitRepoStatus(deleteRepoName, '1 / 1', '3 / 3');
+      cy.checkResourcePolicyAnnotation({
+        crdName: deleteCrdName,
+        serviceName,
+        configMapName,
+        annotationOnCrd: false,
+      });
+    },
+  );
+});

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -1514,3 +1514,46 @@ Cypress.Commands.add('getClusterIds', (clusterList) => {
 
   return cy.wrap(clusterMap);
 });
+
+// Assert whether a resource's YAML carries the given annotation.
+// Reads the full document via getValue, since CodeMirror only renders visible lines.
+Cypress.Commands.add('checkAnnotationInYaml', (resourceName, annotation, shouldBePresent = true) => {
+  // Big lists (CustomResourceDefinitions especially) take longer than the default
+  // command timeout to render, and the search box only appears with the table.
+  cy.get('table > tbody > tr.main-row', { timeout: 60000 }).should('exist');
+  cy.filterInSearchBox(resourceName);
+  cy.verifyTableRow(0, resourceName);
+  cy.open3dotsMenu(resourceName, 'Edit YAML');
+  cy.get('.CodeMirror', { log: false }).should(($el) => {
+    const yamlText = ($el[0] as any).CodeMirror.getValue();
+    expect(
+      yamlText.includes(annotation),
+      `${resourceName} should ${shouldBePresent ? '' : 'not '}have "${annotation}"`,
+    ).to.eq(shouldBePresent);
+  });
+  cy.clickButton('Cancel');
+});
+
+// Check "helm.sh/resource-policy: keep" on every resource of the helm-resource-policy
+// bundle. Only the CRD may carry it; the Service and the ConfigMap never should.
+Cypress.Commands.add(
+  'checkResourcePolicyAnnotation',
+  ({ crdName, serviceName, configMapName, annotationOnCrd, clusterName = 'local' }) => {
+    const resourcePolicyAnnotation = 'helm.sh/resource-policy: keep';
+
+    cy.accesMenuSelection(clusterName);
+    cy.clickNavMenu(['More Resources', 'API', 'CustomResourceDefinitions']);
+    cy.checkAnnotationInYaml(crdName, resourcePolicyAnnotation, annotationOnCrd);
+
+    // Helm renders Services after CRDs, so the Service is the resource which used
+    // to inherit the annotation. This is the actual regression check.
+    cy.accesMenuSelection(clusterName, 'Service Discovery', 'Services');
+    cy.nameSpaceMenuToggle('All Namespaces');
+    cy.checkAnnotationInYaml(serviceName, resourcePolicyAnnotation, false);
+
+    // ConfigMaps are rendered before CRDs and were never affected. Control check.
+    cy.accesMenuSelection(clusterName, 'Storage', 'ConfigMaps');
+    cy.nameSpaceMenuToggle('All Namespaces');
+    cy.checkAnnotationInYaml(configMapName, resourcePolicyAnnotation, false);
+  },
+);

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -185,6 +185,20 @@ declare global {
       executeKubectlCommand(labelCommand: string, clusterName?: string): Chainable<Element>;
       continuousDeliveryGitRepoRestrictionsMenu(): Chainable<Element>;
       getClusterIds(clusterList: string[]): Chainable<Record<string, string>>;
+      checkAnnotationInYaml(resourceName: string, annotation: string, shouldBePresent?: boolean): Chainable<Element>;
+      checkResourcePolicyAnnotation({
+        crdName,
+        serviceName,
+        configMapName,
+        annotationOnCrd,
+        clusterName,
+      }: {
+        crdName: string;
+        serviceName: string;
+        configMapName: string;
+        annotationOnCrd: boolean;
+        clusterName?: string;
+      }): Chainable<Element>;
     }
   }
 }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -186,19 +186,13 @@ declare global {
       continuousDeliveryGitRepoRestrictionsMenu(): Chainable<Element>;
       getClusterIds(clusterList: string[]): Chainable<Record<string, string>>;
       checkAnnotationInYaml(resourceName: string, annotation: string, shouldBePresent?: boolean): Chainable<Element>;
-      checkResourcePolicyAnnotation({
-        crdName,
-        serviceName,
-        configMapName,
-        annotationOnCrd,
-        clusterName,
-      }: {
-        crdName: string;
-        serviceName: string;
-        configMapName: string;
-        annotationOnCrd: boolean;
-        clusterName?: string;
-      }): Chainable<Element>;
+      checkResourcePolicyAnnotation(
+        crdName: string,
+        serviceName: string,
+        configMapName: string,
+        annotationOnCrd: boolean,
+        clusterName?: string,
+      ): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `Fleet-149` (qase 149) covering [rancher/fleet#2716](https://github.com/rancher/fleet/issues/2716):
`helm.sh/resource-policy: keep` was leaking onto **every** resource rendered after the
first CRD in a bundle, instead of being applied to CRDs only.

Uses the new [`qa-test-apps/helm-resource-policy`](https://github.com/rancher/fleet-test-data/tree/master/qa-test-apps/helm-resource-policy)
bundle (CRD + Service + ConfigMap), which brackets the CRD on both sides of Helm's
kind-based install order: `ConfigMap` → `CustomResourceDefinition` → `Service`.

Two scenarios in one test:

| Path | `deleteCRDResources` | CRD | Service | ConfigMap |
|---|---|---|---|---|
| `helm-resource-policy/default` | unset (default `false`) | `keep` | — | — |
| `helm-resource-policy/delete-crd-resources` | `true` | — | — | — |

The **Service** assertion is the regression check — it is the resource that used to
inherit the annotation, and the only one whose value differs between a pre-fix and a
fixed Fleet. The ConfigMap is the control on the other side of the CRD.

Between the two scenarios the test deletes the CRD explicitly: `keep` means it outlives
its `GitRepo` by design, and a leftover would break Helm release ownership on re-runs.

## Changes

- `p1_2_fleet.spec.ts` — new `describe`/`it` for Fleet-149, tagged `@p1_2` / `@fleet-149`.
- `commands.ts` — two new commands:
  - `checkAnnotationInYaml(resourceName, annotation, shouldBePresent)` — reads the full
    document via `CodeMirror.getValue()` rather than `cy.contains`, since CodeMirror only
    renders visible lines and an annotation scrolled out of view can never match.
  - `checkResourcePolicyAnnotation({ crdName, serviceName, configMapName, annotationOnCrd })` —
    walks the three resources for one scenario.
- `e2e.ts` — type declarations for both.

## CI status
- :green_circle: 2.15: https://github.com/rancher/fleet-e2e/actions/runs/30557952549/job/90923377354#step:10:492
- :green_circle: 2.14: https://github.com/rancher/fleet-e2e/actions/runs/30558007196/job/90923576076#step:10:492
- :green_circle: 2.13: https://github.com/rancher/fleet-e2e/actions/runs/30557978344/job/90923468607#step:10:493
- :green_circle: 2.12: https://github.com/rancher/fleet-e2e/actions/runs/30558030088/job/90928918231#step:10:464