### PR TITLE
Moving test 153  to special test cases and extending checks to avoid stale deletion

### DIFF
--- a/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
+++ b/tests/cypress/e2e/unit_tests/p1_2_fleet.spec.ts
@@ -1286,60 +1286,8 @@ describe('Test GitRepoRestrictions scenarios for GitRepo application deployment.
     },
   );
 
-  it(
-    qase(153, 'Fleet-153: Test "defaultServiceAccount" from "GitRepoRestrictions" is enforced on downstream cluster'),
-    { tags: '@fleet-153' },
-    () => {
-      const repoName = 'local-gitreporestrictions-fleet-153';
-      const dsCluster = 'imported-0';
-
-      // Ensure no GitRepoRestriction is left over from a previous (failed) run,
-      // otherwise the "unrestricted" deploy below would be restricted too.
-      cy.continuousDeliveryMenuSelection();
-      cy.continuousDeliveryGitRepoRestrictionsMenu();
-      cy.fleetNamespaceToggle('fleet-default');
-      cy.wait(1000);
-      cy.deleteAll(false);
-
-      // Deploy GitRepo, no restriction present yet, deploy succeeds using the fleet-agent's own credentials.
-      cy.addFleetRepoFromYaml('assets/git-repo-restrictions-153.yaml', 'fleet-default');
-      cy.verifyTableRow(0, 'Active', repoName);
-      cy.checkGitRepoStatus(repoName, '1 / 1');
-      cy.checkApplicationStatus(appName, dsCluster, 'All Namespaces');
-
-      // Add "limited-service-account" on the downstream cluster, pointed at by the restriction below.
-      cy.importYaml({ clusterName: dsCluster, yamlFilePath: 'assets/limited-service-account.yaml' });
-
-      // Add GitRepoRestriction on the upstream cluster, defaulting the GitRepo's service account.
-      cy.continuousDeliveryMenuSelection();
-      cy.continuousDeliveryGitRepoRestrictionsMenu();
-      cy.clickButton('Create from YAML');
-      cy.addYamlFile('assets/git-repo-restrictions-default-service-account.yaml');
-      cy.clickButton('Create');
-
-      // Let the page settle on the GitRepoRestrictions list before navigating away,
-      // otherwise the burger-menu click below can be intercepted by a covering nav element.
-      cy.verifyTableRow(0, 'Active', 'restriction');
-
-      // Force update the GitRepo, so it picks up the "defaultServiceAccount" restriction.
-      cy.continuousDeliveryMenuSelection();
-      cy.fleetNamespaceToggle('fleet-default');
-      cy.open3dotsMenu(repoName, 'Force Update');
-
-      // Deploy is now denied: the Bundle's error banner names the defaulted service
-      // account, proving the restriction's defaulting was applied.
-      cy.verifyTableRow(0, 'Err Applied', repoName);
-      cy.contains(repoName).click();
-      cy.contains('limited-service-account').should('be.visible');
-
-      // Cleanup: remove the restriction.
-      cy.continuousDeliveryMenuSelection();
-      cy.continuousDeliveryGitRepoRestrictionsMenu();
-      cy.fleetNamespaceToggle('fleet-default');
-      cy.verifyTableRow(0, 'Active', 'restriction');
-      cy.deleteAll(false);
-    },
-  );
+  // Fleet-153 lives in special_fleet_tests.spec.ts (@special): its failures were
+  // cascading into every test below it in this file on Rancher 2.12.
 });
 
 describe('Test Fleet `doNotDeploy: true` skips deploying resources to clusters.', { tags: '@p1_2' }, () => {

--- a/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
+++ b/tests/cypress/e2e/unit_tests/special_fleet_tests.spec.ts
@@ -291,3 +291,66 @@ describe('Test Appco - Fleet integration', { tags: '@appco' }, () => {
     });
   });
 });
+
+// TODO: move back this with resto of GitRepoRestrictions tests once proven consistently successful on 2.12
+describe(
+  'Test "defaultServiceAccount" from "GitRepoRestrictions" is enforced on downstream cluster',
+  { tags: '@special_tests' },
+  () => {
+    it(
+      qase(153, 'Fleet-153: Test "defaultServiceAccount" from "GitRepoRestrictions" is enforced on downstream cluster'),
+      { tags: '@fleet-153' },
+      () => {
+        const repoName = 'local-gitreporestrictions-fleet-153';
+
+        // Ensure no GitRepoRestriction is left over from a previous (failed) run,
+        // otherwise the "unrestricted" deploy below would be restricted too.
+        cy.continuousDeliveryMenuSelection();
+        cy.continuousDeliveryGitRepoRestrictionsMenu();
+        cy.fleetNamespaceToggle('fleet-default');
+        cy.wait(1000);
+        cy.deleteAll(false);
+
+        // Deploy GitRepo, no restriction present yet, deploy succeeds using the fleet-agent's own credentials.
+        cy.addFleetRepoFromYaml('assets/git-repo-restrictions-153.yaml', 'fleet-default');
+        cy.verifyTableRow(0, 'Active', repoName);
+        cy.checkGitRepoStatus(repoName, '1 / 1');
+        cy.checkApplicationStatus(appName, clusterName, 'All Namespaces');
+
+        // Add "limited-service-account" on the downstream cluster, pointed at by the restriction below.
+        cy.importYaml({ clusterName, yamlFilePath: 'assets/limited-service-account.yaml' });
+
+        // Add GitRepoRestriction on the upstream cluster, defaulting the GitRepo's service account.
+        cy.continuousDeliveryMenuSelection();
+        cy.continuousDeliveryGitRepoRestrictionsMenu();
+        cy.clickButton('Create from YAML');
+        cy.addYamlFile('assets/git-repo-restrictions-default-service-account.yaml');
+        cy.clickButton('Create');
+
+        // Let the page settle on the GitRepoRestrictions list before navigating away,
+        // otherwise the burger-menu click below can be intercepted by a covering nav element.
+        cy.verifyTableRow(0, 'Active', 'restriction');
+
+        // Force update the GitRepo, so it picks up the "defaultServiceAccount" restriction.
+        cy.continuousDeliveryMenuSelection();
+        cy.fleetNamespaceToggle('fleet-default');
+        cy.open3dotsMenu(repoName, 'Force Update');
+
+        // Deploy is now denied: the Bundle's error banner names the defaulted service
+        // account, proving the restriction's defaulting was applied.
+        cy.verifyTableRow(0, 'Err Applied', repoName);
+        cy.contains(repoName).click();
+        cy.contains('limited-service-account').should('be.visible');
+        cy.contains('Last Updated').should('be.visible'); //Adding this to ensure the page has fully loaded before proceeding with cleanup.
+        cy.wait(1000); // Adding this to ensure the page has fully loaded before proceeding with cleanup.
+
+        // Cleanup: remove the restriction.
+        cy.continuousDeliveryMenuSelection();
+        cy.continuousDeliveryGitRepoRestrictionsMenu();
+        cy.fleetNamespaceToggle('fleet-default');
+        cy.verifyTableRow(0, 'Active', 'restriction');
+        cy.deleteAll(false);
+      },
+    );
+  },
+);


### PR DESCRIPTION
## What happened

[Fleet-153](https://github.com/rancher/fleet-e2e/actions/runs/31069996321/job/92515850040#step:10:638) failed only on Rancher 2.12 CI. 
After clicking into the GitRepo bundle detail page to confirm the deploy was denied, the test immediately navigated back to the Continuous Delivery menu — but on 2.12 the detail page hadn't fully finished loading yet, so the nav's visibility check timed out and the test aborted before reaching its own cleanup. The leftover `GitRepoRestriction` then blocked every later test in the file that deployed into `fleet-default`, cascading into a wall of unrelated failures.

<img width="1280" height="720" alt="Test GitRepoRestrictions scenarios for GitRepo application deployment -- Fleet-153 Test defaultServiceAccount from GitRepoRestrictions is enforced on downstream cluster (Qase ID 153) (failed)" src="https://github.com/user-attachments/assets/5a94c840-98c0-4a62-a66a-813826d55a00" />



## What was done

Added a check on `'Last Updated'` — the last element to render on the detail page — plus a 1-second wait as extra margin, both before navigating away, to ensure the page is fully loaded before proceeding to cleanup. Also moved Fleet-153 out of `p1_2_fleet.spec.ts` into `special_fleet_tests.spec.ts` (`@special_tests`) so a future flake in this test can no longer cascade into the main p1_2 suite.

## CI Passing in 2.12 (in special test cases)
https://github.com/rancher/fleet-e2e/actions/runs/31082568786

CI in 2.12 only 2 failed cases now in `p1_2` and `rbac`: https://github.com/rancher/fleet-e2e/actions/runs/31083966663/job/92559104483
